### PR TITLE
Add new plural strings

### DIFF
--- a/desktop_modules/module_coverdeck.lua
+++ b/desktop_modules/module_coverdeck.lua
@@ -12,6 +12,7 @@ local TextWidget     = require("ui/widget/textwidget")
 local VerticalGroup  = require("ui/widget/verticalgroup")
 local Screen         = Device.screen
 local _              = require("gettext")
+local N_             = _.ngettext
 local logger         = require("logger")
 
 local Config       = require("sui_config")
@@ -570,9 +571,7 @@ function M.build(w, ctx)
                 text = string.format(_("%d%% Read"), math.floor((bd.percent or 0) * 100))
             elseif bstats then
                 if key == "book_days" and bstats.days and bstats.days > 0 then
-                    text = bstats.days == 1
-                        and _("1 day of reading")
-                        or  string.format(_("%d days of reading"), bstats.days)
+                    text = string.format(N_("%d day of reading", "%d days of reading", bstats.days), bstats.days)
                 elseif key == "book_time" and bstats.total_secs and bstats.total_secs > 0 then
                     text = string.format(_("%s read"), fmtTime(bstats.total_secs))
                 elseif key == "book_remaining" then

--- a/desktop_modules/module_currently.lua
+++ b/desktop_modules/module_currently.lua
@@ -5,6 +5,7 @@
 local Device  = require("device")
 local Screen  = Device.screen
 local _       = require("gettext")
+local N_      = _.ngettext
 local logger  = require("logger")
 
 local Blitbuffer      = require("ffi/blitbuffer")
@@ -536,9 +537,7 @@ function M.build(w, ctx)
         elseif elem == "book_days" and show.days and bstats and bstats.days > 0
                and stats_style == "default" then
             gap_before(pct_gap)
-            local days_label = bstats.days == 1
-                and _("1 day of reading")
-                or  string.format(_("%d days of reading"), bstats.days)
+            local days_label = string.format(N_("%d day of reading", "%d days of reading", bstats.days), bstats.days)
             meta[#meta+1] = TextWidget:new{
                 text    = days_label,
                 face    = face_s,
@@ -605,9 +604,7 @@ function M.build(w, ctx)
                     elseif e == "book_remaining" and show.remain and secs_left then
                         parts[#parts+1] = string.format(_("%s left"), fmtTime(secs_left))
                     elseif e == "book_days" and show.days and bstats and bstats.days > 0 then
-                        parts[#parts+1] = bstats.days == 1
-                            and _("1 day of reading")
-                            or  string.format(_("%d days of reading"), bstats.days)
+                        parts[#parts+1] = string.format(N_("%d day of reading", "%d days of reading", bstats.days), bstats.days)
                     end
                 end
 

--- a/desktop_modules/module_quick_actions.lua
+++ b/desktop_modules/module_quick_actions.lua
@@ -20,6 +20,7 @@ local VerticalGroup   = require("ui/widget/verticalgroup")
 local VerticalSpan    = require("ui/widget/verticalspan")
 local Screen          = Device.screen
 local _               = require("gettext")
+local N_              = _.ngettext
 local Config          = require("sui_config")
 local QA              = require("sui_quickactions")
 
@@ -258,7 +259,8 @@ local function makeSlot(slot)
                     local InfoMessage = ctx_menu.InfoMessage or require("ui/widget/infomessage")
                     local uim = ctx_menu.UIManager or UIManager
                     uim:show(InfoMessage:new{
-                        text    = string.format(_("Maximum %d actions per module reached. Remove one first."), MAX_QA),
+                        text    = string.format(N_("The maximum of %d action per module has been reached. Remove one first.",
+                                  "The maximum of %d actions per module has been reached. Remove one first.", MAX_QA), MAX_QA),
                         timeout = 2,
                     })
                     return

--- a/desktop_modules/module_reading_goals.lua
+++ b/desktop_modules/module_reading_goals.lua
@@ -18,6 +18,7 @@ local VerticalGroup   = require("ui/widget/verticalgroup")
 local VerticalSpan    = require("ui/widget/verticalspan")
 local Screen          = Device.screen
 local _               = require("gettext")
+local N_              = _.ngettext
 local logger          = require("logger")
 local Config          = require("sui_config")
 
@@ -412,8 +413,8 @@ local function _annualData(books_read)
         "books_read=", books_read, "physical=", getAnnualPhysical(),
         "read=", read, "pct=", pct, "pct_str=", pct_str)
     local detail = (goal > 0)
-        and string.format(_("%d/%d books"), read, goal)
-        or  string.format(_("%d books"), read)
+        and string.format(N_("%d/%d book", "%d/%d books", goal), read, goal)
+        or  string.format(N_("%d book", "%d books", read), read)
     return pct, pct_str, detail
 end
 
@@ -576,6 +577,7 @@ end
 function M.getMenuItems(ctx_menu)
     local refresh = ctx_menu.refresh
     local _lc     = ctx_menu._
+    local N_lc    = _lc.ngettext
     local scale_item = _makeScaleItem(ctx_menu)
     scale_item.separator = true
     return {
@@ -612,7 +614,7 @@ function M.getMenuItems(ctx_menu)
         { text_func = function()
               local g = getAnnualGoal()
               return g > 0
-                  and string.format(_lc("  Set Goal  (%d books in %s)"), g, _getYearStr())
+                  and string.format(N_lc("  Set Goal  (%d book in %s)", "  Set Goal  (%d books in %s)", g), g, _getYearStr())
                   or  string.format(_lc("  Set Goal  (%s)"), _getYearStr())
           end,
           keep_menu_open = true,

--- a/desktop_modules/module_reading_stats.lua
+++ b/desktop_modules/module_reading_stats.lua
@@ -402,6 +402,7 @@ function M.getMenuItems(ctx_menu)
     local SortWidget  = ctx_menu.SortWidget
     local refresh     = ctx_menu.refresh
     local _lc         = ctx_menu._
+    local N_lc        = _lc.ngettext
     local items_key   = pfx .. "reading_stats_items"
     local MAX_RS      = M.MAX_ITEMS
 
@@ -415,7 +416,8 @@ function M.getMenuItems(ctx_menu)
         if not found then
             if #cur >= MAX_RS then
                 _UIManager:show(InfoMessage:new{
-                    text = string.format(_lc("Maximum %d stats per row. Remove one first."), MAX_RS), timeout = 2 })
+                    text = string.format(N_lc("The maximum of %d stat per row has been reached. Remove one first.",
+                           "The maximum of %d stats per row has been reached. Remove one first.", MAX_RS), MAX_RS), timeout = 2 })
                 return
             end
             new_items[#new_items+1] = id

--- a/locale/simpleui.pot
+++ b/locale/simpleui.pot
@@ -4,290 +4,314 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: simpleui\n"
-"POT-Creation-Date: 2026-03-27 12:00+0000\n"
+"POT-Creation-Date: 2026-04-10 23:03\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: sui_menu.lua:347
-msgid "General"
-msgstr ""
-
-#: sui_menu.lua:320
-msgid "    Size"
-msgstr ""
-
-#: desktop_modules/module_reading_goals.lua:602
+#: desktop_modules/module_reading_goals.lua:624
 msgid "  Physical Books  (%d in %s)"
 msgstr ""
 
-#: desktop_modules/module_reading_goals.lua:595
-msgid "  Set Goal  (%d books in %s)"
-msgstr ""
-
-#: desktop_modules/module_reading_goals.lua:617
+#: desktop_modules/module_reading_goals.lua:639
 msgid "  Set Goal  (%d min/day)"
 msgstr ""
 
-#: desktop_modules/module_reading_goals.lua:596
+#: desktop_modules/module_reading_goals.lua:618
 msgid "  Set Goal  (%s)"
 msgstr ""
 
-#: desktop_modules/module_reading_goals.lua:616
+#: desktop_modules/module_reading_goals.lua:638
 msgid "  Set Goal  (disabled)"
 msgstr ""
 
-#: desktop_modules/module_reading_goals.lua:429
-msgid "%d books"
-msgstr ""
-
-#: desktop_modules/module_currently.lua:336
-msgid "%d days of reading"
-msgstr ""
-
-#: desktop_modules/module_recent.lua:123
+#: desktop_modules/module_recent.lua:125
 msgid "%d%%"
 msgstr ""
 
-#: desktop_modules/module_currently.lua:309
-#: desktop_modules/module_new_books.lua:141
-#: desktop_modules/module_recent.lua:157
+#: desktop_modules/module_coverdeck.lua:571
+#: desktop_modules/module_currently.lua:529
+#: desktop_modules/module_new_books.lua:182
+#: desktop_modules/module_recent.lua:159
 msgid "%d%% Read"
 msgstr ""
 
-#: desktop_modules/module_reading_goals.lua:428
-msgid "%d/%d books"
+#: desktop_modules/module_currently.lua:605
+msgid "%s left"
 msgstr ""
 
-#: desktop_modules/module_currently.lua:347
-#: desktop_modules/module_reading_goals.lua:445
+#: desktop_modules/module_coverdeck.lua:576
+#: desktop_modules/module_currently.lua:553
+#: desktop_modules/module_currently.lua:603
+#: desktop_modules/module_reading_goals.lua:433
 msgid "%s read"
 msgstr ""
 
-#: desktop_modules/module_currently.lua:370
+#: desktop_modules/module_coverdeck.lua:582
+#: desktop_modules/module_currently.lua:572
 msgid "%s remaining"
 msgstr ""
 
-#: desktop_modules/module_currently.lua:335
-msgid "1 day of reading"
-msgstr ""
-
-#: sui_menu.lua:1122
-msgid "Add at least 2 actions to arrange."
-msgstr ""
-
-#: desktop_modules/module_reading_stats.lua:546
-msgid "Add at least 2 stats to arrange."
-msgstr ""
-
-#: desktop_modules/module_reading_stats.lua:67
-msgid "All time — Books"
-msgstr ""
-
-#: desktop_modules/module_reading_stats.lua:66
-msgid "All time — Time"
-msgstr ""
-
-#: desktop_modules/module_reading_goals.lua:585
-msgid "Annual Goal"
-msgstr ""
-
-#: sui_menu.lua:1024
-#: desktop_modules/module_reading_goals.lua:362
-msgid "Annual Reading Goal"
-msgstr ""
-
-#: sui_config.lua:1562
-#: sui_config.lua:1643
-#: sui_menu.lua:593
-#: sui_menu.lua:651
-#: sui_menu.lua:1364
-#: sui_menu.lua:1399
-msgid "Apply"
-msgstr ""
-
-#: desktop_modules/module_clock.lua:49
-msgid "April"
-msgstr ""
-
-#: sui_menu.lua:1120
-#: desktop_modules/module_reading_stats.lua:543
-msgid "Arrange"
-msgstr ""
-
-#: sui_menu.lua:1126
-msgid "Arrange %s"
-msgstr ""
-
-#: sui_menu.lua:840
-#: sui_menu.lua:891
-#: sui_menu.lua:906
-msgid "Arrange Buttons"
-msgstr ""
-
-#: desktop_modules/module_collections.lua:535
-#: desktop_modules/module_collections.lua:548
-msgid "Arrange Collections"
-msgstr ""
-
-#: sui_menu.lua:483
-#: sui_menu.lua:511
-msgid "Arrange Items"
-msgstr ""
-
-#: sui_menu.lua:1280
-#: sui_menu.lua:1296
-msgid "Arrange Modules"
-msgstr ""
-
-#: desktop_modules/module_reading_stats.lua:552
-msgid "Arrange Reading Stats"
-msgstr ""
-
-#: sui_menu.lua:193
-#: sui_menu.lua:203
-msgid "Arrange tabs"
-msgstr ""
-
-#: desktop_modules/module_clock.lua:50
-msgid "August"
-msgstr ""
-
-#: sui_foldercovers.lua:405
-#: desktop_modules/module_collections.lua:497
-msgid "Auto (first book)"
-msgstr ""
-
-#: sui_titlebar.lua:54
-msgid "Back"
-msgstr ""
-
-#: desktop_modules/module_collections.lua:575
-msgid "Badge position: Bottom"
-msgstr ""
-
-#: desktop_modules/module_collections.lua:576
-msgid "Badge position: Top"
-msgstr ""
-
-#: sui_config.lua:143
-msgid "Battery"
-msgstr ""
-
-#: sui_quickactions.lua:404
-msgid "Book Info"
-msgstr ""
-
-#: sui_bottombar.lua:886
-msgid "Bookmark browser"
-msgstr ""
-
-#: sui_bottombar.lua:859
-msgid "Bookmark browser not available."
-msgstr ""
-
-#: sui_config.lua:118
-msgid "Bookmarks"
-msgstr ""
-
-#: desktop_modules/module_reading_goals.lua:363
-msgid "Books to read in %s:"
-msgstr ""
-
-#: sui_menu.lua:1545
-#: sui_menu.lua:1624
-#: sui_menu.lua:1680
-msgid "Bottom"
-msgstr ""
-
-#: sui_bottombar.lua:736
-#: sui_menu.lua:618
-msgid "Bottom Bar"
-msgstr ""
-
-#: sui_menu.lua:644
-msgid "Bottom Bar Size"
-msgstr ""
-
-#: sui_menu.lua
+#: sui_menu.lua:846
 msgid "A restart is required to apply the new bar size across all layouts.\n\nRestart now?"
 msgstr ""
 
-#: sui_menu.lua:626
+#: sui_menu.lua:2106
+msgid "About"
+msgstr ""
+
+#: desktop_modules/module_coverdeck.lua:750
+msgid "Above"
+msgstr ""
+
+#: sui_menu.lua:1320
+#: desktop_modules/module_quick_actions.lua:288
+msgid "Add at least 2 actions to arrange."
+msgstr ""
+
+#: desktop_modules/module_tbr.lua:409
+msgid "Add at least 2 books to arrange."
+msgstr ""
+
+#: desktop_modules/module_reading_stats.lua:485
+msgid "Add at least 2 stats to arrange."
+msgstr ""
+
+#: desktop_modules/module_tbr.lua:265
+msgid "Add to To Be Read"
+msgstr ""
+
+#: desktop_modules/module_reading_stats.lua:66
+msgid "All time — Books"
+msgstr ""
+
+#: desktop_modules/module_reading_stats.lua:65
+msgid "All time — Time"
+msgstr ""
+
+#: desktop_modules/module_reading_goals.lua:607
+msgid "Annual Goal"
+msgstr ""
+
+#: sui_menu.lua:1230
+#: desktop_modules/module_reading_goals.lua:353
+msgid "Annual Reading Goal"
+msgstr ""
+
+#: sui_config.lua:1626
+#: sui_config.lua:1707
+#: sui_menu.lua:766
+#: sui_menu.lua:836
+#: sui_menu.lua:1669
+#: sui_menu.lua:1704
+msgid "Apply"
+msgstr ""
+
+#: desktop_modules/module_clock.lua:54
+msgid "April"
+msgstr ""
+
+#: desktop_modules/module_reading_stats.lua:482
+msgid "Arrange"
+msgstr ""
+
+#: sui_menu.lua:1324
+#: desktop_modules/module_quick_actions.lua:300
+msgid "Arrange %s"
+msgstr ""
+
+#: sui_menu.lua:1046
+#: sui_menu.lua:1097
+#: sui_menu.lua:1112
+msgid "Arrange Buttons"
+msgstr ""
+
+#: desktop_modules/module_collections.lua:621
+#: desktop_modules/module_collections.lua:634
+msgid "Arrange Collections"
+msgstr ""
+
+#: sui_menu.lua:601
+#: sui_menu.lua:630
+#: sui_menu.lua:1314
+#: desktop_modules/module_currently.lua:863
+#: desktop_modules/module_currently.lua:887
+#: desktop_modules/module_quick_actions.lua:279
+msgid "Arrange Items"
+msgstr ""
+
+#: sui_menu.lua:1511
+msgid "Arrange Modules"
+msgstr ""
+
+#: desktop_modules/module_reading_stats.lua:491
+msgid "Arrange Reading Stats"
+msgstr ""
+
+#: desktop_modules/module_coverdeck.lua:774
+#: desktop_modules/module_coverdeck.lua:787
+msgid "Arrange Statistics"
+msgstr ""
+
+#: desktop_modules/module_tbr.lua:402
+#: desktop_modules/module_tbr.lua:421
+msgid "Arrange To Be Read list"
+msgstr ""
+
+#: sui_menu.lua:195
+#: sui_menu.lua:205
+msgid "Arrange tabs"
+msgstr ""
+
+#: desktop_modules/module_clock.lua:55
+msgid "August"
+msgstr ""
+
+#: desktop_modules/module_currently.lua:266
+msgid "Author"
+msgstr ""
+
+#: sui_menu.lua:2122
+msgid "Author: %s"
+msgstr ""
+
+#: sui_foldercovers.lua:540
+#: sui_foldercovers.lua:605
+#: desktop_modules/module_collections.lua:582
+msgid "Auto (first book)"
+msgstr ""
+
+#: sui_titlebar.lua:55
+msgid "Back"
+msgstr ""
+
+#: desktop_modules/module_collections.lua:661
+msgid "Badge position: Bottom"
+msgstr ""
+
+#: desktop_modules/module_collections.lua:662
+msgid "Badge position: Top"
+msgstr ""
+
+#: sui_config.lua:162
+msgid "Battery"
+msgstr ""
+
+#: desktop_modules/module_coverdeck.lua:758
+msgid "Below"
+msgstr ""
+
+#: sui_quickactions.lua:569
+msgid "Book Info"
+msgstr ""
+
+#: sui_bottombar.lua:1035
+msgid "Bookmark browser"
+msgstr ""
+
+#: sui_bottombar.lua:967
+msgid "Bookmark browser not available."
+msgstr ""
+
+#: sui_config.lua:137
+msgid "Bookmarks"
+msgstr ""
+
+#: desktop_modules/module_reading_goals.lua:354
+msgid "Books to read in %s:"
+msgstr ""
+
+#: sui_menu.lua:1874
+#: sui_menu.lua:1968
+#: sui_menu.lua:2030
+msgid "Bottom"
+msgstr ""
+
+#: sui_bottombar.lua:843
+#: sui_menu.lua:803
+msgid "Bottom Bar"
+msgstr ""
+
+#: sui_menu.lua:829
+msgid "Bottom Bar Size"
+msgstr ""
+
+#: sui_menu.lua:811
 msgid "Bottom Bar will be %s after restart.\n\nRestart now?"
 msgstr ""
 
-#: sui_menu.lua:668
-#: sui_menu.lua:671
+#: sui_menu.lua:862
+#: sui_menu.lua:865
 msgid "Bottom Margin"
 msgstr ""
 
-#: sui_menu.lua:669
+#: sui_menu.lua:863
 msgid "Bottom Margin — %d%%"
 msgstr ""
 
-#: sui_homescreen.lua:701
-msgid "Top Margin  (%d%%)"
-msgstr ""
-
-#: sui_homescreen.lua:704
-msgid "Vertical space above this module.\n100% is the default spacing."
-msgstr ""
-
-#: sui_config.lua:120
-#: sui_config.lua:142
+#: sui_config.lua:139
+#: sui_config.lua:161
 msgid "Brightness"
 msgstr ""
 
-#: sui_menu.lua:956
+#: sui_menu.lua:1162
 msgid "Button Size"
 msgstr ""
 
-#: sui_bottombar.lua:911
-#: sui_bottombar.lua:1428
-#: sui_config.lua:1563
-#: sui_config.lua:1644
-#: sui_foldercovers.lua:431
-#: sui_menu.lua:594
-#: sui_menu.lua:652
-#: sui_menu.lua:1365
-#: sui_menu.lua:1400
-#: sui_quickactions.lua:188
-#: sui_quickactions.lua:279
-#: sui_quickactions.lua:387
-#: sui_quickactions.lua:565
-#: sui_quickactions.lua:636
-#: sui_quickactions.lua:664
-#: sui_quickactions.lua:692
-#: sui_quickactions.lua:708
-#: sui_quickactions.lua:820
-#: sui_quickactions.lua:961
-#: desktop_modules/module_collections.lua:523
-#: desktop_modules/module_quote.lua:892
-#: desktop_modules/module_reading_goals.lua:366
-#: desktop_modules/module_reading_goals.lua:383
-#: desktop_modules/module_reading_goals.lua:401
-#: sui_updater.lua:184
-#: sui_updater.lua:237
-#: sui_updater.lua:258
+#: sui_bottombar.lua:1060
+#: sui_bottombar.lua:1745
+#: sui_config.lua:1627
+#: sui_config.lua:1708
+#: sui_foldercovers.lua:569
+#: sui_foldercovers.lua:636
+#: sui_menu.lua:563
+#: sui_menu.lua:767
+#: sui_menu.lua:837
+#: sui_menu.lua:1670
+#: sui_menu.lua:1705
+#: sui_quickactions.lua:358
+#: sui_quickactions.lua:444
+#: sui_quickactions.lua:552
+#: sui_quickactions.lua:756
+#: sui_quickactions.lua:827
+#: sui_quickactions.lua:855
+#: sui_quickactions.lua:883
+#: sui_quickactions.lua:899
+#: sui_quickactions.lua:1011
+#: sui_quickactions.lua:1153
+#: sui_updater.lua:421
+#: sui_updater.lua:438
+#: desktop_modules/module_collections.lua:608
+#: desktop_modules/module_quote.lua:952
+#: desktop_modules/module_reading_goals.lua:357
+#: desktop_modules/module_reading_goals.lua:373
+#: desktop_modules/module_reading_goals.lua:390
 msgid "Cancel"
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:494
+#: desktop_modules/module_reading_stats.lua:433
 msgid "Cards"
 msgstr ""
 
-#: sui_menu.lua:498
-#: sui_menu.lua:1672
+#: sui_menu.lua:617
+#: sui_menu.lua:2022
 msgid "Center"
 msgstr ""
 
-#: sui_quickactions.lua:869
+#: sui_quickactions.lua:1060
 msgid "Change Icons"
 msgstr ""
 
-#: sui_config.lua:140
-#: desktop_modules/module_clock.lua:211
+#: sui_menu.lua:2127
+msgid "Check for Updates"
+msgstr ""
+
+#: sui_updater.lua:460
+msgid "Checking for updates…"
+msgstr ""
+
+#: sui_config.lua:159
+#: desktop_modules/module_clock.lua:227
 msgid "Clock"
 msgstr ""
 
@@ -295,959 +319,1068 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: sui_quickactions.lua:312
+#: sui_quickactions.lua:477
 msgid "Codepoint out of valid Unicode range (0–10FFFF)."
 msgstr ""
 
-#: sui_quickactions.lua:702
+#: sui_quickactions.lua:893
 msgid "Collection"
 msgstr ""
 
-#: desktop_modules/module_collections.lua:484
-#: desktop_modules/module_collections.lua:490
+#: desktop_modules/module_collections.lua:569
+#: desktop_modules/module_collections.lua:575
 msgid "Collection is empty."
 msgstr ""
 
-#: sui_quickactions.lua:1029
+#: sui_quickactions.lua:1245
 msgid "Collection not available: %s"
 msgstr ""
 
-#: sui_bottombar.lua:897
-#: sui_config.lua:114
-#: sui_quickactions.lua:406
-#: desktop_modules/module_collections.lua:290
-#: desktop_modules/module_collections.lua:291
+#: sui_bottombar.lua:1046
+#: sui_config.lua:133
+#: sui_quickactions.lua:571
+#: desktop_modules/module_collections.lua:298
+#: desktop_modules/module_collections.lua:299
+#: desktop_modules/module_collections.lua:318
+#: desktop_modules/module_collections.lua:619
 msgid "Collections"
 msgstr ""
 
-#: sui_bottombar.lua:1121
+#: sui_patches.lua:900
+msgid "Collections (%1)"
+msgstr ""
+
+#: sui_bottombar.lua:1323
 msgid "Collections not available."
 msgstr ""
 
-#: sui_menu.lua:960
-#: desktop_modules/module_reading_goals.lua:573
+#: sui_menu.lua:1166
+#: desktop_modules/module_currently.lua:964
+#: desktop_modules/module_reading_goals.lua:594
 msgid "Compact"
 msgstr ""
 
-#: sui_quickactions.lua:197
+#: sui_quickactions.lua:367
 msgid "Confirm"
 msgstr ""
 
-#: sui_config.lua:116
+#: sui_config.lua:135
 msgid "Continue"
 msgstr ""
 
-#: desktop_modules/module_collections.lua:527
+#: desktop_modules/module_coverdeck.lua:325
+msgid "Cover Deck"
+msgstr ""
+
+#: desktop_modules/module_collections.lua:612
 msgid "Cover for \"%s\""
 msgstr ""
 
-#: desktop_modules/module_collections.lua:564
-#: desktop_modules/module_collections.lua:566
-#: desktop_modules/module_currently.lua:447
-#: desktop_modules/module_currently.lua:449
-#: desktop_modules/module_new_books.lua:218
-#: desktop_modules/module_new_books.lua:220
-#: desktop_modules/module_recent.lua:239
-#: desktop_modules/module_recent.lua:241
+#: desktop_modules/module_collections.lua:650
+#: desktop_modules/module_collections.lua:652
+#: desktop_modules/module_coverdeck.lua:707
+#: desktop_modules/module_coverdeck.lua:708
+#: desktop_modules/module_currently.lua:811
+#: desktop_modules/module_currently.lua:813
+#: desktop_modules/module_new_books.lua:260
+#: desktop_modules/module_new_books.lua:262
+#: desktop_modules/module_recent.lua:256
+#: desktop_modules/module_recent.lua:258
 msgid "Cover size"
 msgstr ""
 
-#: sui_quickactions.lua:878
+#: sui_quickactions.lua:1069
 msgid "Create Quick Action"
 msgstr ""
 
-#: desktop_modules/module_currently.lua:232
-#: desktop_modules/module_currently.lua:233
+#: sui_config.lua:1735
+#: desktop_modules/module_currently.lua:296
+#: desktop_modules/module_currently.lua:297
+#: desktop_modules/module_currently.lua:401
+#: desktop_modules/module_currently.lua:981
 msgid "Currently Reading"
 msgstr ""
 
-#: sui_config.lua:637
+#: sui_config.lua:555
 msgid "Custom"
 msgstr ""
 
-#: sui_menu.lua:933
+#: sui_config.lua:165
+#: sui_menu.lua:555
+msgid "Custom Text"
+msgstr ""
+
+#: sui_menu.lua:1139
 msgid "Custom Title Bar"
 msgstr ""
 
-#: sui_menu.lua:944
+#: sui_menu.lua:1150
 msgid "Custom Title Bar will be %s after restart.\n\nRestart now?"
 msgstr ""
 
-#: desktop_modules/module_reading_goals.lua:606
+#: desktop_modules/module_reading_goals.lua:628
 msgid "Daily Goal"
 msgstr ""
 
-#: desktop_modules/module_reading_goals.lua:398
+#: desktop_modules/module_reading_goals.lua:387
 msgid "Daily Reading Goal"
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:65
+#: desktop_modules/module_reading_stats.lua:64
 msgid "Daily avg — Pages"
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:64
+#: desktop_modules/module_reading_stats.lua:63
 msgid "Daily avg — Time"
 msgstr ""
 
-#: desktop_modules/module_clock.lua:51
+#: desktop_modules/module_coverdeck.lua:76
+#: desktop_modules/module_currently.lua:269
+msgid "Days of reading"
+msgstr ""
+
+#: desktop_modules/module_clock.lua:56
 msgid "December"
 msgstr ""
 
-#: sui_menu.lua:297
-#: sui_menu.lua:326
-#: sui_menu.lua:961
-#: sui_quickactions.lua:347
-#: desktop_modules/module_quick_actions.lua:266
-#: desktop_modules/module_quick_actions.lua:271
-#: desktop_modules/module_reading_goals.lua:565
+#: sui_menu.lua:353
+#: sui_menu.lua:482
+#: sui_menu.lua:1167
+#: sui_quickactions.lua:512
+#: desktop_modules/module_currently.lua:954
+#: desktop_modules/module_quick_actions.lua:402
+#: desktop_modules/module_quick_actions.lua:407
+#: desktop_modules/module_reading_goals.lua:586
 msgid "Default"
 msgstr ""
 
-#: sui_quickactions.lua:610
-#: sui_quickactions.lua:629
+#: sui_quickactions.lua:801
+#: sui_quickactions.lua:820
 msgid "Default (Folder)"
 msgstr ""
 
-#: sui_quickactions.lua:656
+#: sui_quickactions.lua:847
 msgid "Default (Plugin)"
 msgstr ""
 
-#: sui_quickactions.lua:684
+#: sui_quickactions.lua:875
 msgid "Default (System)"
 msgstr ""
 
-#: desktop_modules/module_quote.lua:976
+#: desktop_modules/module_quote.lua:1040
 msgid "Default Quotes"
 msgstr ""
 
-#: sui_quickactions.lua:955
-#: sui_quickactions.lua:960
+#: sui_quickactions.lua:1147
+#: sui_quickactions.lua:1152
 msgid "Delete"
 msgstr ""
 
-#: sui_quickactions.lua:959
+#: sui_quickactions.lua:1151
 msgid "Delete quick action \"%s\"?"
 msgstr ""
 
-#: sui_quickactions.lua:409
+#: sui_quickactions.lua:574
 msgid "Dictionary Lookup"
 msgstr ""
 
-#: sui_menu.lua:1025
+#: sui_menu.lua:1231
 msgid "Digital Goal  (%s)"
 msgstr ""
 
-#: sui_menu.lua:1025
-msgid "Digital: %d books in %s"
-msgstr ""
-
-#: sui_menu.lua:1384
+#: sui_menu.lua:1689
 msgid "Disable \"Lock Scale\" first to set a custom label scale."
 msgstr ""
 
-#: sui_config.lua:1547
+#: sui_config.lua:1611
 msgid "Disable \"Lock Scale\" first to set a per-module scale."
 msgstr ""
 
-#: sui_config.lua:144
+#: sui_config.lua:163
 msgid "Disk Usage"
 msgstr ""
 
-#: sui_quickactions.lua:1014
+#: sui_quickactions.lua:1206
 msgid "Dispatcher not available."
 msgstr ""
 
-#: sui_quickactions.lua:945
+#: sui_menu.lua:390
+msgid "Dot Pager"
+msgstr ""
+
+#: sui_updater.lua:437
+msgid "Download and install"
+msgstr ""
+
+#: sui_updater.lua:348
+msgid "Download error: "
+msgstr ""
+
+#: sui_updater.lua:323
+msgid "Downloading Simple UI %s…"
+msgstr ""
+
+#: sui_quickactions.lua:1137
 msgid "Edit"
 msgstr ""
 
-#: sui_quickactions.lua:511
+#: sui_menu.lua:547
+#: sui_menu.lua:549
+msgid "Edit Custom Text"
+msgstr ""
+
+#: sui_quickactions.lua:702
 msgid "Edit Quick Action"
 msgstr ""
 
-#: sui_menu.lua:1292
-msgid "Enable at least 2 modules to arrange."
-msgstr ""
-
-#: sui_quickactions.lua:271
+#: sui_quickactions.lua:441
 msgid "Enter the Unicode codepoint (hex) of a Nerd Fonts symbol.\nYou can look up codes with wakamaifondue.com using the file:\n  /koreader/fonts/nerdfonts/symbols.ttf\nLeave blank and press OK to remove a Nerd Font icon."
 msgstr ""
 
-#: sui_menu.lua:324
+#: sui_updater.lua:466
+msgid "Error checking for updates."
+msgstr ""
+
+#: sui_updater.lua:471
+msgid "Error checking for updates: "
+msgstr ""
+
+#: sui_menu.lua:458
 msgid "Extra Small"
 msgstr ""
 
-#: sui_config.lua:117
-#: sui_quickactions.lua:405
+#: sui_updater.lua:350
+msgid "Extraction error: "
+msgstr ""
+
+#: sui_config.lua:136
+#: sui_quickactions.lua:570
 msgid "Favorites"
 msgstr ""
 
-#: sui_bottombar.lua:1149
+#: sui_bottombar.lua:1373
 msgid "Favorites not available."
 msgstr ""
 
-#: desktop_modules/module_clock.lua:49
+#: desktop_modules/module_clock.lua:54
 msgid "February"
 msgstr ""
 
-#: sui_bottombar.lua:867
+#: sui_bottombar.lua:989
 msgid "Fetching bookmarks\xe2\x80\xa6"
 msgstr ""
 
-#: sui_quickactions.lua:407
+#: sui_quickactions.lua:572
 msgid "File Search"
 msgstr ""
 
-#: desktop_modules/module_quick_actions.lua:266
-#: desktop_modules/module_quick_actions.lua:280
-#: desktop_modules/module_reading_stats.lua:504
+#: desktop_modules/module_quick_actions.lua:402
+#: desktop_modules/module_quick_actions.lua:416
+#: desktop_modules/module_reading_stats.lua:443
 msgid "Flat"
 msgstr ""
 
-#: sui_quickactions.lua:700
+#: sui_quickactions.lua:891
 msgid "Folder"
 msgstr ""
 
-#: sui_menu.lua:1578
+#: sui_menu.lua:1912
 msgid "Folder Covers"
 msgstr ""
 
-#: sui_menu.lua:1640
+#: sui_menu.lua:1990
 msgid "Folder Name"
 msgstr ""
 
-#: sui_quickactions.lua:408
+#: sui_menu.lua:2042
+msgid "Folder Name Text Size"
+msgstr ""
+
+#: sui_quickactions.lua:573
 msgid "Folder Shortcuts"
 msgstr ""
 
-#: sui_foldercovers.lua:436
+#: sui_foldercovers.lua:641
 msgid "Folder cover"
 msgstr ""
 
-#: desktop_modules/module_clock.lua:46
+#: desktop_modules/module_clock.lua:51
 msgid "Friday"
 msgstr ""
 
-#: sui_bottombar.lua:1253
+#: sui_bottombar.lua:1510
 msgid "Frontlight not available on this device."
 msgstr ""
 
-#: sui_menu.lua:1358
+#: sui_menu.lua:350
+msgid "General"
+msgstr ""
+
+#: sui_menu.lua:1663
 msgid "Global scale for all modules.\nIndividual overrides in Module Settings take precedence.\n100% is the default size."
 msgstr ""
 
-#: sui_menu.lua:645
+#: sui_menu.lua:1932
+msgid "Group Books by Series"
+msgstr ""
+
+#: sui_menu.lua:830
 msgid "Height of the bottom navigation bar.\n100% is the default size."
 msgstr ""
 
-#: sui_menu.lua:587
+#: sui_menu.lua:760
 msgid "Height of the top status bar.\n100% is the default size."
 msgstr ""
 
-#: sui_menu.lua:728
-#: sui_menu.lua:1605
-#: sui_menu.lua:1643
+#: sui_menu.lua:374
+#: sui_menu.lua:433
+#: sui_menu.lua:922
+#: sui_menu.lua:1949
+#: sui_menu.lua:1993
 msgid "Hidden"
 msgstr ""
 
-#: sui_menu.lua:1132
+#: sui_menu.lua:1348
+#: desktop_modules/module_quick_actions.lua:330
 msgid "Hide Text"
 msgstr ""
 
-#: sui_menu.lua:1702
+#: sui_menu.lua:529
+msgid "Hide Wi-Fi icon when off"
+msgstr ""
+
+#: sui_menu.lua:2064
 msgid "Hide selection underline"
 msgstr ""
 
-#: sui_bottombar.lua:890
-#: sui_config.lua:115
-#: sui_quickactions.lua:403
+#: sui_menu.lua:441
+msgid "Hides the pagination bar on the homescreen.\nNot available when Navpager is active."
+msgstr ""
+
+#: sui_bottombar.lua:1039
+#: sui_config.lua:134
+#: sui_quickactions.lua:568
 msgid "History"
 msgstr ""
 
-#: sui_bottombar.lua:1125
+#: sui_bottombar.lua:1327
 msgid "History not available."
 msgstr ""
 
-#: sui_config.lua:113
+#: sui_config.lua:132
 msgid "Home"
 msgstr ""
 
-#: sui_menu.lua:1449
-#: sui_menu.lua:1543
-#: sui_patches.lua:289
-#: sui_patches.lua:293
-#: sui_patches.lua:306
+#: sui_menu.lua:387
+#: sui_menu.lua:1754
+#: sui_menu.lua:1872
+#: sui_patches.lua:497
+#: sui_patches.lua:520
 msgid "Home Screen"
 msgstr ""
 
-#: sui_bottombar.lua:907
+#: sui_bottombar.lua:1056
 msgid "Home folder"
 msgstr ""
 
-#: sui_bottombar.lua:909
+#: sui_bottombar.lua:1058
 msgid "Home folder + subfolders"
 msgstr ""
 
-#: sui_homescreen.lua:446
+#: sui_homescreen.lua:1041
 msgid "Homescreen"
 msgstr ""
 
-#: sui_bottombar.lua:1144
+#: sui_bottombar.lua:1368
 msgid "Homescreen not available."
 msgstr ""
 
-#: sui_quickactions.lua:520
-#: sui_quickactions.lua:524
+#: sui_quickactions.lua:711
+#: sui_quickactions.lua:715
 msgid "Icon"
 msgstr ""
 
-#: sui_menu.lua:690
-#: sui_menu.lua:693
+#: sui_menu.lua:884
+#: sui_menu.lua:887
 msgid "Icon Size"
 msgstr ""
 
-#: sui_menu.lua:691
+#: sui_menu.lua:885
 msgid "Icon Size — %d%%"
 msgstr ""
 
-#: sui_quickactions.lua:515
+#: sui_quickactions.lua:706
 msgid "Icon: Default"
 msgstr ""
 
-#: sui_menu.lua:101
+#: sui_menu.lua:103
 msgid "Icons"
 msgstr ""
 
-#: sui_menu.lua:102
+#: sui_menu.lua:104
 msgid "Icons only"
 msgstr ""
 
-#: sui_menu.lua:853
+#: sui_menu.lua:1059
 msgid "Invalid arrangement.\nKeep items between the Left and Right separators."
 msgstr ""
 
-#: sui_menu.lua:525
+#: sui_menu.lua:644
 msgid "Invalid arrangement.\nKeep the Left, Center and Right separators in order."
 msgstr ""
 
-#: sui_quickactions.lua:318
+#: sui_quickactions.lua:483
 msgid "Invalid input. Please enter 1–6 hexadecimal digits (0–9, A–F)."
 msgstr ""
 
-#: desktop_modules/module_currently.lua:671
-#: sui_menu.lua:606
+#: sui_menu.lua:779
+#: sui_menu.lua:1358
+#: desktop_modules/module_coverdeck.lua:769
+#: desktop_modules/module_currently.lua:983
+#: desktop_modules/module_quick_actions.lua:340
 msgid "Items"
 msgstr ""
 
-#: desktop_modules/module_clock.lua:49
+#: desktop_modules/module_clock.lua:54
 msgid "January"
 msgstr ""
 
-#: desktop_modules/module_clock.lua:50
+#: desktop_modules/module_clock.lua:55
 msgid "July"
 msgstr ""
 
-#: desktop_modules/module_clock.lua:50
+#: desktop_modules/module_clock.lua:55
 msgid "June"
 msgstr ""
 
-#: sui_menu.lua:1392
+#: sui_menu.lua:411
+msgid "KOReader"
+msgstr ""
+
+#: sui_menu.lua:1697
 msgid "Label Scale"
 msgstr ""
 
-#: sui_menu.lua:710
-#: sui_menu.lua:713
+#: sui_menu.lua:904
+#: sui_menu.lua:907
 msgid "Label Size"
 msgstr ""
 
-#: sui_menu.lua:711
+#: sui_menu.lua:905
 msgid "Label Size — %d%%"
 msgstr ""
 
-#: sui_menu.lua:1377
+#: sui_menu.lua:1682
 msgid "Labels"
 msgstr ""
 
-#: sui_menu.lua:962
+#: sui_menu.lua:1168
 msgid "Large"
 msgstr ""
 
-#: sui_menu.lua:310
-#: sui_menu.lua:340
-#: sui_menu.lua:398
-#: sui_menu.lua:570
-#: sui_menu.lua:627
-#: sui_menu.lua:948
-#: sui_menu.lua:1524
-#: sui_updater.lua:184
+#: sui_menu.lua:338
+#: sui_menu.lua:743
+#: sui_menu.lua:812
+#: sui_menu.lua:848
+#: sui_menu.lua:1154
+#: sui_menu.lua:1853
+#: sui_updater.lua:361
 msgid "Later"
 msgstr ""
 
-#: sui_menu.lua:492
-#: sui_menu.lua:823
+#: sui_menu.lua:611
+#: sui_menu.lua:1029
 msgid "Left"
 msgstr ""
 
-#: sui_config.lua:112
-#: sui_config.lua:485
-#: sui_menu.lua:1564
-#: sui_titlebar.lua:568
+#: sui_config.lua:131
+#: sui_config.lua:403
+#: sui_menu.lua:1893
+#: sui_titlebar.lua:675
 msgid "Library"
 msgstr ""
 
-#: sui_menu.lua:966
+#: sui_menu.lua:1172
 msgid "Library Buttons"
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:514
+#: desktop_modules/module_reading_stats.lua:453
 msgid "List"
 msgstr ""
 
-#: sui_menu.lua:1338
+#: sui_menu.lua:1643
 msgid "Lock Scale"
 msgstr ""
 
-#: desktop_modules/module_clock.lua:49
+#: desktop_modules/module_clock.lua:54
 msgid "March"
 msgstr ""
 
-#: sui_menu.lua:1095
-msgid "Maximum %d actions per module reached. Remove one first."
-msgstr ""
-
-#: sui_menu.lua:1152
-msgid "Maximum %d modules active. Disable one first."
-msgstr ""
-
-#: sui_quickactions.lua:883
-msgid "Maximum %d quick actions reached. Delete one first."
-msgstr ""
-
-#: desktop_modules/module_reading_stats.lua:481
-msgid "Maximum %d stats per row. Remove one first."
-msgstr ""
-
-#: sui_menu.lua:270
-msgid "Maximum %d tabs reached. Remove one first."
-msgstr ""
-
-#: desktop_modules/module_collections.lua:616
+#: desktop_modules/module_collections.lua:709
 msgid "Maximum 5 collections. Remove one first."
 msgstr ""
 
-#: desktop_modules/module_clock.lua:50
+#: desktop_modules/module_clock.lua:55
 msgid "May"
 msgstr ""
 
-#: sui_titlebar.lua:53
+#: sui_titlebar.lua:54
 #: sui_titlebar.lua:58
 msgid "Menu"
 msgstr ""
 
-#: sui_menu.lua:260
+#: sui_menu.lua:262
 msgid "Minimum 1 tab required in navpager mode."
 msgstr ""
 
-#: sui_menu.lua:261
+#: sui_menu.lua:263
 msgid "Minimum 2 tabs required. Select another tab first."
 msgstr ""
 
-#: desktop_modules/module_reading_goals.lua:399
+#: desktop_modules/module_reading_goals.lua:388
 msgid "Minutes per day:"
 msgstr ""
 
-#: sui_menu.lua:1355
+#: sui_menu.lua:1660
 msgid "Module Scale"
 msgstr ""
 
-#: sui_menu.lua:1314
+#: sui_menu.lua:1635
 msgid "Module Settings"
 msgstr ""
 
-#: sui_menu.lua:1326
-msgid "Module limit disabled. Enabling too many modules may slow down the homescreen significantly and modules may be clipped at the bottom of the page."
-msgstr ""
-
-#: sui_menu.lua:1349
+#: sui_menu.lua:1654
 msgid "Modules"
 msgstr ""
 
-#: sui_menu.lua:1271
-msgid "Modules  (%d — no limit)"
-msgstr ""
-#: sui_menu.lua:1385
+#: sui_menu.lua:1475
 msgid "Modules  (%d)"
 msgstr ""
 
-#: sui_menu.lua:1275
-msgid "Modules  (%d/%d — %d left)"
-msgstr ""
-
-#: sui_menu.lua:1274
-msgid "Modules  (%d/%d — at limit)"
-msgstr ""
-
-#: desktop_modules/module_clock.lua:45
+#: desktop_modules/module_clock.lua:50
 msgid "Monday"
 msgstr ""
 
-#: desktop_modules/module_quote.lua:996
+#: desktop_modules/module_quote.lua:1060
 msgid "My Highlights"
 msgstr ""
 
-#: sui_quickactions.lua:609
-#: sui_quickactions.lua:628
-#: sui_quickactions.lua:655
-#: sui_quickactions.lua:683
+#: sui_quickactions.lua:800
+#: sui_quickactions.lua:819
+#: sui_quickactions.lua:846
+#: sui_quickactions.lua:874
 msgid "Name"
 msgstr ""
 
-#: sui_menu.lua:1547
+#: sui_menu.lua:1876
 msgid "Navigation Bar"
 msgstr ""
 
-#: sui_menu.lua:375
+#: sui_menu.lua:363
 msgid "Navpager"
 msgstr ""
 
-#: sui_menu.lua:397
-msgid "Navpager will be %s after restart.\n\nRestart now?"
+#: sui_menu.lua:370
+msgid "Navpager enabled.\n\nRestart now?"
 msgstr ""
 
-#: sui_quickactions.lua:268
+#: sui_quickactions.lua:438
 msgid "Nerd Font Icon"
 msgstr ""
 
-#: sui_quickactions.lua:358
+#: sui_quickactions.lua:523
 msgid "Nerd Font symbol…"
 msgstr ""
 
-#: sui_bottombar.lua:1213
+#: sui_bottombar.lua:1437
 msgid "Network manager unavailable."
 msgstr ""
 
-#: desktop_modules/module_new_books.lua:139
+#: desktop_modules/module_new_books.lua:180
 msgid "New"
 msgstr ""
 
 #: desktop_modules/module_new_books.lua:46
 #: desktop_modules/module_new_books.lua:47
+#: desktop_modules/module_new_books.lua:107
+#: desktop_modules/module_new_books.lua:280
 msgid "New Books"
 msgstr ""
 
-#: sui_quickactions.lua:511
+#: sui_quickactions.lua:702
 msgid "New Quick Action"
 msgstr ""
 
-#: sui_quickactions.lua:817
+#: sui_quickactions.lua:1008
 msgid "New name…"
 msgstr ""
 
-#: sui_bottombar.lua:245
+#: sui_bottombar.lua:293
 msgid "Next"
 msgstr ""
 
-#: sui_menu.lua:1318
-msgid "No Module Limit  ⚠ not recommended"
+#: sui_updater.lua:419
+msgid "No automatic update file was found.\n\nOpen the releases page on GitHub?"
 msgstr ""
 
-#: sui_bottombar.lua:1171
+#: sui_bottombar.lua:1395
 msgid "No book in history."
 msgstr ""
 
-#: sui_foldercovers.lua:394
+#: sui_foldercovers.lua:594
 msgid "No books found in this folder."
 msgstr ""
 
-#: sui_homescreen.lua:116
+#: sui_foldercovers.lua:529
+msgid "No books found in this series."
+msgstr ""
+
+#: desktop_modules/module_tbr.lua:455
+msgid "No books in To Be Read list."
+msgstr ""
+
+#: sui_homescreen.lua:190
 msgid "No books opened yet"
 msgstr ""
 
-#: desktop_modules/module_collections.lua:586
+#: desktop_modules/module_collections.lua:672
 msgid "No collections found."
 msgstr ""
 
-#: desktop_modules/module_collections.lua:322
+#: desktop_modules/module_collections.lua:378
 msgid "No collections selected"
 msgstr ""
 
-#: sui_quickactions.lua:1036
+#: sui_quickactions.lua:1252
 msgid "No folder, collection or plugin configured.\nGo to Simple UI \xe2\x86\x92 Settings \xe2\x86\x92 Quick Actions to set one."
 msgstr ""
 
-#: desktop_modules/module_quote.lua:699
+#: desktop_modules/module_quote.lua:745
 msgid "No highlights found. Open a book and highlight some passages."
 msgstr ""
 
-#: sui_quickactions.lua:371
+#: sui_quickactions.lua:536
 msgid "No icons found in:"
 msgstr ""
 
-#: sui_quickactions.lua:645
+#: sui_quickactions.lua:836
 msgid "No plugins found."
 msgstr ""
 
-#: desktop_modules/module_quote.lua:665
+#: desktop_modules/module_quote.lua:711
 msgid "No quotes found."
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:367
+#: desktop_modules/module_reading_stats.lua:286
 msgid "No stats selected"
 msgstr ""
 
-#: sui_quickactions.lua:673
+#: sui_quickactions.lua:864
 msgid "No system actions found."
 msgstr ""
 
-#: desktop_modules/module_clock.lua:51
+#: desktop_modules/module_clock.lua:56
 msgid "November"
 msgstr ""
 
-#: sui_menu.lua:1602
+#: sui_menu.lua:1946
 msgid "Number of Books in Folder"
 msgstr ""
 
-#: sui_menu.lua:1634
+#: sui_menu.lua:1480
+#: sui_menu.lua:1978
 msgid "Number of Pages"
 msgstr ""
-#: sui_menu.lua:494
+
+#: sui_menu.lua:497
 msgid "Number of Pages in Title Bar Always"
 msgstr ""
 
-#: sui_quickactions.lua:286
+#: sui_quickactions.lua:451
 msgid "OK"
 msgstr ""
 
-#: desktop_modules/module_clock.lua:51
+#: desktop_modules/module_clock.lua:56
 msgid "October"
 msgstr ""
 
-#: sui_menu.lua:296
-#: sui_menu.lua:356
-#: sui_menu.lua:374
-#: sui_menu.lua:561
-#: sui_menu.lua:618
-#: sui_menu.lua:787
-#: sui_menu.lua:933
-#: sui_menu.lua:1449
-#: sui_menu.lua:1506
-#: desktop_modules/module_clock.lua:378
-#: desktop_modules/module_clock.lua:386
+#: sui_menu.lua:734
+#: sui_menu.lua:803
+#: sui_menu.lua:993
+#: sui_menu.lua:1139
+#: sui_menu.lua:1754
+#: sui_menu.lua:1835
 msgid "Off"
 msgstr ""
 
-#: sui_menu.lua:296
-#: sui_menu.lua:356
-#: sui_menu.lua:374
-#: sui_menu.lua:561
-#: sui_menu.lua:618
-#: sui_menu.lua:787
-#: sui_menu.lua:933
-#: sui_menu.lua:1449
-#: sui_menu.lua:1506
-#: desktop_modules/module_clock.lua:378
-#: desktop_modules/module_clock.lua:386
+#: sui_menu.lua:734
+#: sui_menu.lua:803
+#: sui_menu.lua:993
+#: sui_menu.lua:1139
+#: sui_menu.lua:1754
+#: sui_menu.lua:1835
 msgid "On"
 msgstr ""
 
-#: desktop_modules/module_quote.lua:891
+#: sui_homescreen.lua:420
+#: desktop_modules/module_quote.lua:951
 msgid "Open"
 msgstr ""
 
-#: sui_homescreen.lua:125
+#: sui_homescreen.lua:199
 msgid "Open a book to get started"
 msgstr ""
 
-#: sui_menu.lua:1598
+#: sui_updater.lua:420
+msgid "Open in browser"
+msgstr ""
+
+#: sui_homescreen.lua:419
+#: desktop_modules/module_quote.lua:950
+msgid "Open this file?"
+msgstr ""
+
+#: sui_menu.lua:1942
 msgid "Overlays"
 msgstr ""
 
-#: sui_patches.lua:1125
-#: sui_patches.lua:1239
+#: sui_homescreen.lua:1611
+#: sui_patches.lua:1561
 msgid "Page %1 of %2"
 msgstr ""
 
-#: sui_menu.lua:356
-msgid "Page number in title bar"
-msgstr ""
-
-#: sui_menu.lua:1548
+#: sui_menu.lua:1877
 msgid "Pagination Bar"
 msgstr ""
 
-#: sui_menu.lua:339
+#: sui_menu.lua:380
+msgid "Pagination bar hidden.\n\nRestart now?"
+msgstr ""
+
+#: sui_menu.lua:359
+msgid "Pagination bar set to Default.\n\nRestart now?"
+msgstr ""
+
+#: sui_menu.lua:466
+#: sui_menu.lua:478
+#: sui_menu.lua:490
 msgid "Pagination bar size will change after restart.\n\nRestart now?"
 msgstr ""
 
-#: sui_menu.lua:309
-msgid "Pagination bar will be %s after restart.\n\nRestart now?"
-msgstr ""
-
-#: sui_titlebar.lua:57
-msgid "Path"
-msgstr ""
-
-#: sui_quickactions.lua:592
+#: sui_quickactions.lua:783
 msgid "Path chooser not available."
 msgstr ""
 
-#: desktop_modules/module_recent.lua:286
+#: desktop_modules/module_recent.lua:304
 msgid "Percentage overlay on cover"
 msgstr ""
 
-#: desktop_modules/module_currently.lua:524
+#: desktop_modules/module_coverdeck.lua:75
+#: desktop_modules/module_currently.lua:268
+#: desktop_modules/module_currently.lua:911
 msgid "Percentage read"
 msgstr ""
 
-#: desktop_modules/module_recent.lua:276
+#: desktop_modules/module_recent.lua:294
 msgid "Percentage text"
 msgstr ""
 
-#: desktop_modules/module_reading_goals.lua:380
+#: desktop_modules/module_reading_goals.lua:370
 msgid "Physical Books — %s"
 msgstr ""
 
-#: desktop_modules/module_reading_goals.lua:381
+#: desktop_modules/module_reading_goals.lua:371
 msgid "Physical books read this year:"
 msgstr ""
 
-#: sui_menu.lua:1031
-msgid "Physical: %d books in %s"
+#: sui_menu.lua:2071
+msgid "Placeholder cover for bookless folders"
 msgstr ""
 
-#: sui_quickactions.lua:704
+#: sui_quickactions.lua:895
 msgid "Plugin"
 msgstr ""
 
-#: sui_quickactions.lua:1021
+#: sui_quickactions.lua:1237
 msgid "Plugin error: %s"
 msgstr ""
 
-#: sui_quickactions.lua:1023
+#: sui_quickactions.lua:1239
 msgid "Plugin not available: %s"
 msgstr ""
 
-#: sui_config.lua:122
+#: sui_config.lua:141
 msgid "Power"
 msgstr ""
 
-#: sui_bottombar.lua:245
+#: sui_bottombar.lua:293
 msgid "Prev"
 msgstr ""
 
-#: desktop_modules/module_recent.lua:266
+#: desktop_modules/module_currently.lua:267
+#: desktop_modules/module_recent.lua:284
 msgid "Progress bar"
 msgstr ""
 
-#: desktop_modules/module_currently.lua:499
+#: desktop_modules/module_currently.lua:923
 msgid "Progress bar style"
 msgstr ""
 
-#: sui_menu.lua:1248
-#: sui_menu.lua:1555
+#: sui_menu.lua:1453
+#: sui_menu.lua:1884
 msgid "Quick Actions"
 msgstr ""
 
-#: sui_menu.lua:1559
+#: sui_menu.lua:1888
 msgid "Quick Actions  (%d/%d — %d left)"
 msgstr ""
 
-#: sui_menu.lua:1557
+#: sui_menu.lua:1886
 msgid "Quick Actions  (%d/%d — at limit)"
 msgstr ""
 
-#: sui_menu.lua:1084
-#: desktop_modules/module_quick_actions.lua:197
+#: sui_menu.lua:1290
+#: desktop_modules/module_quick_actions.lua:198
+#: desktop_modules/module_quick_actions.lua:244
 msgid "Quick Actions %d"
 msgstr ""
 
-#: sui_bottombar.lua:1420
+#: sui_bottombar.lua:1736
 msgid "Quit"
 msgstr ""
 
-#: desktop_modules/module_quote.lua:767
+#: desktop_modules/module_quote.lua:821
 msgid "Quote of the Day"
 msgstr ""
 
-#: desktop_modules/module_quote.lua:1018
+#: desktop_modules/module_quote.lua:1082
 msgid "Quotes + My Highlights"
 msgstr ""
 
-#: sui_config.lua:145
+#: sui_config.lua:164
 msgid "RAM Usage"
 msgstr ""
 
-#: desktop_modules/module_reading_goals.lua:454
-#: desktop_modules/module_reading_goals.lua:455
+#: desktop_modules/module_reading_goals.lua:442
+#: desktop_modules/module_reading_goals.lua:443
+#: desktop_modules/module_reading_goals.lua:468
+#: desktop_modules/module_reading_goals.lua:606
 msgid "Reading Goals"
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:308
+#: desktop_modules/module_reading_stats.lua:218
 msgid "Reading Stats"
 msgstr ""
 
-#: desktop_modules/module_flow_recent.lua:55
-msgid "Flow Recent Books"
-msgstr ""
-
-#: desktop_modules/module_recent.lua:61
+#: desktop_modules/module_coverdeck.lua:728
 #: desktop_modules/module_recent.lua:62
-#: desktop_modules/module_flow_recent.lua:56
-#: desktop_modules/module_flow_recent.lua:93
-msgid "Cover Deck"
+#: desktop_modules/module_recent.lua:63
+#: desktop_modules/module_recent.lua:72
+#: desktop_modules/module_recent.lua:281
+msgid "Recent Books"
 msgstr ""
 
-#: desktop_modules/module_flow_recent.lua:124
-msgid "To Be Read (Deck)"
+#: desktop_modules/module_tbr.lua:265
+msgid "Remove from To Be Read"
 msgstr ""
 
-#: sui_quickactions.lua:815
-#: sui_quickactions.lua:873
+#: sui_quickactions.lua:1006
+#: sui_quickactions.lua:1064
 msgid "Rename"
 msgstr ""
 
-#: sui_menu.lua:378
+#: sui_menu.lua:366
 msgid "Replaces the pagination bar with Prev/Next arrows at the edges of the bottom bar.\nThe arrows dim when there is no previous or next page.\nWith navpager active, as few as 1 tab and at most 4 tabs can be configured."
 msgstr ""
 
-#: sui_menu.lua:1420
-#: sui_quickactions.lua:824
+#: sui_menu.lua:1725
+#: sui_quickactions.lua:1015
 msgid "Reset"
 msgstr ""
 
-#: sui_menu.lua:1419
+#: sui_menu.lua:1724
 msgid "Reset all scales to default (100%)? This cannot be undone."
 msgstr ""
 
-#: sui_menu.lua:1414
+#: sui_menu.lua:1719
 msgid "Reset to Default Scale"
 msgstr ""
 
-#: sui_bottombar.lua:1412
-#: sui_menu.lua:310
-#: sui_menu.lua:340
-#: sui_menu.lua:398
-#: sui_menu.lua:570
-#: sui_menu.lua:627
-#: sui_menu.lua:947
-#: sui_menu.lua:1524
-#: sui_updater.lua:183
+#: sui_bottombar.lua:1715
+#: sui_menu.lua:338
+#: sui_menu.lua:743
+#: sui_menu.lua:812
+#: sui_menu.lua:847
+#: sui_menu.lua:1153
+#: sui_menu.lua:1853
+#: sui_updater.lua:360
 msgid "Restart"
 msgstr ""
 
-#: sui_menu.lua:504
-#: sui_menu.lua:831
+#: sui_menu.lua:1774
+msgid "Return to Book Folder"
+msgstr ""
+
+#: sui_menu.lua:623
+#: sui_menu.lua:1037
 msgid "Right"
 msgstr ""
 
-#: desktop_modules/module_clock.lua:46
+#: desktop_modules/module_clock.lua:51
 msgid "Saturday"
 msgstr ""
 
-#: sui_quickactions.lua:567
-#: sui_quickactions.lua:835
-#: desktop_modules/module_reading_goals.lua:366
-#: desktop_modules/module_reading_goals.lua:383
-#: desktop_modules/module_reading_goals.lua:401
+#: sui_quickactions.lua:758
+#: sui_quickactions.lua:1026
+#: desktop_modules/module_reading_goals.lua:357
+#: desktop_modules/module_reading_goals.lua:373
+#: desktop_modules/module_reading_goals.lua:390
 msgid "Save"
 msgstr ""
 
-#: sui_menu.lua:1334
-#: desktop_modules/module_clock.lua:356
-#: desktop_modules/module_clock.lua:358
-#: desktop_modules/module_collections.lua:432
-#: desktop_modules/module_collections.lua:434
-#: desktop_modules/module_currently.lua:433
-#: desktop_modules/module_currently.lua:435
-#: desktop_modules/module_new_books.lua:204
-#: desktop_modules/module_new_books.lua:206
-#: desktop_modules/module_quick_actions.lua:245
-#: desktop_modules/module_quick_actions.lua:247
-#: desktop_modules/module_quote.lua:938
-#: desktop_modules/module_quote.lua:942
-#: desktop_modules/module_reading_goals.lua:546
-#: desktop_modules/module_reading_goals.lua:548
-#: desktop_modules/module_reading_stats.lua:452
-#: desktop_modules/module_reading_stats.lua:454
-#: desktop_modules/module_recent.lua:225
-#: desktop_modules/module_recent.lua:227
+#: sui_menu.lua:1639
+#: desktop_modules/module_clock.lua:433
+#: desktop_modules/module_clock.lua:435
+#: desktop_modules/module_collections.lua:500
+#: desktop_modules/module_collections.lua:502
+#: desktop_modules/module_coverdeck.lua:698
+#: desktop_modules/module_coverdeck.lua:700
+#: desktop_modules/module_currently.lua:797
+#: desktop_modules/module_currently.lua:799
+#: desktop_modules/module_new_books.lua:246
+#: desktop_modules/module_new_books.lua:248
+#: desktop_modules/module_quick_actions.lua:381
+#: desktop_modules/module_quick_actions.lua:383
+#: desktop_modules/module_quote.lua:1002
+#: desktop_modules/module_quote.lua:1006
+#: desktop_modules/module_reading_goals.lua:566
+#: desktop_modules/module_reading_goals.lua:568
+#: desktop_modules/module_reading_stats.lua:389
+#: desktop_modules/module_reading_stats.lua:391
+#: desktop_modules/module_recent.lua:242
+#: desktop_modules/module_recent.lua:244
+#: desktop_modules/module_tbr.lua:362
+#: desktop_modules/module_tbr.lua:364
 msgid "Scale"
 msgstr ""
 
-#: desktop_modules/module_currently.lua:463
+#: desktop_modules/module_currently.lua:827
 msgid "Scale for all text elements (title, author, progress, time).\n100% is the default size."
 msgstr ""
 
-#: desktop_modules/module_quick_actions.lua:259
+#: desktop_modules/module_quick_actions.lua:395
 msgid "Scale for the button label text.\n100% is the default size."
 msgstr ""
 
-#: desktop_modules/module_collections.lua:448
+#: desktop_modules/module_collections.lua:516
 msgid "Scale for the collection name text.\n100% is the default size."
 msgstr ""
 
-#: desktop_modules/module_collections.lua:567
+#: desktop_modules/module_collections.lua:653
 msgid "Scale for the collection thumbnails only.\nThe label text follows the module scale.\n100% is the default size."
 msgstr ""
 
-#: desktop_modules/module_currently.lua:450
+#: desktop_modules/module_currently.lua:814
 msgid "Scale for the cover thumbnail only.\n100% is the default size."
 msgstr ""
 
-#: desktop_modules/module_new_books.lua:221
-#: desktop_modules/module_recent.lua:242
+#: desktop_modules/module_coverdeck.lua:709
+msgid "Scale for the cover thumbnails only.\n100% is the default size."
+msgstr ""
+
+#: desktop_modules/module_new_books.lua:263
+#: desktop_modules/module_recent.lua:259
 msgid "Scale for the cover thumbnails only.\nText and progress bar follow the module scale.\n100% is the default size."
 msgstr ""
 
-#: desktop_modules/module_new_books.lua:233
+#: sui_menu.lua:2043
+msgid "Scale for the folder name overlay text.\n100% is the default size."
+msgstr ""
+
+#: desktop_modules/module_new_books.lua:275
 msgid "Scale for the label text.\n100% is the default size."
 msgstr ""
 
-#: desktop_modules/module_recent.lua:256
+#: desktop_modules/module_recent.lua:273
 msgid "Scale for the percentage read text.\n100% is the default size."
 msgstr ""
 
-#: desktop_modules/module_clock.lua:359
-#: desktop_modules/module_collections.lua:435
-#: desktop_modules/module_currently.lua:436
-#: desktop_modules/module_new_books.lua:207
-#: desktop_modules/module_quick_actions.lua:248
-#: desktop_modules/module_quote.lua:944
-#: desktop_modules/module_reading_goals.lua:549
-#: desktop_modules/module_reading_stats.lua:455
-#: desktop_modules/module_recent.lua:228
+#: desktop_modules/module_coverdeck.lua:701
+msgid "Scale for this module."
+msgstr ""
+
+#: desktop_modules/module_clock.lua:436
+#: desktop_modules/module_collections.lua:503
+#: desktop_modules/module_currently.lua:800
+#: desktop_modules/module_new_books.lua:249
+#: desktop_modules/module_quick_actions.lua:384
+#: desktop_modules/module_quote.lua:1008
+#: desktop_modules/module_reading_goals.lua:569
+#: desktop_modules/module_reading_stats.lua:392
+#: desktop_modules/module_recent.lua:245
+#: desktop_modules/module_tbr.lua:365
 msgid "Scale for this module.\n100% is the default size."
 msgstr ""
 
-#: sui_menu.lua:1357
+#: desktop_modules/module_coverdeck.lua:717
+msgid "Scale for title and statistics text.\n100% is the default size."
+msgstr ""
+
+#: sui_menu.lua:1662
 msgid "Scales all modules and labels together.\n100% is the default size."
 msgstr ""
 
-#: sui_menu.lua:1393
+#: sui_menu.lua:1698
 msgid "Scales the section label text above each module.\n100% is the default size."
 msgstr ""
 
-#: sui_titlebar.lua:55
+#: sui_menu.lua:2086
+msgid "Scan subfolders for cover"
+msgstr ""
+
+#: sui_titlebar.lua:56
 msgid "Search"
 msgstr ""
 
-#: desktop_modules/module_collections.lua:540
+#: desktop_modules/module_collections.lua:626
 msgid "Select at least 2 collections to arrange."
 msgstr ""
 
-#: desktop_modules/module_clock.lua:51
+#: desktop_modules/module_clock.lua:56
 msgid "September"
 msgstr ""
 
-#: sui_foldercovers.lua:455
+#: sui_menu.lua:1984
+msgid "Series Index"
+msgstr ""
+
+#: sui_foldercovers.lua:574
+msgid "Series cover"
+msgstr ""
+
+#: sui_menu.lua:568
+msgid "Set"
+msgstr ""
+
+#: sui_foldercovers.lua:664
 msgid "Set folder cover…"
 msgstr ""
 
-#: sui_menu.lua:1533
+#: sui_foldercovers.lua:664
+msgid "Set series cover…"
+msgstr ""
+
+#: sui_menu.lua:1862
 msgid "Settings"
 msgstr ""
 
-#: desktop_modules/module_clock.lua:386
+#: sui_menu.lua:781
+#: sui_menu.lua:951
+#: sui_menu.lua:1786
+msgid "Settings on Long Tap"
+msgstr ""
+
+#: desktop_modules/module_clock.lua:466
 msgid "Show Battery"
 msgstr ""
 
@@ -1255,715 +1388,513 @@ msgstr ""
 msgid "Show Clock"
 msgstr ""
 
-#: desktop_modules/module_clock.lua:378
+#: desktop_modules/module_clock.lua:460
 msgid "Show Date"
 msgstr ""
 
-#: sui_menu.lua:364
+#: sui_config.lua:1748
+msgid "Show section label"
+msgstr ""
+
+#: sui_menu.lua:501
 msgid "Shows \"Page X of Y\" in the title bar subtitle when browsing the library, history or collections.\nNavpager enables this automatically.\nNot available when Navpager is active."
 msgstr ""
 
-#: desktop_modules/module_currently.lua:502
+#: sui_menu.lua:398
+msgid "Shows a row of dots at the bottom of the homescreen.\nThe active page dot is filled; the others are dimmed.\nAlways active when Navpager is selected."
+msgstr ""
+
+#: desktop_modules/module_currently.lua:926
 msgid "Simple"
 msgstr ""
 
-#: main.lua:381
-#: main.lua:394
-#: sui_menu.lua:1502
-#: sui_menu.lua:1506
+#: main.lua:541
+#: main.lua:554
+#: sui_menu.lua:1831
+#: sui_menu.lua:1835
 msgid "Simple UI"
 msgstr ""
 
-#: main.lua:68
-msgid "Simple UI was updated (%s → %s).\n\nA restart is recommended to apply all changes cleanly."
+#: sui_updater.lua:407
+msgid "Simple UI %s is available!\nYou have %s."
 msgstr ""
 
-#: sui_menu.lua:1523
+#: sui_updater.lua:357
+msgid "Simple UI %s successfully installed.\n\nRestart KOReader to apply the update?"
+msgstr ""
+
+#: sui_updater.lua:399
+msgid "Simple UI is up to date (%s)."
+msgstr ""
+
+#: sui_menu.lua:1852
 msgid "Simple UI will be %s after restart.\n\nRestart now?"
 msgstr ""
 
-#: sui_menu.lua:580
-#: sui_menu.lua:638
+#: sui_menu.lua:454
+#: sui_menu.lua:753
+#: sui_menu.lua:823
 msgid "Size"
 msgstr ""
 
-#: sui_menu.lua:694
+#: sui_menu.lua:888
 msgid "Size of the tab icons.\n100% is the default size."
 msgstr ""
 
-#: sui_menu.lua:714
+#: sui_menu.lua:908
 msgid "Size of the tab label text.\n100% is the default size."
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:534
+#: desktop_modules/module_reading_stats.lua:473
 msgid "Size of the text inside the stat cards.\nDoes not affect card size or padding.\n100% is the default size."
 msgstr ""
 
-#: sui_menu.lua:325
+#: sui_bottombar.lua:1726
+msgid "Sleep"
+msgstr ""
+
+#: sui_menu.lua:470
 msgid "Small"
 msgstr ""
 
-#: desktop_modules/module_quote.lua:970
+#: desktop_modules/module_coverdeck.lua:725
+#: desktop_modules/module_quote.lua:1034
 msgid "Source"
 msgstr ""
 
-#: sui_menu.lua:672
+#: sui_menu.lua:866
 msgid "Space below the bottom navigation bar.\n100% is the default spacing."
 msgstr ""
 
-#: sui_patches.lua:306
-#: sui_patches.lua:308
+#: sui_patches.lua:520
+#: sui_patches.lua:522
 msgid "Start with"
 msgstr ""
 
-#: sui_menu.lua:1459
+#: sui_menu.lua:1764
 msgid "Start with Home Screen"
 msgstr ""
 
-#: sui_bottombar.lua:956
-#: sui_bottombar.lua:1184
+#: sui_bottombar.lua:1123
+#: sui_bottombar.lua:1408
 msgid "Statistics plugin not available."
 msgstr ""
 
-#: sui_config.lua:121
+#: sui_config.lua:140
 msgid "Stats"
 msgstr ""
 
-#: sui_menu.lua:1539
+#: desktop_modules/module_currently.lua:951
+msgid "Stats layout"
+msgstr ""
+
+#: sui_menu.lua:1868
 msgid "Status Bar"
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:68
+#: desktop_modules/module_reading_stats.lua:67
 msgid "Streak"
 msgstr ""
 
-#: sui_menu.lua:971
+#: sui_menu.lua:1177
 msgid "Sub-pages Buttons"
 msgstr ""
 
-#: desktop_modules/module_clock.lua:45
+#: desktop_modules/module_clock.lua:50
 msgid "Sunday"
 msgstr ""
 
-#: sui_menu.lua:417
+#: sui_menu.lua:519
 msgid "Swipe Indicator"
 msgstr ""
 
-#: sui_menu.lua:427
-msgid "Hide Wi-Fi icon when off"
-msgstr ""
-
-#: sui_quickactions.lua:706
+#: sui_quickactions.lua:897
 msgid "System Actions"
 msgstr ""
 
-#: sui_quickactions.lua:1011
+#: sui_quickactions.lua:1203
 msgid "System action error: %s"
 msgstr ""
 
-#: sui_menu.lua:752
+#: sui_menu.lua:946
 msgid "Tabs  (%d/%d — %d left)"
 msgstr ""
 
-#: sui_menu.lua:750
+#: sui_menu.lua:944
 msgid "Tabs  (%d/%d — at limit)"
 msgstr ""
 
-#: sui_menu.lua:101
+#: sui_menu.lua:103
 msgid "Text"
 msgstr ""
 
-#: desktop_modules/module_collections.lua:446
-#: desktop_modules/module_collections.lua:447
-#: desktop_modules/module_currently.lua:461
-#: desktop_modules/module_currently.lua:462
-#: desktop_modules/module_new_books.lua:231
-#: desktop_modules/module_new_books.lua:232
-#: desktop_modules/module_quick_actions.lua:255
-#: desktop_modules/module_quick_actions.lua:258
-#: desktop_modules/module_reading_stats.lua:530
-#: desktop_modules/module_reading_stats.lua:533
-#: desktop_modules/module_recent.lua:254
-#: desktop_modules/module_recent.lua:255
+#: desktop_modules/module_collections.lua:514
+#: desktop_modules/module_collections.lua:515
+#: desktop_modules/module_currently.lua:825
+#: desktop_modules/module_currently.lua:826
+#: desktop_modules/module_new_books.lua:273
+#: desktop_modules/module_new_books.lua:274
+#: desktop_modules/module_quick_actions.lua:391
+#: desktop_modules/module_quick_actions.lua:394
+#: desktop_modules/module_reading_stats.lua:469
+#: desktop_modules/module_reading_stats.lua:472
+#: desktop_modules/module_recent.lua:271
+#: desktop_modules/module_recent.lua:272
 msgid "Text Size"
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:531
+#: desktop_modules/module_reading_stats.lua:470
 msgid "Text Size — %d%%"
 msgstr ""
 
-#: sui_menu.lua:103
+#: sui_menu.lua:105
 msgid "Text only"
 msgstr ""
 
-#: desktop_modules/module_clock.lua:46
+#: sui_menu.lua:558
+msgid "Text shown in the top bar.\nMaximum %d characters."
+msgstr ""
+
+#: sui_menu.lua:2040
+#: desktop_modules/module_coverdeck.lua:715
+#: desktop_modules/module_coverdeck.lua:716
+msgid "Text size"
+msgstr ""
+
+#: sui_patches.lua:669
+msgid "The «To Be Read» collection cannot be renamed."
+msgstr ""
+
+#: desktop_modules/module_clock.lua:51
 msgid "Thursday"
 msgstr ""
 
-#: sui_titlebar.lua:56
+#: desktop_modules/module_coverdeck.lua:77
+#: desktop_modules/module_currently.lua:270
+msgid "Time read"
+msgstr ""
+
+#: desktop_modules/module_coverdeck.lua:78
+#: desktop_modules/module_currently.lua:271
+msgid "Time remaining"
+msgstr ""
+
+#: sui_titlebar.lua:57
+#: desktop_modules/module_currently.lua:265
 msgid "Title"
 msgstr ""
 
-#: sui_menu.lua:1540
+#: sui_menu.lua:1869
 msgid "Title Bar"
 msgstr ""
 
-#: desktop_modules/module_reading_goals.lua:491
-#: desktop_modules/module_reading_goals.lua:493
-#: desktop_modules/module_reading_goals.lua:515
-#: desktop_modules/module_reading_goals.lua:517
+#: desktop_modules/module_coverdeck.lua:747
+msgid "Title Position"
+msgstr ""
+
+#: desktop_modules/module_coverdeck.lua:736
+#: desktop_modules/module_tbr.lua:229
+#: desktop_modules/module_tbr.lua:230
+#: desktop_modules/module_tbr.lua:244
+#: desktop_modules/module_tbr.lua:280
+#: desktop_modules/module_tbr.lua:398
+msgid "To Be Read"
+msgstr ""
+
+#: desktop_modules/module_tbr.lua:450
+msgid "To Be Read books"
+msgstr ""
+
+#: sui_patches.lua:717
+#: sui_patches.lua:756
+#: sui_patches.lua:788
+#: sui_patches.lua:829
+msgid "To Be Read list is full (max. 5 books)."
+msgstr ""
+
+#: desktop_modules/module_reading_goals.lua:509
+#: desktop_modules/module_reading_goals.lua:511
+#: desktop_modules/module_reading_goals.lua:534
+#: desktop_modules/module_reading_goals.lua:537
 msgid "Today"
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:63
+#: desktop_modules/module_reading_stats.lua:62
 msgid "Today — Pages"
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:62
+#: desktop_modules/module_reading_stats.lua:61
 msgid "Today — Time"
 msgstr ""
 
-#: sui_menu.lua:1537
-#: sui_menu.lua:1616
-#: sui_menu.lua:1664
+#: sui_menu.lua:1866
+#: sui_menu.lua:1960
+#: sui_menu.lua:2014
 msgid "Top"
 msgstr ""
 
-#: sui_menu.lua:561
-#: sui_topbar.lua:473
+#: sui_menu.lua:734
+#: sui_topbar.lua:507
 msgid "Top Bar"
 msgstr ""
 
-#: sui_menu.lua:586
+#: sui_menu.lua:759
 msgid "Top Bar Size"
 msgstr ""
 
-#: sui_menu.lua:569
+#: sui_menu.lua:742
 msgid "Top Bar will be %s after restart.\n\nRestart now?"
 msgstr ""
 
-#: sui_menu.lua:728
+#: sui_homescreen.lua:1681
+msgid "Top Margin  (%d%%)"
+msgstr ""
+
+#: sui_menu.lua:922
 msgid "Top separator"
 msgstr ""
 
-#: sui_menu.lua:1653
+#: sui_menu.lua:2003
 msgid "Transparent"
 msgstr ""
 
-#: desktop_modules/module_clock.lua:45
+#: desktop_modules/module_clock.lua:50
 msgid "Tuesday"
 msgstr ""
 
-#: sui_menu.lua:741
-#: desktop_modules/module_quick_actions.lua:267
-#: desktop_modules/module_reading_goals.lua:563
-#: desktop_modules/module_reading_stats.lua:491
+#: sui_menu.lua:935
+#: desktop_modules/module_quick_actions.lua:403
+#: desktop_modules/module_reading_goals.lua:584
+#: desktop_modules/module_reading_stats.lua:430
 msgid "Type"
 msgstr ""
 
-#: sui_menu.lua:1692
+#: sui_menu.lua:2054
 msgid "Uniformize Covers (2:3)"
 msgstr ""
 
-#: sui_menu.lua:728
+#: sui_updater.lua:377
+msgid "Update cancelled."
+msgstr ""
+
+#: sui_updater.lua:487
+msgid "Update check cancelled."
+msgstr ""
+
+#: sui_menu.lua:2132
+msgid "Updater module not found."
+msgstr ""
+
+#: sui_menu.lua:420
+msgid "Uses the standard KOReader pagination bar on the homescreen.\nNot available when Navpager is active."
+msgstr ""
+
+#: sui_menu.lua:2117
+msgid "Version: %s"
+msgstr ""
+
+#: sui_homescreen.lua:1684
+msgid "Vertical space above this module.\n100% is the default spacing."
+msgstr ""
+
+#: sui_menu.lua:922
 msgid "Visible"
 msgstr ""
 
-#: desktop_modules/module_clock.lua:45
+#: desktop_modules/module_clock.lua:50
 msgid "Wednesday"
 msgstr ""
 
-#: sui_config.lua:119
+#: sui_updater.lua:412
+msgid "What's new:"
+msgstr ""
+
+#: sui_menu.lua:1787
+msgid "When enabled, long-pressing a section opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
+msgstr ""
+
+#: sui_menu.lua:952
+msgid "When enabled, long-pressing the bottom bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
+msgstr ""
+
+#: sui_menu.lua:782
+msgid "When enabled, long-pressing the top bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
+msgstr ""
+
+#: sui_menu.lua:1775
+msgid "When enabled, opening the file browser after finishing or closing a book navigates to the folder the book is in, matching native KOReader behaviour.\nWhen disabled (default), SimpleUI always returns to the library root.\nThis option works independently of \"Start with Home Screen\"."
+msgstr ""
+
+#: sui_config.lua:138
 msgid "Wi-Fi"
 msgstr ""
 
-#: sui_bottombar.lua:1221
+#: sui_bottombar.lua:1445
 msgid "Wi-Fi off"
 msgstr ""
 
-#: sui_config.lua:141
+#: sui_config.lua:160
 msgid "WiFi"
 msgstr ""
 
-#: sui_bottombar.lua:1208
+#: sui_bottombar.lua:1432
 msgid "WiFi not available on this device."
 msgstr ""
 
-#: sui_quickactions.lua:410
+#: sui_quickactions.lua:575
 msgid "Wikipedia Lookup"
 msgstr ""
 
-#: desktop_modules/module_currently.lua:512
+#: desktop_modules/module_currently.lua:936
 msgid "With percentage"
 msgstr ""
 
-#: desktop_modules/module_quote.lua:701
+#: desktop_modules/module_quote.lua:747
 msgid "Your highlights"
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:67
+#: sui_updater.lua:410
+msgid "\n\nDownload and install now?"
+msgstr ""
+
+#: desktop_modules/module_reading_stats.lua:66
 msgid "books finished"
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:64
+#: desktop_modules/module_reading_stats.lua:63
 msgid "daily avg (7 days)"
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:69
+#: desktop_modules/module_reading_stats.lua:68
 msgid "day streak"
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:69
+#: desktop_modules/module_reading_stats.lua:68
 msgid "days streak"
+msgstr ""
+
+#: sui_quickactions.lua:960
+msgid "default"
+msgstr ""
+
+#: sui_menu.lua:742
+#: sui_menu.lua:811
+#: sui_menu.lua:1151
+#: sui_menu.lua:1852
+msgid "disabled"
+msgstr ""
+
+#: sui_quickactions.lua:800
+msgid "e.g. Comics…"
+msgstr ""
+
+#: sui_quickactions.lua:846
+msgid "e.g. Rakuyomi…"
+msgstr ""
+
+#: sui_quickactions.lua:819
+msgid "e.g. Sci-Fi…"
+msgstr ""
+
+#: sui_quickactions.lua:874
+msgid "e.g. Sleep, Refresh…"
+msgstr ""
+
+#: sui_menu.lua:742
+#: sui_menu.lua:811
+#: sui_menu.lua:1151
+#: sui_menu.lua:1852
+msgid "enabled"
+msgstr ""
+
+#: sui_quickactions.lua:440
+msgid "hex code, e.g. E001"
 msgstr ""
 
 #: desktop_modules/module_reading_stats.lua:68
 msgid "no streak"
 msgstr ""
 
-#: sui_quickactions.lua:769
-msgid "default"
-msgstr ""
-
-#: sui_menu.lua:395
-#: sui_menu.lua:569
-#: sui_menu.lua:626
-#: sui_menu.lua:945
-#: sui_menu.lua:1523
-msgid "disabled"
-msgstr ""
-
-#: sui_quickactions.lua:609
-msgid "e.g. Comics…"
-msgstr ""
-
-#: sui_quickactions.lua:655
-msgid "e.g. Rakuyomi…"
-msgstr ""
-
-#: sui_quickactions.lua:628
-msgid "e.g. Sci-Fi…"
-msgstr ""
-
-#: sui_quickactions.lua:683
-msgid "e.g. Sleep, Refresh…"
-msgstr ""
-
-#: sui_menu.lua:395
-#: sui_menu.lua:569
-#: sui_menu.lua:626
-#: sui_menu.lua:945
-#: sui_menu.lua:1523
-msgid "enabled"
-msgstr ""
-
-#: sui_quickactions.lua:270
-msgid "hex code, e.g. E001"
-msgstr ""
-
-#: sui_menu.lua:307
-msgid "hidden"
-msgstr ""
-
-#: sui_quickactions.lua:921
-#: sui_quickactions.lua:937
+#: sui_quickactions.lua:1113
+#: sui_quickactions.lua:1129
 msgid "not configured"
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:62
+#: desktop_modules/module_reading_stats.lua:61
 msgid "of reading today"
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:66
+#: desktop_modules/module_reading_stats.lua:65
 msgid "of reading, all time"
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:63
+#: desktop_modules/module_reading_stats.lua:62
 msgid "pages read today"
 msgstr ""
 
-#: desktop_modules/module_reading_stats.lua:65
+#: desktop_modules/module_reading_stats.lua:64
 msgid "pages/day (7 days)"
 msgstr ""
 
-#: sui_menu.lua:307
-msgid "visible"
-msgstr ""
-
-#: desktop_modules/module_currently.lua:271
-msgid "Author"
-msgstr ""
-
-#: desktop_modules/module_currently.lua:274
-msgid "Days of reading"
-msgstr ""
-
-#: desktop_modules/module_currently.lua:275
-msgid "Time read"
-msgstr ""
-
-#: desktop_modules/module_currently.lua:276
-msgid "Time remaining"
-msgstr ""
-
-#: desktop_modules/module_currently.lua
-msgid "%s left"
-msgstr ""
-
-#: desktop_modules/module_currently.lua
-msgid "1 day"
-msgstr ""
-
-#: desktop_modules/module_currently.lua
-msgid "%d days"
-msgstr ""
-
-#: desktop_modules/module_currently.lua
-msgid "Stats layout"
-msgstr ""
-
-#: sui_menu.lua:356
-msgid "Pagination bar set to Default.\n\nRestart now?"
-msgstr ""
-
-#: sui_menu.lua:367
-msgid "Navpager enabled.\n\nRestart now?"
-msgstr ""
-
-#: sui_menu.lua:377
-msgid "Pagination bar hidden.\n\nRestart now?"
-msgstr ""
-
-#: sui_menu.lua:387
-msgid "Dot Pager"
-msgstr ""
-
-#: sui_menu.lua:395
-msgid "Shows a row of dots at the bottom of the homescreen.\nThe active page dot is filled; the others are dimmed.\nAlways active when Navpager is selected."
-msgstr ""
-
-#: sui_menu.lua:417
-msgid "Uses the standard KOReader pagination bar on the homescreen.\nNot available when Navpager is active."
-msgstr ""
-
-#: sui_menu.lua:438
-msgid "Hides the pagination bar on the homescreen.\nNot available when Navpager is active."
-msgstr ""
-
-#: sui_menu.lua:1566
-msgid "Modules per Page  (%d)"
-msgstr ""
-
-#: sui_menu.lua:1572
-msgid "Modules per Page"
-msgstr ""
-
-#: sui_menu.lua:1573
-msgid "Maximum number of modules shown on each page.\nSwipe left/right on the Home Screen to turn pages."
-msgstr ""
-
-#: sui_menu.lua:1834
-msgid "Placeholder cover for bookless folders"
-msgstr ""
-
-#: sui_menu.lua:1849
-msgid "  Scan subfolders for cover"
-msgstr ""
-
-#: sui_menu.lua
-msgid "Check for Updates"
-msgstr ""
-
-#: sui_menu.lua
-msgid "About"
-msgstr ""
-
-#: sui_menu.lua
-msgid "Version: %s"
-msgstr ""
-
-#: sui_menu.lua
-msgid "Author: %s"
-msgstr ""
-
-#: sui_homescreen.lua:407
-#: desktop_modules/module_quote.lua:950
-msgid "Open this file?"
-msgstr ""
-
-#: sui_bottombar.lua:1638
-msgid "Sleep"
-msgstr ""
-
-#: sui_updater.lua:157
-msgid "Downloading Simple UI "
-msgstr ""
-
-#: sui_updater.lua:163
-msgid "Download error: "
-msgstr ""
-
-#: sui_updater.lua:174
-msgid "Extraction error: "
-msgstr ""
-
-#: sui_updater.lua:180
-msgid "Simple UI %s successfully installed.\n\nRestart KOReader to apply the update?"
-msgstr ""
-
-#: sui_updater.lua:194
-msgid "Checking for updates..."
-msgstr ""
-
-#: sui_updater.lua:200
-msgid "Error checking for updates: "
-msgstr ""
-
-#: sui_updater.lua:216
-msgid "Could not retrieve version information."
-msgstr ""
-
-#: sui_updater.lua:222
-msgid "Simple UI is up to date (%s)."
-msgstr ""
-
-#: sui_updater.lua:233
-msgid "Simple UI %s is available (you have %s).\n\nNo automatic update file was found.\n\nOpen the releases page on GitHub?"
-msgstr ""
-
-#: sui_updater.lua:236
-msgid "Open in browser"
-msgstr ""
-
-#: sui_updater.lua:254
-msgid "Simple UI %s is available!\nCurrent version: %s\n\nDownload and install now?"
-msgstr ""
-
-#: sui_updater.lua:257
-msgid "Download and install"
-msgstr ""
-
-#: sui_menu.lua
-msgid "Return to Book Folder"
-msgstr ""
-
-#: sui_menu.lua
-msgid "When enabled, opening the file browser after finishing or closing a book navigates to the folder the book is in, matching native KOReader behaviour.\nWhen disabled (default), SimpleUI always returns to the library root."
-msgstr ""
-
-#: sui_menu.lua
-msgid "Settings on Long Tap"
-msgstr ""
-
-#: sui_menu.lua
-msgid "When enabled, long-pressing a section opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
-msgstr ""
-
-#: sui_menu.lua
-msgid "When enabled, long-pressing the top bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
-msgstr ""
-
-#: sui_menu.lua
-msgid "When enabled, long-pressing the bottom bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
-msgstr ""
-
-#: desktop_modules/module_tbr.lua
-msgid "Arrange To Be Read list"
-msgstr ""
-
-#: desktop_modules/module_tbr.lua
-msgid "Add at least 2 books to arrange."
-msgstr ""
-
-#: desktop_modules/module_tbr.lua
-msgid "To Be Read books"
-msgstr ""
-
-#: desktop_modules/module_tbr.lua
-msgid "No books in To Be Read list."
-msgstr ""
-
-#: desktop_modules/module_tbr.lua
-msgid "Add to To Be Read"
-msgstr ""
-
-#: desktop_modules/module_tbr.lua
-msgid "Remove from To Be Read"
-msgstr ""
-
-#: desktop_modules/module_tbr.lua
-msgid "To Be Read"
-msgstr ""
-
-#: sui_foldercovers.lua sui_menu.lua
-msgid "Group Books by Series"
-msgstr ""
-
-#: sui_menu.lua
-msgid "Series Index"
-msgstr ""
-
-#: sui_foldercovers.lua
-msgid "Series cover"
-msgstr ""
-
-#: sui_foldercovers.lua
-msgid "Set series cover…"
-msgstr ""
-
-#: sui_foldercovers.lua
-msgid "No books found in this series."
-msgstr ""
-
-#: sui_foldercovers.lua
-msgid "Scan subfolders for cover"
-msgstr ""
-
-#: desktop_modules/module_coverdeck.lua
-msgid "Scale for this module."
-msgstr ""
-
-#: desktop_modules/module_coverdeck.lua
-msgid "Scale for the cover thumbnails only.\n100% is the default size."
-msgstr ""
-
-#: desktop_modules/module_coverdeck.lua
-msgid "Scale for title and statistics text.\n100% is the default size."
-msgstr ""
-
-#: desktop_modules/module_coverdeck.lua
-#: sui_menu.lua
-msgid "Recent Books"
-msgstr ""
-
-#: desktop_modules/module_coverdeck.lua
-msgid "Title Position"
-msgstr ""
-
-#: desktop_modules/module_coverdeck.lua
-msgid "Above"
-msgstr ""
-
-#: desktop_modules/module_coverdeck.lua
-msgid "Below"
-msgstr ""
-
-#: desktop_modules/module_coverdeck.lua
-msgid "Arrange Statistics"
-msgstr ""
-
-#: sui_menu.lua
-msgid "Updater module not found."
-msgstr ""
-
-#: sui_menu.lua
-msgid "Recent"
-msgstr ""
-
-#: sui_menu.lua
-msgid "KOReader"
-msgstr ""
-
-#: sui_config.lua:165 sui_menu.lua:553
-msgid "Custom Text"
-msgstr ""
-
-
-#: sui_menu.lua:545 sui_menu.lua:547
-msgid "Edit Custom Text"
-msgstr ""
-
-
-#: sui_menu.lua:1953
-msgid "Folder Name Text Size"
-msgstr ""
-
-
-#: sui_menu.lua:1951
-msgid "Text size"
-msgstr ""
-
-
-#: sui_menu.lua:566
-msgid "Set"
-msgstr ""
-
-
-#: sui_menu.lua:556
-msgid "Text shown in the top bar.\nMaximum %d characters."
-msgstr ""
-
-
-#: sui_menu.lua:1954
-msgid "Scale for the folder name overlay text.\n100% is the default size."
-msgstr ""
-
-
-#: sui_config.lua:1748
-msgid "Show section label"
-msgstr ""
-
-
-#: sui_updater.lua:377
-msgid "Update cancelled."
-msgstr ""
-
-
-#: sui_updater.lua:487
-msgid "Update check cancelled."
-msgstr ""
-
-
-#: sui_updater.lua:466
-msgid "Error checking for updates."
-msgstr ""
-
-
-#: sui_updater.lua:407
-msgid "Simple UI %s is available!\nYou have %s."
-msgstr ""
-
-
-#: sui_updater.lua:410
-msgid "\n\nDownload and install now?"
-msgstr ""
-
-
-#: sui_updater.lua:412
-msgid "What's new:"
-msgstr ""
-
-
-#: sui_updater.lua:419
-msgid "No automatic update file was found.\n\nOpen the releases page on GitHub?"
-msgstr ""
-
-
-#: sui_menu.lua:1772
-msgid "When enabled, opening the file browser after finishing or closing a book navigates to the folder the book is in, matching native KOReader behaviour.\nWhen disabled (default), SimpleUI always returns to the library root.\nThis option works independently of \"Start with Home Screen\"."
-msgstr ""
-
-
-#: sui_updater.lua:460
-msgid "Checking for updates…"
-msgstr ""
-
-
-#: sui_updater.lua:323
-msgid "Downloading Simple UI %s…"
-msgstr ""
-
-
-#: sui_menu.lua:1492
-msgid "Choose how many pages the homescreen has.\nEmpty pages stay empty. Modules keep their position."
-msgstr ""
-
-
-#: sui_menu.lua:1549 sui_menu.lua:1569
-msgid "Page %d"
-msgstr ""
-
-
-#: sui_menu.lua:1580
-msgid "Cannot place modules after Page 1 separator.\nPage 1 must always have at least 1 module."
-msgstr ""
+#: desktop_modules/module_reading_goals.lua:617
+msgid "  Set Goal  (%d book in %s)"
+msgid_plural "  Set Goal  (%d books in %s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: desktop_modules/module_reading_goals.lua:417
+msgid "%d book"
+msgid_plural "%d books"
+msgstr[0] ""
+msgstr[1] ""
+
+#: desktop_modules/module_coverdeck.lua:574
+#: desktop_modules/module_currently.lua:540
+#: desktop_modules/module_currently.lua:607
+msgid "%d day of reading"
+msgid_plural "%d days of reading"
+msgstr[0] ""
+msgstr[1] ""
+
+#: desktop_modules/module_reading_goals.lua:416
+msgid "%d/%d book"
+msgid_plural "%d/%d books"
+msgstr[0] ""
+msgstr[1] ""
+
+#: sui_menu.lua:1231
+msgid "Digital: %d book in %s"
+msgid_plural "Digital: %d books in %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: sui_menu.lua:1237
+msgid "Physical: %d book in %s"
+msgid_plural "Physical: %d books in %s"
+msgstr[0] ""
+msgstr[1] ""
+
+#: sui_menu.lua:1301
+#: desktop_modules/module_quick_actions.lua:262
+msgid "The maximum of %d action per module has been reached. Remove one first."
+msgid_plural "The maximum of %d actions per module has been reached. Remove one first."
+msgstr[0] ""
+msgstr[1] ""
+
+#: sui_quickactions.lua:1074
+msgid "The maximum of %d quick action has been reached. Delete one first."
+msgid_plural "The maximum of %d quick actions has been reached. Delete one first."
+msgstr[0] ""
+msgstr[1] ""
+
+#: desktop_modules/module_reading_stats.lua:419
+msgid "The maximum of %d stat per row has been reached. Remove one first."
+msgid_plural "The maximum of %d stats per row has been reached. Remove one first."
+msgstr[0] ""
+msgstr[1] ""
+
+#: sui_menu.lua:272
+msgid "The maximum of %d tab has been reached. Remove one first."
+msgid_plural "The maximum of %d tabs has been reached. Remove one first."
+msgstr[0] ""
+msgstr[1] ""

--- a/sui_homescreen.lua
+++ b/sui_homescreen.lua
@@ -1669,7 +1669,7 @@ function HomescreenWidget:_onHoldModRelease(wrapper)
     local Topbar   = require("sui_topbar")
     local topbar_h = G_reader_settings:nilOrTrue("navbar_topbar_enabled")
                      and Topbar.TOTAL_TOP_H() or 0
-    local _tr = _
+    local _lc = _
     UI.showSettingsMenu(
         mod.name or mod.id,
         function()
@@ -1678,10 +1678,10 @@ function HomescreenWidget:_onHoldModRelease(wrapper)
             local gap_item = Config.makeGapItem({
                 text_func = function()
                     local pct = Config.getModuleGapPct(mod.id, PFX)
-                    return string.format(_tr("Top Margin  (%d%%)"), pct)
+                    return string.format(_lc("Top Margin  (%d%%)"), pct)
                 end,
                 title   = mod.name or mod.id,
-                info    = _tr("Vertical space above this module.\n100% is the default spacing."),
+                info    = _lc("Vertical space above this module.\n100% is the default spacing."),
                 get     = function() return Config.getModuleGapPct(mod.id, PFX) end,
                 set     = function(v) Config.setModuleGap(v, mod.id, PFX) end,
                 refresh = ctx_menu.refresh,

--- a/sui_menu.lua
+++ b/sui_menu.lua
@@ -9,6 +9,7 @@ local Screen    = Device.screen
 local lfs       = require("libs/libkoreader-lfs")
 local logger    = require("logger")
 local _         = require("gettext")
+local N_        = _.ngettext
 
 -- Heavy UI widgets — lazy-loaded on first use so that require("menu") at boot
 -- does not pull them into memory before the user ever opens the settings menu.
@@ -268,7 +269,8 @@ SimpleUIPlugin.addToMainMenu = function(self, menu_items)
                     else
                         if #tabs >= limit then
                             UIManager:show(InfoMessage():new{
-                                text = string.format(_("Maximum %d tabs reached. Remove one first."), limit), timeout = 2,
+                                text = string.format(N_("The maximum of %d tab has been reached. Remove one first.",
+                                       "The maximum of %d tabs has been reached. Remove one first.", limit), limit), timeout = 2,
                             })
                             return
                         end
@@ -1226,13 +1228,13 @@ SimpleUIPlugin.addToMainMenu = function(self, menu_items)
         local ButtonDialog = require("ui/widget/buttondialog")
         local dlg
         dlg = ButtonDialog:new{ title = _("Annual Reading Goal"), buttons = {
-            {{ text = goal > 0 and string.format(_("Digital: %d books in %s"), goal, os.date("%Y")) or string.format(_("Digital Goal  (%s)"), os.date("%Y")),
+            {{ text = goal > 0 and string.format(N_("Digital: %d book in %s", "Digital: %d books in %s", goal), goal, os.date("%Y")) or string.format(_("Digital Goal  (%s)"), os.date("%Y")),
                callback = function()
                    UIManager:close(dlg)
                    local ok_rg, RG = pcall(require, "readinggoals")
                    if ok_rg and RG then RG.showAnnualGoalDialog(function() refreshHomescreen() end) end
                end }},
-            {{ text = string.format(_("Physical: %d books in %s"), physical, os.date("%Y")),
+            {{ text = string.format(N_("Physical: %d book in %s", "Physical: %d books in %s", physical), physical, os.date("%Y")),
                callback = function()
                    UIManager:close(dlg)
                    local ok_rg, RG = pcall(require, "readinggoals")
@@ -1296,7 +1298,8 @@ SimpleUIPlugin.addToMainMenu = function(self, menu_items)
             for _i, v in ipairs(items) do if v == id then found = true else new_items[#new_items+1] = v end end
             if not found then
                 if #items >= MAX_QA_ITEMS then
-                    UIManager:show(InfoMessage():new{ text = string.format(_("Maximum %d actions per module reached. Remove one first."), MAX_QA_ITEMS), timeout = 2 })
+                    UIManager:show(InfoMessage():new{ text = string.format(N_("The maximum of %d action per module has been reached. Remove one first.",
+                              "The maximum of %d actions per module has been reached. Remove one first.", MAX_QA_ITEMS), MAX_QA_ITEMS), timeout = 2 })
                     return
                 end
                 new_items[#new_items+1] = id

--- a/sui_quickactions.lua
+++ b/sui_quickactions.lua
@@ -15,6 +15,7 @@ local Screen    = Device.screen
 local lfs       = require("libs/libkoreader-lfs")
 local logger    = require("logger")
 local _         = require("gettext")
+local N_        = _.ngettext
 
 local Config    = require("sui_config")
 
@@ -1070,7 +1071,8 @@ function QA.makeMenuItems(plugin)
         callback     = function(_menu_self, suppress_refresh)
             if #Config.getCustomQAList() >= MAX_CUSTOM_QA then
                 UIManager:show(InfoMessage:new{
-                    text    = string.format(_("Maximum %d quick actions reached. Delete one first."), MAX_CUSTOM_QA),
+                    text    = string.format(N_("The maximum of %d quick action has been reached. Delete one first.",
+                              "The maximum of %d quick actions has been reached. Delete one first.", MAX_CUSTOM_QA), MAX_CUSTOM_QA),
                     timeout = 2,
                 })
                 return


### PR DESCRIPTION
Part 2 fix for #187

Convert existing fake-plural strings to real plural strings. Total: 10 strings.

Define the following helpers where needed:

```lua
local N_ = _.ngettext
local N_lc = _lc.ngettext
```

Regenerate po template.