### PR TITLE
FIX: handle table-valued show_filter.status on KOReader 2026.03

### DIFF
--- a/sui_foldercovers.lua
+++ b/sui_foldercovers.lua
@@ -492,7 +492,22 @@ local function _installItemCache()
         if not M.getItemCache() then
             return _orig_getListItem(fc, dirpath, f, fullpath, attributes, collate)
         end
-        local filter = fc.show_filter and fc.show_filter.status or ""
+        local filter_raw = fc.show_filter and fc.show_filter.status or ""
+        local filter
+        if type(filter_raw) == "table" then
+            -- Newer KOReader stores active status filters as a set table.
+            -- Sort keys so equivalent filter states produce the same cache key.
+            local parts = {}
+            for k, v in pairs(filter_raw) do
+                if v then
+                    parts[#parts + 1] = tostring(k)
+                end
+            end
+            table.sort(parts)
+            filter = table.concat(parts, "\1")
+        else
+            filter = tostring(filter_raw)
+        end
         local key = tostring(dirpath) .. "\0" .. tostring(f) .. "\0"
                  .. tostring(fullpath) .. "\0" .. filter
         if not _cache[key] then


### PR DESCRIPTION
## Summary

Fixes #109.

This fixes a crash in `sui_foldercovers.lua` on newer KOReader builds where `show_filter.status` is a table instead of a string-like value.

The crash happened while building the FileChooser item-cache key and produced:

```lua
attempt to concatenate local 'filter' (a table value)
```

This was reproducible on KOReader `v2026.03-25-g9eb45af16_2026-03-26` during File Manager initialization.

## Cause

Newer KOReader versions use `show_filter.status` as a set-like table of enabled statuses.

SimpleUI was concatenating that value directly into the cache key in `FileChooser.getListItem`, which crashes when the value is a table.

## Fix

Normalize `show_filter.status` before using it in the cache key:

- if it is a table, collect active keys
- sort them for stability
- join them into a deterministic string
- otherwise fall back to `tostring(...)`

This keeps the newer folder cover and item-cache behavior while restoring compatibility with current KOReader versions.

## Environment

- KOReader version: `v2026.03-25-g9eb45af16_2026-03-26`
- Device: Kindle Paperwhite 5

## Notes

- No new UI strings were added
- No translation updates are required
- Fix created with ChatGPT assistance
