### PR TITLE
SimpleUI Configuration System

### DIFF
--- a/config/init.lua
+++ b/config/init.lua
@@ -1,0 +1,61 @@
+-- SimpleUI User Configuration
+-- Rename this file to init.lua to apply your customizations.
+--
+-- This file allows you to define custom tabs and actions that appear in the
+-- SimpleUI bottom navigation bar.
+
+return {
+    -- Override the tabs displayed in the bottom bar.
+    -- These are the IDs of the actions you want to appear, in order.
+    -- Built-in options include: "home", "history", "collections", "favorites"
+    -- You can also include IDs from your `custom_actions` below.
+    tabs = { "home", "collections", "custom_opds", "my_custom_screen" },
+
+    -- Define your own custom buttons and screens here
+    custom_actions = {
+        -- Example 1: A Quick Action (Action Only)
+        -- This example simply runs a KOReader dispatcher action without changing the screen layout.
+        {
+            id = "custom_opds",
+            label = "Catalog",
+            -- You can provide an absolute path to a custom SVG icon, or a path relative to the plugin directory
+            icon = "config/icons/app.svg",
+            is_action_only = true,   -- Set to true if this button only triggers an action instead of opening a SimpleUI view
+            is_in_place = false,     -- Set to false so SimpleUI closes the homescreen/menus before executing the action
+            action = function(plugin, fm_self)
+                local Dispatcher = require("dispatcher")
+                
+                -- Dispatch KOReader's official OPDS Catalog natively
+                Dispatcher:execute({ opds_show_catalog = true })
+            end
+        },
+        
+        -- Example 2: A Custom Fullscreen Screen
+        -- This example shows how to launch a completely custom widget wrapped with SimpleUI navbars.
+        {
+            id = "my_custom_screen",
+            label = "Custom",
+            icon = "config/icons/settings.svg",
+            is_fullscreen_view = true, -- Set to true to automatically inject top/bottom navbars into your widget
+            action = function(plugin, fm_self)
+                local UIManager = require("ui/uimanager")
+                local Screen = require("device").screen
+                
+                -- Load your custom widget module (This file must exist!)
+                local MyCustomWidget = require("config/screens/my_custom_widget")
+                
+                local my_widget = MyCustomWidget:new{
+                    dimen = require("ui/geometry"):new{
+                        w = Screen:getWidth(), 
+                        h = Screen:getHeight()
+                    }
+                }
+                
+                -- Note: Your widget must have its 'name' property set to match this action 'id' (e.g., "my_custom_screen")
+                -- for SimpleUI to recognize it and attach the navigation bars!
+                my_widget.name = "my_custom_screen"
+                UIManager:show(my_widget)
+            end
+        }
+    }
+}

--- a/config/screens/my_custom_widget.lua
+++ b/config/screens/my_custom_widget.lua
@@ -1,0 +1,56 @@
+local InputContainer = require("ui/widget/container/inputcontainer")
+local FrameContainer = require("ui/widget/container/framecontainer")
+local CenterContainer = require("ui/widget/container/centercontainer")
+local TextWidget = require("ui/widget/textwidget")
+local Font = require("ui/font")
+local Blitbuffer = require("ffi/blitbuffer")
+local logger = require("logger")
+
+-- A simple native KOReader widget that will be wrapped by SimpleUI
+local MyCustomWidget = InputContainer:extend{
+    name = "my_custom_screen",
+    covers_fullscreen = true,
+    stop_events_propagation = true,
+}
+
+function MyCustomWidget:init()
+    logger.dbg("SimpleUI: MyCustomWidget:init called")
+    self[1] = FrameContainer:new{
+        dimen = self.dimen:copy(),
+        background = Blitbuffer.COLOR_WHITE,
+        padding = 0,
+        margin = 0,
+        bordersize = 0,
+        CenterContainer:new{
+            dimen = self.dimen:copy(),
+            TextWidget:new{
+                text = "Welcome to your Custom Screen!\n\nYou can build any UI here using\nnative KOReader widgets.",
+                face = Font:getFace("cfont", 24),
+                align = "center",
+            }
+        }
+    }
+end
+
+function MyCustomWidget:onShow()
+    -- Sync inner container dimensions when the widget is shown or re-wrapped
+    if self[1] and self[1].dimen then
+        local inner = self[1]
+        if inner[1] and inner[1].dimen then
+            inner[1].dimen = inner.dimen:copy()
+        end
+    end
+end
+
+function MyCustomWidget:_recalculateDimen()
+    -- Ensure inner children match the newly injected height on rotation
+    self:onShow()
+end
+
+function MyCustomWidget:onClose()
+    logger.dbg("SimpleUI: MyCustomWidget:onClose called")
+    local UIManager = require("ui/uimanager")
+    UIManager:close(self)
+end
+
+return MyCustomWidget

--- a/sui_bottombar.lua
+++ b/sui_bottombar.lua
@@ -865,16 +865,34 @@ end
 -- Tab tap handler
 -- ---------------------------------------------------------------------------
 
+local function _isActionOnly(action_id)
+    if _ACTION_ONLY[action_id] then return true end
+    local a = Config.ACTION_BY_ID and Config.ACTION_BY_ID[action_id]
+    if a and a.is_action_only then return true end
+    return false
+end
+
 function M.onTabTap(plugin, action_id, fm_self)
-    -- Action-only tabs: open their dialog/action without changing the active tab.
-    -- The indicator stays on whatever tab was active before the tap.
-    -- _ACTION_ONLY is the single authoritative list — same one used by
-    -- setActiveAndRefreshFM so the two sites can never drift.
-    if _ACTION_ONLY[action_id] then
+    local is_action_only = _isActionOnly(action_id)
+    local is_in_place = _ACTION_ONLY[action_id] or false
+    
+    if not is_in_place then
+        local a = Config.ACTION_BY_ID and Config.ACTION_BY_ID[action_id]
+        if a and a.is_in_place then is_in_place = true end
+    end
+
+    -- Action-only + in-place tabs: open their dialog/action without changing the active tab
+    -- and without tearing down the current view (homescreen or submenus).
+    if is_action_only and is_in_place then
         if     action_id == "power"            then M.showPowerDialog(plugin)
         elseif action_id == "wifi_toggle"      then M.doWifiToggle(plugin)
         elseif action_id == "frontlight"       then M.showFrontlightDialog()
         elseif action_id == "bookmark_browser" then M.showBookmarkBrowserSourceDialog(plugin.ui)
+        else
+            local a = Config.ACTION_BY_ID and Config.ACTION_BY_ID[action_id]
+            if a and type(a.action) == "function" then
+                a.action(plugin, fm_self)
+            end
         end
         return
     end
@@ -885,7 +903,10 @@ function M.onTabTap(plugin, action_id, fm_self)
     -- Track whether this tab was already active before the tap.
     local already_active = (plugin.active_action == action_id)
 
-    plugin.active_action = action_id
+    if not is_action_only then
+        plugin.active_action = action_id
+    end
+    
     -- Skip the eager replaceBar when the homescreen is open: navigate() will
     -- close the HS and call replaceBar+setDirty itself, so doing it here too
     -- produces a redundant buildBarWidget call and extra repaint flushes.
@@ -893,12 +914,13 @@ function M.onTabTap(plugin, action_id, fm_self)
     -- when the HS widget is shown, covering the bar update at that point.
     -- Also skip when already_active: the indicator is already correct and
     -- rebuilding the bar would allocate all widgets for an identical result.
+    -- Also skip for action_only tabs as their indicator should not be highlighted.
     local hs_open = (function()
         local HS = package.loaded["sui_homescreen"]
         return HS and HS._instance ~= nil
     end)()
     if fm_self._navbar_container and action_id ~= "homescreen" and not hs_open
-            and not already_active then
+            and not already_active and not is_action_only then
         M.replaceBar(fm_self, M.buildBarWidget(action_id, tabs), tabs)
         -- setDirty(fm_self) covers the full screen and recurses into navbar_container.
         -- The previous double-dirty (navbar_container + fm_self) queued two e-ink cycles.
@@ -920,7 +942,7 @@ local function setActiveAndRefreshFM(plugin, action_id, tabs)
     -- Never mark an action-only tab (bookmark_browser, wifi, etc.) as the
     -- active navigation tab — doing so would light up its indicator even
     -- though the user never "navigated" to it.
-    if not _ACTION_ONLY[action_id] then
+    if not _isActionOnly(action_id) then
         plugin.active_action = action_id
     end
     local fm = plugin.ui
@@ -948,6 +970,8 @@ local function _isInPlaceAction(action_id)
         -- Delegate to sui_quickactions — single source of truth for QA config.
         return _QA().isInPlaceCustomQA(action_id)
     end
+    local a = Config.ACTION_BY_ID and Config.ACTION_BY_ID[action_id]
+    if a and a.is_in_place then return true end
     return false
 end
 
@@ -1134,6 +1158,12 @@ local function _executeInPlace(action_id, plugin, fm)
     elseif action_id:match("^custom_qa_%d+$") then
         -- Delegate to sui_quickactions — single source of truth for QA execution.
         _QA().executeCustomQA(action_id, fm, showUnavailable)
+
+    else
+        local a = Config.ACTION_BY_ID and Config.ACTION_BY_ID[action_id]
+        if a and type(a.action) == "function" then
+            a.action(plugin, fm)
+        end
     end
 
     -- Restore HS to its original position and repaint to reflect any changes
@@ -1246,7 +1276,7 @@ function M.navigate(plugin, action_id, fm_self, tabs, force)
         hs_inst._navbar_closing_intentionally = nil
         -- Update the FM bar.
         if fm._navbar_container then
-            M.replaceBar(fm, M.buildBarWidget(action_id, tabs), tabs)
+            M.replaceBar(fm, M.buildBarWidget(plugin.active_action, tabs), tabs)
             UIManager:setDirty(fm, "ui")
         end
         -- For "home": navigate the FM to home_dir now that the HS is gone.
@@ -1285,7 +1315,7 @@ function M.navigate(plugin, action_id, fm_self, tabs, force)
     end
 
     if fm_self ~= fm and fm._navbar_container then
-        M.replaceBar(fm, M.buildBarWidget(action_id, tabs), tabs)
+        M.replaceBar(fm, M.buildBarWidget(plugin.active_action, tabs), tabs)
         UIManager:setDirty(fm, "ui")
     end
 
@@ -1398,6 +1428,11 @@ function M.navigate(plugin, action_id, fm_self, tabs, force)
             -- only runs when the HS is already closed (e.g. tap from the FM bar).
             -- Delegate to sui_quickactions — single source of truth for QA execution.
             _QA().executeCustomQA(action_id, fm, showUnavailable)
+        else
+            local a = Config.ACTION_BY_ID and Config.ACTION_BY_ID[action_id]
+            if a and type(a.action) == "function" then
+                a.action(plugin, fm)
+            end
         end
     end
 end

--- a/sui_config.lua
+++ b/sui_config.lua
@@ -124,6 +124,38 @@ for _i, id in ipairs(M.DEFAULT_TABS) do
 end
 
 -- ---------------------------------------------------------------------------
+-- User config handling (config/init.lua)
+-- ---------------------------------------------------------------------------
+local _user_config_cache = nil
+local _user_config_loaded = false
+
+function M.getUserConfig()
+    if _user_config_loaded then return _user_config_cache end
+    _user_config_loaded = true
+    
+    local lfs = require("libs/libkoreader-lfs")
+    local config_path = _plugin_dir .. "config/init.lua"
+    if lfs.attributes(config_path, "mode") == "file" then
+        local ok, res = pcall(dofile, config_path)
+        if ok and type(res) == "table" then
+            _user_config_cache = res
+            logger.info("simpleui: loaded user config from " .. config_path)
+        else
+            logger.warn("simpleui: failed to load user config from " .. config_path .. ": " .. tostring(res))
+            local UIManager = require("ui/uimanager")
+            UIManager:scheduleIn(2, function()
+                local InfoMessage = require("ui/widget/infomessage")
+                UIManager:show(InfoMessage:new{
+                    text = "Simple UI: Failed to load config/init.lua\n" .. tostring(res),
+                    timeout = 6,
+                })
+            end)
+        end
+    end
+    return _user_config_cache
+end
+
+-- ---------------------------------------------------------------------------
 -- Predefined action catalogue
 -- ---------------------------------------------------------------------------
 
@@ -140,6 +172,18 @@ M.ALL_ACTIONS = {
     { id = "stats_calendar",   label = _("Stats"),            icon = M.ICON.stats       },
     { id = "power",            label = _("Power"),            icon = M.ICON.power       },
 }
+
+-- Load user config and inject actions
+local user_config = M.getUserConfig()
+if user_config and user_config.custom_actions then
+    for _, action in ipairs(user_config.custom_actions) do
+        -- Fix relative icon paths
+        if action.icon and type(action.icon) == "string" and not action.icon:match("^/") and not action.icon:match("^nerd:") then
+            action.icon = _plugin_dir .. action.icon
+        end
+        M.ALL_ACTIONS[#M.ALL_ACTIONS + 1] = action
+    end
+end
 
 -- Fast lookup map keyed by action ID.
 M.ACTION_BY_ID = {}
@@ -270,6 +314,16 @@ end
 
 function M.loadTabConfig()
     if _tabs_cache then return _tabs_cache end
+
+    local user_cfg = M.getUserConfig()
+    if user_cfg and type(user_cfg.tabs) == "table" and #user_cfg.tabs > 0 then
+        local result = {}
+        for _, id in ipairs(user_cfg.tabs) do result[#result + 1] = id end
+        M._ensureHomePresent(result)
+        _tabs_cache = result
+        return _tabs_cache
+    end
+
     local cfg = G_reader_settings:readSetting("navbar_tabs")
     local result = {}
     local min_tabs = M.isNavpagerEnabled() and 1 or 2

--- a/sui_menu.lua
+++ b/sui_menu.lua
@@ -189,6 +189,20 @@ SimpleUIPlugin.addToMainMenu = function(self, menu_items)
     local function makeTabsMenu()
         local items = {}
 
+        local user_cfg = Config.getUserConfig()
+        if user_cfg and type(user_cfg.tabs) == "table" and #user_cfg.tabs > 0 then
+            items[#items + 1] = {
+                text = "Tabs are managed by config/init.lua",
+                callback = function()
+                    UIManager:show(InfoMessage():new{
+                        text = "Your tabs are currently defined in config/init.lua.\nRemove the 'tabs' array from your config file to enable GUI editing again.",
+                        timeout = 6,
+                    })
+                end,
+            }
+            return items
+        end
+
         items[#items + 1] = {
             text           = _("Arrange tabs"),
             keep_menu_open = true,

--- a/sui_patches.lua
+++ b/sui_patches.lua
@@ -752,6 +752,13 @@ function M.patchUIManagerShow(plugin)
 
     local INJECT_NAMES = { collections = true, history = true, coll_list = true, homescreen = true }
 
+    local Config = require("sui_config")
+    for _, act in ipairs(Config.ALL_ACTIONS) do
+        if act.is_fullscreen_view then
+            INJECT_NAMES[act.id] = true
+        end
+    end
+
     -- Resolves the live FileManager menu at call time, never capturing a stale
     -- reference. The FM is destroyed and recreated each time the reader closes,
     -- so a closure over the old FM's .menu would point at ReaderMenu and crash.
@@ -847,7 +854,7 @@ function M.patchUIManagerShow(plugin)
             and not widget._navbar_skip_inject
             and widget ~= plugin.ui
             and widget.covers_fullscreen
-            and widget.title_bar      -- truthiness check, not ~= nil
+            and (widget.title_bar or (widget.name and INJECT_NAMES[widget.name]))
             and (widget._navbar_height_reduced or (widget.name and INJECT_NAMES[widget.name]))
 
         if not should_inject then


### PR DESCRIPTION
This PR introduces an underlying configuration system to SimpleUI, allowing
users to define custom tabs, actions, and screens natively via a
`config/init.lua` file.

## Additions & Changes

### 1. User Configuration Loader (`sui_config.lua`)

- Implemented `getUserConfig()` which securely loads `config/init.lua` using
  `pcall` and `libkoreader-lfs`.
- Catches syntax errors or missing files gracefully, displaying an InfoMessage
  in the UI if the configuration file is malformed.
- Automatically injects configured `custom_actions` into the global
  `ALL_ACTIONS` registry on boot, resolving relative icon paths to absolute
  plugin paths.
- Allows users to entirely override the bottom bar `tabs` order.

### 2. GUI Menu Protections (`sui_menu.lua`)

- If the user has hardcoded their tab layout in `config/init.lua`, the "Arrange
  tabs" GUI editor is safely disabled.
- Tapping the menu item now shows an informative popup explaining that tabs are
  managed via configuration, preventing accidental conflicts between GUI
  settings and the config file.

### 3. Dynamic Action Routing (`sui_bottombar.lua`)

- Refactored `onTabTap` and `navigate` to properly support dynamically
  registered user actions.
- Introduced `_isActionOnly` helper to correctly identify custom quick actions.
- Action-only tabs that are not `is_in_place` are correctly routed through
  `navigate()`. The homescreen and active menus are torn down, but the active
  tab indicator is preserved correctly on the previous tab instead of getting
  stuck on the quick action.
- Action-only tabs that _are_ `is_in_place` execute gracefully above the current
  view without changing the tab indicator or closing the homescreen.

### 4. Custom Fullscreen Widget Support (`sui_patches.lua`)

- Modified `UIManager.show` monkey-patching to natively support injecting
  SimpleUI top and bottom navigation bars into user-defined custom widgets.
- Iterates over `ALL_ACTIONS` on boot and registers any user action marked with
  `is_fullscreen_view = true` into the `INJECT_NAMES` table.
- Relaxed the strict `widget.title_bar` requirement during widget injection. As
  long as a custom widget declares `covers_fullscreen = true` and its
  `widget.name` matches the action's ID, SimpleUI will successfully wrap it.

### 5. Configuration Examples (`config/init.example.lua`)

- Shipped an example configuration file documenting the schema.
- Includes `custom_opds`: A working example of a Quick Action tab that natively
  launches KOReader's OPDS catalog (`dispatcher:execute`).
- Includes `my_custom_screen`: A working example of how to implement and route a
  completely custom Lua widget wrapped in SimpleUI's navigation context.
