### PR TITLE
Add arrow-button navigation

### DIFF
--- a/desktop_modules/module_currently.lua
+++ b/desktop_modules/module_currently.lua
@@ -582,6 +582,22 @@ function M.build(w, ctx)
         return true
     end
 
+    -- Keyboard focus: overlay a black rectangular border on the tappable when
+    -- this book is the currently selected keyboard-navigation item.
+    if ctx.kb_currently_focused then
+        local bw = Screen:scaleBySize(3)
+        local tw = w
+        local th = content_h
+        return OverlapGroup:new{
+            dimen = Geom:new{ w = tw, h = th },
+            tappable,
+            LineWidget:new{ dimen = Geom:new{ w = tw, h = bw },    background = Blitbuffer.COLOR_BLACK },
+            LineWidget:new{ dimen = Geom:new{ w = tw, h = bw },    background = Blitbuffer.COLOR_BLACK, overlap_offset = {0, th - bw} },
+            LineWidget:new{ dimen = Geom:new{ w = bw, h = th },    background = Blitbuffer.COLOR_BLACK },
+            LineWidget:new{ dimen = Geom:new{ w = bw, h = th },    background = Blitbuffer.COLOR_BLACK, overlap_offset = {tw - bw, 0} },
+        }
+    end
+
     return tappable
 end
 

--- a/desktop_modules/module_recent.lua
+++ b/desktop_modules/module_recent.lua
@@ -12,6 +12,7 @@ local UIManager       = require("ui/uimanager")
 local HorizontalGroup = require("ui/widget/horizontalgroup")
 local HorizontalSpan  = require("ui/widget/horizontalspan")
 local InputContainer  = require("ui/widget/container/inputcontainer")
+local LineWidget      = require("ui/widget/linewidget")
 local OverlapGroup    = require("ui/widget/overlapgroup")
 local CenterContainer = require("ui/widget/container/centercontainer")
 local TextWidget      = require("ui/widget/textwidget")
@@ -183,10 +184,25 @@ function M.build(w, ctx)
             return true
         end
 
+        -- Keyboard focus: overlay a black rectangular border on this book cell
+        -- when it is the currently selected keyboard-navigation item.
+        local cell_widget = tappable
+        if ctx.kb_recent_focus_idx == i then
+            local bw = Screen:scaleBySize(3)
+            cell_widget = OverlapGroup:new{
+                dimen = Geom:new{ w = cw, h = cell_h },
+                tappable,
+                LineWidget:new{ dimen = Geom:new{ w = cw, h = bw },    background = Blitbuffer.COLOR_BLACK },
+                LineWidget:new{ dimen = Geom:new{ w = cw, h = bw },    background = Blitbuffer.COLOR_BLACK, overlap_offset = {0, cell_h - bw} },
+                LineWidget:new{ dimen = Geom:new{ w = bw, h = cell_h }, background = Blitbuffer.COLOR_BLACK },
+                LineWidget:new{ dimen = Geom:new{ w = bw, h = cell_h }, background = Blitbuffer.COLOR_BLACK, overlap_offset = {cw - bw, 0} },
+            }
+        end
+
         -- Use HorizontalSpan for inter-cell spacing instead of a zero-border
         -- FrameContainer — avoids 4 unnecessary widget allocations per render.
         if i > 1 then row[#row + 1] = HorizontalSpan:new{ width = gap } end
-        row[#row + 1] = tappable
+        row[#row + 1] = cell_widget
     end
 
     return FrameContainer:new{

--- a/sui_bottombar.lua
+++ b/sui_bottombar.lua
@@ -501,6 +501,51 @@ function M.buildBarWidgetWithArrows(active_action_id, tab_config, mode, has_prev
 	return fc
 end
 
+-- Builds a bottom bar identical to buildBarWidget but with a keyboard-focus
+-- rectangle rendered over the tab at kbfocus_idx (1-based).
+-- Used by the library-screen keyboard navigation mode.
+-- Falls back to plain buildBarWidget when navpager is active or kbfocus_idx is nil.
+function M.buildBarWidgetWithKeyFocus(active_action_id, tab_config, kbfocus_idx, num_tabs, mode)
+	if not kbfocus_idx or Config.isNavpagerEnabled() then
+		return M.buildBarWidget(active_action_id, tab_config, num_tabs, mode)
+	end
+	num_tabs = num_tabs or Config.getNumTabs()
+	mode     = mode     or Config.getNavbarMode()
+	local screen_w = Screen:getWidth()
+	local side_m   = M.SIDE_M()
+	local usable_w = screen_w - side_m * 2
+	local widths   = M.getTabWidths(num_tabs, usable_w)
+	local hg_args  = { align = "top" }
+	local bw       = Screen:scaleBySize(3)
+	local OverlapGroup = require("ui/widget/overlapgroup")
+	for i = 1, num_tabs do
+		local action_id = tab_config[i]
+		local cell = M.buildTabCell(action_id, action_id == active_action_id, widths[i], mode)
+		if i == kbfocus_idx then
+			local tw    = widths[i]
+			local tab_h = M.BAR_H()
+			cell = OverlapGroup:new{
+				dimen = Geom:new{ w = tw, h = tab_h },
+				cell,
+				LineWidget:new{ dimen = Geom:new{ w = tw, h = bw },    background = Blitbuffer.COLOR_BLACK },
+				LineWidget:new{ dimen = Geom:new{ w = tw, h = bw },    background = Blitbuffer.COLOR_BLACK, overlap_offset = {0, tab_h - bw} },
+				LineWidget:new{ dimen = Geom:new{ w = bw, h = tab_h }, background = Blitbuffer.COLOR_BLACK },
+				LineWidget:new{ dimen = Geom:new{ w = bw, h = tab_h }, background = Blitbuffer.COLOR_BLACK, overlap_offset = {tw - bw, 0} },
+			}
+		end
+		hg_args[#hg_args + 1] = cell
+	end
+	return FrameContainer:new{
+		bordersize    = 0,
+		padding       = 0,
+		padding_left  = side_m,
+		padding_right = side_m,
+		margin        = 0,
+		background    = Blitbuffer.COLOR_WHITE,
+		HorizontalGroup:new(hg_args),
+	}
+end
+
 -- Swaps the bar widget inside an already-wrapped widget, preserving overlap_offset.
 function M.replaceBar(widget, new_bar, tabs)
 	if not G_reader_settings:nilOrTrue("navbar_enabled") then

--- a/sui_homescreen.lua
+++ b/sui_homescreen.lua
@@ -560,6 +560,154 @@ function HomescreenWidget:init()
             },
         })
     end
+
+    -- ── Keyboard navigation ───────────────────────────────────────────────────
+    -- Layout model: two content rows stacked vertically, then the bottom bar.
+    --   Row A — "Currently reading"  (single book, index 1 in _kb_book_items_fp)
+    --   Row B — "Recent books"       (horizontal strip, indices _kb_first_rec_idx…end)
+    --   Row C — Bottom navigation bar (entered via enterNavbarKbFocus)
+    --
+    -- Up / Down  → move between rows A, B, C.
+    -- Left / Right → move within row B only (no effect on row A).
+    -- Press → open focused book.
+    -- Menu → open main settings menu.
+    --
+    -- Create a per-instance key_events table (avoids mutating the class table).
+    self.key_events = {}
+    if Device:hasDPad() then
+        self.key_events.HSFocusUp    = { { "Up"    } }
+        self.key_events.HSFocusDown  = { { "Down"  } }
+        self.key_events.HSFocusLeft  = { { "Left"  } }
+        self.key_events.HSFocusRight = { { "Right" } }
+        self.key_events.HSKbPress    = { { "Press" } }
+    end
+    if Device:hasKeys() then
+        self.key_events.HSOpenMenu   = { { "Menu"  } }
+    end
+
+    -- Menu key → open the KOReader top settings menu (same as swipe-from-top).
+    function self:onHSOpenMenu()
+        local FM = package.loaded["apps/filemanager/filemanager"]
+        local inst = FM and FM.instance
+        if inst and inst.menu then inst.menu:onTapShowMenu() end
+        return true
+    end
+
+    -- Up: move to the row above the current focus.
+    --   nil          → enter focus at first book of the last content row
+    --   on recent    → move to currently-reading (row A) if it exists
+    --   on currently → already at top, no-op
+    function self:onHSFocusUp()
+        local books = self._kb_book_items_fp
+        if not books or #books == 0 then return end
+        local frec = self._kb_first_rec_idx   -- nil when no recent row
+
+        if self._kb_focus_idx == nil then
+            -- Enter focus at the first book of the lowest content row.
+            self._kb_focus_idx = frec or 1
+        elseif frec and self._kb_focus_idx >= frec then
+            -- On recent row → go to currently-reading if it exists.
+            if frec > 1 then
+                self._kb_focus_idx = 1
+            end
+            -- else: only recent row, already at top — no-op
+        else
+            -- On currently-reading row → already at top, no-op.
+            return
+        end
+        self:_refreshImmediate(true)
+        return true
+    end
+
+    -- Down: move to the row below the current focus.
+    --   nil or currently → move to recent row (or enter navbar if no recent)
+    --   on recent        → enter bottom-bar keyboard focus
+    function self:onHSFocusDown()
+        local books = self._kb_book_items_fp
+        local frec  = self._kb_first_rec_idx
+
+        local on_recent = frec and self._kb_focus_idx and self._kb_focus_idx >= frec
+
+        if on_recent then
+            -- Bottom of content — enter navbar keyboard focus.
+            -- Clear the book focus first so the border disappears after the user
+            -- activates a tab (the return callback sets it again on Up/Back).
+            self._kb_focus_idx = nil
+            self:_refreshImmediate(true)
+            local self_ref = self
+            local ret_frec = frec  -- capture row-start index for the return callback
+            local Patches  = require("sui_patches")
+            Patches.enterNavbarKbFocus(function()
+                -- User pressed Up/Back from the navbar → restore recent-row focus.
+                self_ref._kb_focus_idx = ret_frec
+                self_ref:_refreshImmediate(true)
+            end)
+            return true
+        end
+
+        if not books or #books == 0 then return end
+
+        if self._kb_focus_idx == nil then
+            -- Not yet focused: focus the first content row.
+            self._kb_focus_idx = 1
+        elseif frec then
+            -- On currently-reading → jump to recent row.
+            self._kb_focus_idx = frec
+        else
+            -- Only currently-reading row, no recent — enter navbar directly.
+            self._kb_focus_idx = nil
+            self:_refreshImmediate(true)
+            local self_ref = self
+            local Patches  = require("sui_patches")
+            Patches.enterNavbarKbFocus(function()
+                self_ref._kb_focus_idx = 1
+                self_ref:_refreshImmediate(true)
+            end)
+            return true
+        end
+        self:_refreshImmediate(true)
+        return true
+    end
+
+    -- Left: move one step left within the recent-books row (clamp at first).
+    function self:onHSFocusLeft()
+        local frec = self._kb_first_rec_idx
+        if not frec or not self._kb_focus_idx then return end
+        if self._kb_focus_idx < frec then return end  -- on currently row, ignore
+        if self._kb_focus_idx > frec then
+            self._kb_focus_idx = self._kb_focus_idx - 1
+            self:_refreshImmediate(true)
+            return true
+        end
+        -- already at leftmost recent book
+    end
+
+    -- Right: move one step right within the recent-books row (clamp at last).
+    function self:onHSFocusRight()
+        local frec  = self._kb_first_rec_idx
+        local books = self._kb_book_items_fp
+        if not frec or not self._kb_focus_idx or not books then return end
+        if self._kb_focus_idx < frec then return end  -- on currently row, ignore
+        if self._kb_focus_idx < #books then
+            self._kb_focus_idx = self._kb_focus_idx + 1
+            self:_refreshImmediate(true)
+            return true
+        end
+        -- already at rightmost recent book
+    end
+
+    -- Press: open the currently focused book.
+    function self:onHSKbPress()
+        if self._kb_focus_idx == nil then return end
+        local books = self._kb_book_items_fp
+        if not books then return end
+        local fp = books[self._kb_focus_idx]
+        if fp then
+            self._kb_focus_idx = nil
+            openBook(fp)
+        end
+        return true
+    end
 end
 
 -- ---------------------------------------------------------------------------
@@ -718,8 +866,32 @@ function HomescreenWidget:_buildContent()
     self._header_body_ref   = body
     self._header_is_wrapped = false
     local _tr = _  -- capture gettext before the loop's _ variable shadows it
+    -- Keyboard-navigation book list: rebuilt on every _buildContent call.
+    -- Populated in order below as modules are processed.
+    local _kb_books = {}
+    self._kb_first_rec_idx = nil  -- index where recent books start (nil = no recent row)
+
     local first_mod = true
     for _, mod in ipairs(enabled_mods) do
+        -- Track book items for keyboard navigation and pass focus state to modules.
+        ctx.kb_currently_focused = nil
+        ctx.kb_recent_focus_idx  = nil
+        if mod.id == "currently" and ctx.current_fp then
+            _kb_books[#_kb_books + 1] = ctx.current_fp
+            ctx.kb_currently_focused = (self._kb_focus_idx == #_kb_books)
+        elseif mod.id == "recent" and #(ctx.recent_fps or {}) > 0 then
+            local first_rec_idx = #_kb_books + 1
+            self._kb_first_rec_idx = first_rec_idx
+            local n = math.min(#ctx.recent_fps, 5)
+            for i = 1, n do
+                _kb_books[#_kb_books + 1] = ctx.recent_fps[i]
+            end
+            if self._kb_focus_idx and self._kb_focus_idx >= first_rec_idx
+                    and self._kb_focus_idx <= #_kb_books then
+                ctx.kb_recent_focus_idx = self._kb_focus_idx - first_rec_idx + 1
+            end
+        end
+
         local ok_w, widget = pcall(mod.build, inner_w, ctx)
         if not ok_w then
             logger.warn("simpleui homescreen: build failed for "
@@ -815,6 +987,9 @@ function HomescreenWidget:_buildContent()
         pcall(function() self._db_conn:close() end)
         self._db_conn = nil
     end
+
+    -- Persist the ordered book list for keyboard navigation.
+    self._kb_book_items_fp = _kb_books
 
     if empty_widget then
         body[#body+1] = empty_widget
@@ -1121,6 +1296,9 @@ function HomescreenWidget:onCloseWidget()
     self._hs_ctx_menu        = nil
     self._shown_once         = nil
     self._stats_need_refresh = nil
+    self._kb_book_items_fp   = nil
+    self._kb_focus_idx       = nil
+    self._kb_first_rec_idx   = nil
 
     -- Cancel the module_clock timer and release clock swap state.
     local ClockMod = Registry.get("clock")

--- a/sui_patches.lua
+++ b/sui_patches.lua
@@ -35,6 +35,19 @@ local _start_with_hs = nil
 -- Navpager rebuild coalescence flag.
 local _navpager_rebuild_pending = false
 
+-- Navbar keyboard focus mode: transparent InputContainer placed on top of the
+-- UIManager stack while the user navigates bottom bar tabs via keyboard.
+-- nil when inactive.  _navbar_kb_idx is the 1-based index of the focused tab.
+local _navbar_kb_capture    = nil
+local _navbar_kb_idx        = 1
+-- Optional callback invoked when Up/Back exits navbar keyboard focus mode.
+-- Set by callers such as the homescreen that need to restore their own focus
+-- instead of the default file-chooser last-item focus.
+local _navbar_kb_return_fn  = nil
+-- Forward reference set once inside patchFileManagerClass so the function can
+-- be called from outside (e.g. HomescreenWidget) via M.enterNavbarKbFocus.
+local _enterNavbarKbFocus_fn = nil
+
 -- Returns true when "Start with Homescreen" is the active start_with value.
 -- Caches the result so UIManager.show and UIManager.close (hot paths) avoid
 -- repeated settings lookups on every call.
@@ -131,12 +144,143 @@ function M.patchFileManagerClass(plugin)
             local orig_fc_init   = FileChooser.init
             plugin._orig_fc_init = orig_fc_init
             FileChooser._navbar_patched = true
+
+            -- Capture device + focusmanager references once; shared by the lambdas below.
+            local _Device2      = require("device")
+            local _FocusManager = require("ui/widget/focusmanager")
+
+            -- _enterNavbarKbFocus: called when Down is pressed at the last file.
+            -- Pushes a transparent InputContainer onto the UIManager stack that
+            -- captures Left/Right (tab navigation), Press (activate), Up/Back (exit).
+            -- Optional return_fn is called when Up/Back exits, instead of the
+            -- default file-chooser focus-return (used by the homescreen).
+            local function _enterNavbarKbFocus(return_fn)
+                if not _Device2:hasDPad() then return end
+                if not G_reader_settings:nilOrTrue("navbar_enabled") then return end
+                if _navbar_kb_capture then return end  -- already active
+                _navbar_kb_return_fn = return_fn or false
+
+                -- Find the 1-based index of the currently active tab.
+                local tabs = Config.loadTabConfig()
+                _navbar_kb_idx = 1
+                for i, t in ipairs(tabs) do
+                    if t == plugin.active_action then _navbar_kb_idx = i; break end
+                end
+
+                -- Rebuild the bar with a focus-border on the active tab.
+                -- Use the topmost fullscreen widget that carries a navbar — this is
+                -- the widget whose bar is actually visible on screen right now.
+                -- When the Library is active it is fm; when History/Collections/
+                -- Homescreen is on top it is that widget instead.
+                local FM0 = package.loaded["apps/filemanager/filemanager"]
+                local fm0 = FM0 and FM0.instance
+                local target0 = M._getNavbarTarget and M._getNavbarTarget(fm0) or fm0
+                if target0 then
+                    Bottombar.replaceBar(target0,
+                        Bottombar.buildBarWidgetWithKeyFocus(plugin.active_action, tabs, _navbar_kb_idx),
+                        tabs)
+                    UIManager:setDirty(target0, "ui")
+                end
+
+                -- Build the transparent input-only overlay widget.
+                local InputContainer2 = require("ui/widget/container/inputcontainer")
+                local Geom2 = require("ui/geometry")
+                local capture = InputContainer2:new{
+                    dimen             = Geom2:new{ x = 0, y = 0, w = Screen:getWidth(), h = Screen:getHeight() },
+                    covers_fullscreen = false,
+                }
+                function capture:paintTo() end  -- transparent
+
+                local function _moveNavbar(delta)
+                    local t2 = Config.loadTabConfig()
+                    _navbar_kb_idx = ((_navbar_kb_idx - 1 + delta + #t2) % #t2) + 1
+                    local FM2 = package.loaded["apps/filemanager/filemanager"]
+                    local fm2 = FM2 and FM2.instance
+                    local target2 = M._getNavbarTarget and M._getNavbarTarget(fm2) or fm2
+                    if target2 then
+                        Bottombar.replaceBar(target2,
+                            Bottombar.buildBarWidgetWithKeyFocus(plugin.active_action, t2, _navbar_kb_idx),
+                            t2)
+                        UIManager:setDirty(target2, "ui")
+                    end
+                end
+
+                local function _exitNavbarKb()
+                    _navbar_kb_capture = nil
+                    UIManager:close(capture)
+                    -- Restore the normal (unfocused) bar.
+                    local FM2 = package.loaded["apps/filemanager/filemanager"]
+                    local fm2 = FM2 and FM2.instance
+                    local target2 = M._getNavbarTarget and M._getNavbarTarget(fm2) or fm2
+                    if target2 then
+                        local t2 = Config.loadTabConfig()
+                        Bottombar.replaceBar(target2, Bottombar.buildBarWidget(plugin.active_action, t2), t2)
+                        UIManager:setDirty(target2, "ui")
+                    end
+                    -- Invoke caller-supplied return callback if present,
+                    -- otherwise fall back to returning focus to the file chooser.
+                    local ret_fn = _navbar_kb_return_fn
+                    _navbar_kb_return_fn = nil
+                    if ret_fn then
+                        ret_fn()
+                    elseif fm2 then
+                        local fc = fm2.file_chooser
+                        if fc and fc.layout and #fc.layout > 0 then
+                            fc:moveFocusTo(1, #fc.layout, _FocusManager.FORCED_FOCUS)
+                        end
+                    end
+                end
+
+                capture.key_events = {}
+                capture.key_events.NavbarKbLeft  = { { "Left"  } }
+                capture.key_events.NavbarKbRight = { { "Right" } }
+                capture.key_events.NavbarKbPress = { { "Press" } }
+                capture.key_events.NavbarKbUp    = { { "Up"    } }
+                if _Device2.input and _Device2.input.group then
+                    capture.key_events.NavbarKbBack = { { _Device2.input.group.Back } }
+                end
+
+                function capture:onNavbarKbLeft()   _moveNavbar(-1); return true end
+                function capture:onNavbarKbRight()  _moveNavbar(1);  return true end
+                function capture:onNavbarKbUp()     _exitNavbarKb(); return true end
+                function capture:onNavbarKbBack()   _exitNavbarKb(); return true end
+                function capture:onNavbarKbPress()
+                    _navbar_kb_capture = nil
+                    UIManager:close(capture)
+                    local t2 = Config.loadTabConfig()
+                    local action_id = t2[_navbar_kb_idx]
+                    if action_id then
+                        local FM2 = package.loaded["apps/filemanager/filemanager"]
+                        local fm2 = FM2 and FM2.instance
+                        Bottombar.onTabTap(plugin, action_id, fm2 or plugin.ui)
+                    end
+                    return true
+                end
+
+                _navbar_kb_capture = capture
+                UIManager:show(capture)
+            end
+            -- Expose so external callers (homescreen) can enter navbar KB mode.
+            _enterNavbarKbFocus_fn = _enterNavbarKbFocus
+
             FileChooser.init = function(fc_self)
                 if fc_self.height == nil and fc_self.width == nil then
                     fc_self.height = UI.getContentHeight()
                     fc_self.y      = UI.getContentTop()
                 end
                 orig_fc_init(fc_self)
+                -- Intercept downward wrap-around to enter navbar keyboard focus mode
+                -- instead of cycling back to the first file in the list.
+                if _Device2:hasDPad() then
+                    local _origWrapY = _FocusManager._wrapAroundY
+                    fc_self._wrapAroundY = function(self_fc, dy)
+                        if dy == 1 and G_reader_settings:nilOrTrue("navbar_enabled") then
+                            _enterNavbarKbFocus()
+                            return false  -- stay at last item; suppress wrap
+                        end
+                        return _origWrapY(self_fc, dy)
+                    end
+                end
             end
         end
 
@@ -784,6 +928,36 @@ function M.patchUIManagerShow(plugin)
         widget[1]                  = wrapped
         plugin:_registerTouchZones(widget)
         UI.applyGesturePriorityHandleEvent(widget)
+
+        -- For injected FocusManager-based fullscreen widgets (History, Collections,
+        -- Favorites, etc.) add a per-instance _wrapAroundY override so that pressing
+        -- Down at the last item enters navbar keyboard focus instead of wrapping back
+        -- to the top.  HomescreenWidget handles this itself via onHSFocusDown.
+        if require("device"):hasDPad()
+                and widget.name ~= "homescreen"
+                and widget.selected  -- FocusManager sets this; plain InputContainers don't
+                and not widget._navbar_wrapY_patched then
+            widget._navbar_wrapY_patched = true
+            local _FocMgr2    = require("ui/widget/focusmanager")
+            local _origWrapY  = _FocMgr2._wrapAroundY
+            local _widget_ref = widget
+            widget._wrapAroundY = function(self_w, dy)
+                if dy == 1 and G_reader_settings:nilOrTrue("navbar_enabled") then
+                    if _enterNavbarKbFocus_fn then
+                        _enterNavbarKbFocus_fn(function()
+                            -- On Up/Back from navbar: restore focus to the last
+                            -- item in this widget's layout.
+                            if _widget_ref.layout and #_widget_ref.layout > 0 then
+                                _widget_ref:moveFocusTo(1, #_widget_ref.layout,
+                                    _FocMgr2.FORCED_FOCUS)
+                            end
+                        end)
+                    end
+                    return false  -- stay at last item; suppress wrap
+                end
+                return _origWrapY(self_w, dy)
+            end
+        end
 
         -- Register top-of-screen tap/swipe zones to open the KOReader main menu,
         -- mirroring FileManagerMenu:initGesListener for all injected pages.
@@ -1556,6 +1730,13 @@ function M.teardownAll(plugin)
     _hs_pending_after_reader   = false
     _start_with_hs             = nil
     _navpager_rebuild_pending  = false
+    -- Close any active navbar keyboard focus capture widget.
+    if _navbar_kb_capture then
+        pcall(function() UIManager:close(_navbar_kb_capture) end)
+        _navbar_kb_capture = nil
+    end
+    _navbar_kb_idx       = 1
+    _navbar_kb_return_fn = nil
     Config.reset()
     local Registry = package.loaded["desktop_modules/moduleregistry"]
     if Registry then Registry.invalidate() end
@@ -1563,6 +1744,14 @@ function M.teardownAll(plugin)
     if FC then
         pcall(FC.uninstall)
     end
+end
+
+-- Allow external modules (e.g. HomescreenWidget) to trigger navbar keyboard
+-- focus mode the same way the file-chooser does on Down-past-last-item.
+-- return_fn (optional) is called when the user exits the mode via Up/Back;
+-- if nil, the default behaviour (return focus to file chooser) is used.
+function M.enterNavbarKbFocus(return_fn)
+    if _enterNavbarKbFocus_fn then _enterNavbarKbFocus_fn(return_fn) end
 end
 
 return M


### PR DESCRIPTION
This PR adds an ability to navigate SimpleUI menus using arrow keys which is very convenient for Old NonTouch Kindle devices. 

Tested on my Kindle 4, works without a problem with the default SimpleUI layout. Other layouts would probably require adding code for handling keyboard events to each of the modules. 