### PR TITLE
Fix UTF-8 character truncation causing garbled text in book titles

### DIFF
--- a/desktop_modules/module_books_shared.lua
+++ b/desktop_modules/module_books_shared.lua
@@ -131,6 +131,30 @@ end
 -- ---------------------------------------------------------------------------
 -- coverPlaceholder
 -- ---------------------------------------------------------------------------
+-- Helper function to safely extract first n UTF-8 characters for placeholder text
+local function safeFirstChars(s, n)
+    if not s or n <= 0 then return "" end
+    local chars = {}
+    local i = 1
+    local count = 0
+    while i <= #s and count < n do
+        local byte = s:byte(i)
+        -- Calculate the byte length of the current UTF-8 character
+        local charLen = 1
+        if byte >= 240 then
+            charLen = 4
+        elseif byte >= 224 then
+            charLen = 3
+        elseif byte >= 192 then
+            charLen = 2
+        end
+        chars[#chars + 1] = s:sub(i, i + charLen - 1)
+        count = count + 1
+        i = i + charLen
+    end
+    return table.concat(chars)
+end
+
 function SH.coverPlaceholder(title, w, h)
     return FrameContainer:new{
         bordersize = 1, color = _CLR_COVER_BORDER,
@@ -139,7 +163,7 @@ function SH.coverPlaceholder(title, w, h)
         require("ui/widget/container/centercontainer"):new{
             dimen = Geom:new{ w = w, h = h },
             require("ui/widget/textwidget"):new{
-                text = (title or "?"):sub(1, 2):upper(),
+                text = safeFirstChars(title or "?", 2):upper(),
                 face = Font:getFace("smallinfofont", Screen:scaleBySize(18)),
                 bold = true,
             },

--- a/desktop_modules/module_currently.lua
+++ b/desktop_modules/module_currently.lua
@@ -55,10 +55,57 @@ local _CLR_DARK = Blitbuffer.COLOR_BLACK
 
 local TITLE_MAX_LEN = 60
 
+-- UTF-8 character count: correctly handles multi-byte characters (Chinese, emoji, etc.)
+local function utf8CharCount(s)
+    if not s then return 0 end
+    local count = 0
+    local i = 1
+    while i <= #s do
+        local byte = s:byte(i)
+        -- Calculate the byte length of the current UTF-8 character
+        local charLen = 1
+        if byte >= 240 then
+            charLen = 4  -- 11110xxx
+        elseif byte >= 224 then
+            charLen = 3  -- 1110xxxx
+        elseif byte >= 192 then
+            charLen = 2  -- 110xxxxx
+        end
+        count = count + 1
+        i = i + charLen
+    end
+    return count
+end
+
+-- UTF-8 substring: truncate by character count, avoid cutting multi-byte characters
+local function utf8Sub(s, maxChars)
+    if not s or maxChars <= 0 then return "" end
+    local count = 0
+    local i = 1
+    while i <= #s do
+        local byte = s:byte(i)
+        -- Calculate the byte length of the current UTF-8 character
+        local charLen = 1
+        if byte >= 240 then
+            charLen = 4
+        elseif byte >= 224 then
+            charLen = 3
+        elseif byte >= 192 then
+            charLen = 2
+        end
+        count = count + 1
+        if count > maxChars then
+            return s:sub(1, i - 1)
+        end
+        i = i + charLen
+    end
+    return s
+end
+
 local function truncateTitle(title)
     if not title then return title end
-    if #title > TITLE_MAX_LEN then
-        return title:sub(1, TITLE_MAX_LEN) .. "…"
+    if utf8CharCount(title) > TITLE_MAX_LEN then
+        return utf8Sub(title, TITLE_MAX_LEN) .. "…"
     end
     return title
 end


### PR DESCRIPTION
## Summary
- Fix UTF-8 character truncation causing garbled text in book titles
- Add proper UTF-8 safe character extraction functions

## Changes
- Add `safeFirstChars` function for cover placeholder text
- Add `utf8CharCount` and `utf8Sub` functions for multi-byte character handling
- Update `module_currently.lua` and `module_books_shared.lua`

## Test
- Tested with Chinese, and emoji characters
- Long book titles now display correctly without garbled text