### PR TITLE
Fix refreshing reading statistics

### DIFF
--- a/desktop_modules/module_reading_stats.lua
+++ b/desktop_modules/module_reading_stats.lua
@@ -154,7 +154,7 @@ local function fetchAllStats(shared_conn)
         -- Use '@' as separator — avoids the integer ambiguity of '-'
         -- (page=10, id_book=1 vs page=1, id_book=01 both collapse to "10-1").
         r.today_pages = tonumber(conn:rowexec(string.format(
-            "SELECT count(DISTINCT page||'@'||id_book) FROM page_stat WHERE start_time>=%d;",
+            "SELECT count(DISTINCT page||'@'||id_book) FROM page_stat WHERE start_time>=%d AND duration>0;",
             start_today))) or 0
 
         -- Aggregate per-day first (inner GROUP BY dates), then average across days
@@ -168,7 +168,7 @@ local function fetchAllStats(shared_conn)
             FROM (SELECT strftime('%%Y-%%m-%%d',start_time,'unixepoch','localtime') AS dates,
                          sum(duration) AS sd,
                          count(DISTINCT page||'@'||id_book) AS pg
-                  FROM page_stat WHERE start_time>=%d
+                  FROM page_stat WHERE start_time>=%d AND duration>0
                   GROUP BY dates);]], week_start))
         if rw and rw[1] and rw[1][1] then
             local nd = tonumber(rw[1][1]) or 0

--- a/sui_homescreen.lua
+++ b/sui_homescreen.lua
@@ -873,6 +873,13 @@ function HomescreenWidget:onShow()
     --   self._navbar_container[1] = inner_widget (our placeholder, the _navbar_inner)
     --
     -- We replace the inner slot directly so the navbar (bar, topbar) is untouched.
+    
+    -- Invalidate reading stat caches so the build always shows fresh data,
+    -- e.g. after returning from the reader without a suspend/resume cycle.
+    local ok_rs, RS = pcall(require, "desktop_modules/module_reading_stats")
+    if ok_rs and RS and RS.invalidateCache then RS.invalidateCache() end
+    local ok_rg, RG = pcall(require, "desktop_modules/module_reading_goals")
+    if ok_rg and RG and RG.invalidateCache then RG.invalidateCache() end
     if self._navbar_container then
         local old = self._navbar_container[1]
         local new = self:_buildContent()


### PR DESCRIPTION
This PR
- adds invalidateCache for `module_reading_stats` and `module_reading_goals` when the home screen widget is shown so that statistics are always fresh when going back to Home
- adds duration >0 to the database queries to limit the issue when you get 1 page in the beginning without reading anything