### PR TITLE
Fix WiFi toggle to broadcast network events

### DIFF
--- a/sui_bottombar.lua
+++ b/sui_bottombar.lua
@@ -1222,11 +1222,11 @@ function M.doWifiToggle(plugin)
     if not ok_state then wifi_on = false end
     if wifi_on then
         Config.wifi_optimistic = false
-        pcall(function() NetworkMgr:turnOffWifi() end)
+        pcall(function() NetworkMgr:disableWifi() end)
         UIManager:show(InfoMessage():new{ text = _("Wi-Fi off"), timeout = 1 })
     else
         Config.wifi_optimistic = true
-        local ok_on, err = pcall(function() NetworkMgr:turnOnWifi() end)
+        local ok_on, err = pcall(function() NetworkMgr:enableWifi() end)
         if not ok_on then
             logger.warn("simpleui: Wi-Fi turn-on error:", tostring(err))
             Config.wifi_optimistic = nil


### PR DESCRIPTION
## Summary

- SimpleUI's WiFi toggle button calls `NetworkMgr:turnOffWifi()` / `turnOnWifi()` directly — these are low-level platform calls that bypass KOReader's event system
- `NetworkDisconnecting`, `NetworkDisconnected`, and `NetworkConnected` events are never broadcast
- This breaks any plugin listening for network state changes (e.g. KOSync won't sync progress on disconnect)
- Fix: switch to `disableWifi()` / `enableWifi()` which broadcast proper events and clean up connection state

## Changes

Two-line change in `sui_bottombar.lua:doWifiToggle()`:
- `NetworkMgr:turnOffWifi()` → `NetworkMgr:disableWifi()`
- `NetworkMgr:turnOnWifi()` → `NetworkMgr:enableWifi()`

## Test plan

- [x] Toggle WiFi off via SimpleUI toolbar — verify KOSync syncs progress before disconnect
- [x] Toggle WiFi on via SimpleUI toolbar — verify KOSync reconnects
- [x] Confirm "Wi-Fi off" / optimistic icon still displays correctly (SimpleUI's own feedback is unaffected)