### PR TITLE
feat: add per-module section label visibility toggle

### DIFF
--- a/desktop_modules/module_collections.lua
+++ b/desktop_modules/module_collections.lua
@@ -307,6 +307,7 @@ function M.getCountLabel(_pfx)
 end
 
 function M.build(w, ctx)
+    Config.applyLabelToggle(M, _("Collections"))
     local scale       = Config.getModuleScale("collections", ctx.pfx)
     local thumb_scale = Config.getThumbScale("collections", ctx.pfx)
     local lbl_scale   = Config.getItemLabelScale("collections", ctx.pfx)
@@ -531,6 +532,7 @@ function M.getMenuItems(ctx_menu)
     end
 
     local items = {}
+    items[#items + 1] = Config.makeLabelToggleItem("collections", _("Collections"), refresh, _lc)
     items[#items + 1] = {
         text = _lc("Arrange Collections"), keep_menu_open = true,
         callback = function()

--- a/desktop_modules/module_currently.lua
+++ b/desktop_modules/module_currently.lua
@@ -332,6 +332,7 @@ function M.invalidateCache()
 end
 
 function M.build(w, ctx)
+    Config.applyLabelToggle(M, _("Currently Reading"))
     if not ctx.current_fp then return nil end
 
     local SH = getSH()
@@ -755,6 +756,7 @@ function M.getMenuItems(ctx_menu)
     }
 
     return {
+        Config.makeLabelToggleItem("currently", _("Currently Reading"), refresh, _lc),
         _makeScaleItem(ctx_menu),
         _makeTextScaleItem(ctx_menu),
         thumb,

--- a/desktop_modules/module_new_books.lua
+++ b/desktop_modules/module_new_books.lua
@@ -104,6 +104,7 @@ end
 -- ---------------------------------------------------------------------------
 
 function M.build(w, ctx)
+    Config.applyLabelToggle(M, _("New Books"))
     -- Cache the scan result for the lifetime of this render cycle.
     local new_fps = ctx._new_books_fps
     if not new_fps then
@@ -252,7 +253,7 @@ function M.getMenuItems(ctx_menu)
         set       = function(v) Config.setItemLabelScale(v, "new_books", ctx_menu.pfx) end,
         refresh   = ctx_menu.refresh,
     })
-    return { _makeScaleItem(ctx_menu), label_item, _makeThumbScaleItem(ctx_menu) }
+    return { Config.makeLabelToggleItem("new_books", _("New Books"), ctx_menu.refresh, ctx_menu._), _makeScaleItem(ctx_menu), label_item, _makeThumbScaleItem(ctx_menu) }
 end
 
 return M

--- a/desktop_modules/module_reading_goals.lua
+++ b/desktop_modules/module_reading_goals.lua
@@ -470,6 +470,7 @@ function M.reset() invalidateStatsCache() end
 
 -- Builds the widget. Branches on layout mode: compact (single inline row) or default (two lines).
 function M.build(w, ctx)
+    Config.applyLabelToggle(M, _("Reading Goals"))
     local show_ann = showAnnual()
     local show_day = showDaily()
     if not show_ann and not show_day then return nil end
@@ -573,6 +574,7 @@ function M.getMenuItems(ctx_menu)
     local scale_item = _makeScaleItem(ctx_menu)
     scale_item.separator = true
     return {
+        Config.makeLabelToggleItem("reading_goals", _("Reading Goals"), refresh, _lc),
         { text = _lc("Type"),
           sub_item_table = {
               { text         = _lc("Default"),

--- a/desktop_modules/module_recent.lua
+++ b/desktop_modules/module_recent.lua
@@ -68,6 +68,7 @@ M.default_on  = true
 function M.reset() _SH = nil end
 
 function M.build(w, ctx)
+    Config.applyLabelToggle(M, _("Recent Books"))
     if not ctx.recent_fps or #ctx.recent_fps == 0 then return nil end
 
     local SH          = getSH()
@@ -259,6 +260,7 @@ function M.getMenuItems(ctx_menu)
         refresh   = refresh,
     })
     return {
+        Config.makeLabelToggleItem("recent", _("Recent Books"), refresh, _lc),
         _makeScaleItem(ctx_menu),
         label_item,
         _makeThumbScaleItem(ctx_menu),

--- a/sui_config.lua
+++ b/sui_config.lua
@@ -1711,4 +1711,43 @@ function M.makeGapItem(opts)
     }
 end
 
+-- ---------------------------------------------------------------------------
+-- Per-module label (section title) visibility toggle.
+-- Setting key: "simpleui_hide_label_" .. mod_id  (true = hidden, nil = shown)
+-- Never stored as false — KOReader LuaSettings removes keys set to false.
+-- ---------------------------------------------------------------------------
+local function _labelHideKey(mod_id)
+    return "simpleui_hide_label_" .. (mod_id or "")
+end
+
+-- Returns true when the section label should be hidden.
+function M.isLabelHidden(mod_id)
+    return G_reader_settings:readSetting(_labelHideKey(mod_id)) == true
+end
+
+-- Call at the start of build() to keep mod.label in sync with the setting.
+function M.applyLabelToggle(mod, default_label)
+    if M.isLabelHidden(mod.id) then
+        mod.label = nil
+    else
+        mod.label = default_label
+    end
+end
+
+-- Returns a checkbox menu item for toggling the section label.
+-- _lc is the menu-local gettext wrapper (ctx_menu._).
+function M.makeLabelToggleItem(mod_id, default_label, refresh, _lc)
+    return {
+        text           = _lc("Show label"),
+        checked_func   = function() return not M.isLabelHidden(mod_id) end,
+        keep_menu_open = true,
+        callback       = function()
+            -- Store true to hide, nil (remove key) to show — never store false.
+            G_reader_settings:saveSetting(_labelHideKey(mod_id),
+                not M.isLabelHidden(mod_id) and true or nil)
+            refresh()
+        end,
+    }
+end
+
 return M


### PR DESCRIPTION
Adds three helpers to sui_config.lua:
- Config.isLabelHidden(mod_id)
- Config.applyLabelToggle(mod, default_label)
- Config.makeLabelToggleItem(mod_id, default_label, refresh, _lc)

Each module with a section label (Currently Reading, Recent Books, New Books, Collections, Reading Goals) now shows a "Show label" checkbox at the top of its hold-settings menu. The toggle hides or restores the section title above the module without affecting layout or any other settings.

The setting is stored as true (hidden) or nil (shown) — never false, since KOReader LuaSettings silently removes keys set to false.