### PR TITLE
Update spanish language and reorder strings

### DIFF
--- a/locale/es.po
+++ b/locale/es.po
@@ -17,213 +17,565 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: sui_menu.lua:347
+msgid "General"
+msgstr "General"
 
+#: sui_menu.lua:320
+msgid "    Size"
+msgstr "    Tamaño"
+
+#: desktop_modules/module_reading_goals.lua:602
 msgid "  Physical Books  (%d in %s)"
 msgstr "  Libros físicos  (%d en %s)"
 
+#: desktop_modules/module_reading_goals.lua:595
 msgid "  Set Goal  (%d books in %s)"
 msgstr "  Establecer objetivo  (%d libros en %s)"
 
+#: desktop_modules/module_reading_goals.lua:617
 msgid "  Set Goal  (%d min/day)"
 msgstr "  Establecer objetivo  (%d min/día)"
 
+#: desktop_modules/module_reading_goals.lua:596
 msgid "  Set Goal  (%s)"
 msgstr "  Establecer objetivo  (%s)"
 
+#: desktop_modules/module_reading_goals.lua:616
 msgid "  Set Goal  (disabled)"
 msgstr "  Establecer objetivo  (desactivado)"
 
+#: desktop_modules/module_reading_goals.lua:429
 msgid "%d books"
 msgstr "%d libros"
 
+#: desktop_modules/module_currently.lua:336
+msgid "%d days of reading"
+msgstr "%d días leyendo"
+
+#: desktop_modules/module_recent.lua:123
+msgid "%d%%"
+msgstr "%d%%"
+
+#: desktop_modules/module_currently.lua:309
+#: desktop_modules/module_new_books.lua:141
+#: desktop_modules/module_recent.lua:157
 msgid "%d%% Read"
 msgstr "%d%% leído"
 
+#: desktop_modules/module_reading_goals.lua:428
 msgid "%d/%d books"
 msgstr "%d/%d libros"
 
 msgid "%s TO GO"
 msgstr "Ir a %s"
 
+#: desktop_modules/module_currently.lua:347
+#: desktop_modules/module_reading_goals.lua:445
 msgid "%s read"
 msgstr "%s leído"
 
+#: desktop_modules/module_currently.lua:370
+msgid "%s remaining"
+msgstr "%s restante"
+
+#: desktop_modules/module_currently.lua:335
+msgid "1 day of reading"
+msgstr "1 día de lectura"
+
+#: sui_menu.lua:1122
 msgid "Add at least 2 actions to arrange."
 msgstr "Añade al menos 2 acciones para organizar."
 
+#: desktop_modules/module_reading_stats.lua:546
 msgid "Add at least 2 stats to arrange."
 msgstr "Añade al menos 2 estadísticas para organizar."
 
+#: desktop_modules/module_reading_stats.lua:67
 msgid "All time — Books"
 msgstr "Total — Libros"
 
+#: desktop_modules/module_reading_stats.lua:66
 msgid "All time — Time"
 msgstr "Total — Tiempo"
 
+#: desktop_modules/module_reading_goals.lua:585
 msgid "Annual Goal"
 msgstr "Objetivo anual"
 
+#: desktop_modules/module_reading_goals.lua:362
 msgid "Annual Reading Goal"
 msgstr "Objetivo anual de lectura"
 
+#: sui_config.lua:1562
+#: sui_config.lua:1643
+#: sui_menu.lua:593
+#: sui_menu.lua:651
+#: sui_menu.lua:1364
+#: sui_menu.lua:1399
+msgid "Apply"
+msgstr "Aplicar"
+
+#: desktop_modules/module_clock.lua:49
+msgid "April"
+msgstr "Abril"
+
+#: sui_menu.lua:1120
+#: desktop_modules/module_reading_stats.lua:543
 msgid "Arrange"
 msgstr "Organizar"
 
+#: sui_menu.lua:1126
 msgid "Arrange %s"
 msgstr "Organizar %s"
 
+#: sui_menu.lua:840
+#: sui_menu.lua:891
+#: sui_menu.lua:906
+msgid "Arrange Buttons"
+msgstr "Reorganizar botones"
+
+#: desktop_modules/module_collections.lua:535
+#: desktop_modules/module_collections.lua:548
 msgid "Arrange Collections"
 msgstr "Organizar colecciones"
 
+#: sui_menu.lua:483
+#: sui_menu.lua:511
 msgid "Arrange Items"
 msgstr "Organizar elementos"
 
+#: sui_menu.lua:1280
+#: sui_menu.lua:1296
 msgid "Arrange Modules"
 msgstr "Organizar módulos"
 
+#: desktop_modules/module_reading_stats.lua:552
 msgid "Arrange Reading Stats"
 msgstr "Organizar estadísticas de lectura"
 
+#: sui_menu.lua:193
+#: sui_menu.lua:203
 msgid "Arrange tabs"
 msgstr "Organizar pestañas"
 
+#: desktop_modules/module_clock.lua:50
+msgid "August"
+msgstr "Agosto"
+
+#: sui_foldercovers.lua:405
+#: desktop_modules/module_collections.lua:497
 msgid "Auto (first book)"
 msgstr "Auto (primer libro)"
 
+#: sui_titlebar.lua:54
+msgid "Back"
+msgstr "Atrás"
+
+#: desktop_modules/module_collections.lua:575
+msgid "Badge position: Bottom"
+msgstr "Posición del indicador: Abajo"
+
+#: desktop_modules/module_collections.lua:576
+msgid "Badge position: Top"
+msgstr "Posición del indicador: Arriba"
+
+#: sui_config.lua:143
 msgid "Battery"
 msgstr "Batería"
 
+#: sui_quickactions.lua:404
 msgid "Book Info"
 msgstr "Información del libro"
 
+#: sui_bottombar.lua:886
+msgid "Bookmark browser"
+msgstr "Explorador de marcadores"
+
+#: sui_bottombar.lua:859
+msgid "Bookmark browser not available."
+msgstr "Explorador de marcadores no disponible."
+
+#: sui_config.lua:118
+msgid "Bookmarks"
+msgstr "Marcadores"
+
+#: desktop_modules/module_reading_goals.lua:363
 msgid "Books to read in %s:"
 msgstr "Libros para leer en %s:"
 
+#: sui_menu.lua:1545
+#: sui_menu.lua:1624
+#: sui_menu.lua:1680
+msgid "Bottom"
+msgstr "Abajo"
+
+#: sui_bottombar.lua:736
+#: sui_menu.lua:618
 msgid "Bottom Bar"
 msgstr "Barra inferior"
 
+#: sui_menu.lua:644
+msgid "Bottom Bar Size"
+msgstr "Tamaño de la barra inferior"
+
+#: sui_menu.lua
+msgid "A restart is required to apply the new bar size across all layouts.\n\nRestart now?"
+msgstr "Es necesario reiniciar para aplicar el nuevo tamaño de la barra inferior en todos los diseños.\n\n¿Reiniciar ahora?"
+
+#: sui_menu.lua:626
 msgid "Bottom Bar will be %s after restart.\n\nRestart now?"
 msgstr "La barra inferior será %s después de reiniciar.\n\n¿Reiniciar ahora?"
 
+#: sui_menu.lua:668
+#: sui_menu.lua:671
+msgid "Bottom Margin"
+msgstr "Margen Inferior"
+
+#: sui_menu.lua:669
+msgid "Bottom Margin — %d%%"
+msgstr "Margen Inferior — %d%%"
+
+#: sui_homescreen.lua:701
+msgid "Top Margin  (%d%%)"
+msgstr "Margen Superior  (%d%%)"
+
+#: sui_homescreen.lua:704
+msgid "Vertical space above this module.\n100% is the default spacing."
+msgstr "Espacio vertical sobre este módulo.\n100% es el espacio predeterminado."
+
+#: sui_config.lua:120
+#: sui_config.lua:142
 msgid "Brightness"
 msgstr "Brillo"
 
+#: sui_menu.lua:956
+msgid "Button Size"
+msgstr "Tamaño de botón"
+
+#: sui_bottombar.lua:911
+#: sui_bottombar.lua:1428
+#: sui_config.lua:1563
+#: sui_config.lua:1644
+#: sui_foldercovers.lua:431
+#: sui_menu.lua:594
+#: sui_menu.lua:652
+#: sui_menu.lua:1365
+#: sui_menu.lua:1400
+#: sui_quickactions.lua:188
+#: sui_quickactions.lua:279
+#: sui_quickactions.lua:387
+#: sui_quickactions.lua:565
+#: sui_quickactions.lua:636
+#: sui_quickactions.lua:664
+#: sui_quickactions.lua:692
+#: sui_quickactions.lua:708
+#: sui_quickactions.lua:820
+#: sui_quickactions.lua:961
+#: desktop_modules/module_collections.lua:523
+#: desktop_modules/module_quote.lua:892
+#: desktop_modules/module_reading_goals.lua:366
+#: desktop_modules/module_reading_goals.lua:383
+#: desktop_modules/module_reading_goals.lua:401
+#: sui_updater.lua:184
+#: sui_updater.lua:237
+#: sui_updater.lua:258
 msgid "Cancel"
 msgstr "Cancelar"
 
+#: desktop_modules/module_reading_stats.lua:494
+msgid "Cards"
+msgstr "Tarjetas"
+
+#: sui_menu.lua:498
+#: sui_menu.lua:1672
+msgid "Center"
+msgstr "Centro"
+
+#: sui_quickactions.lua:869
+msgid "Change Icons"
+msgstr "Cambiar Iconos"
+
+#: sui_config.lua:140
+#: desktop_modules/module_clock.lua:211
 msgid "Clock"
 msgstr "Reloj"
 
+#: sui_titlebar.lua:59
+msgid "Close"
+msgstr "Cerrar"
+
+#: sui_quickactions.lua:312
+msgid "Codepoint out of valid Unicode range (0–10FFFF)."
+msgstr "Punto de código fuera del rango válido de Unicode (0–10FFFF)."
+
+#: sui_quickactions.lua:702
 msgid "Collection"
 msgstr "Colección"
 
+#: desktop_modules/module_collections.lua:484
+#: desktop_modules/module_collections.lua:490
 msgid "Collection is empty."
 msgstr "Colección vacía."
 
+#: sui_quickactions.lua:1029
 msgid "Collection not available: %s"
 msgstr "Colección no disponible: %s"
 
+#: sui_bottombar.lua:897
+#: sui_config.lua:114
+#: sui_quickactions.lua:406
+#: desktop_modules/module_collections.lua:290
+#: desktop_modules/module_collections.lua:291
 msgid "Collections"
 msgstr "Colecciones"
 
+#: sui_bottombar.lua:1121
 msgid "Collections not available."
 msgstr "Colecciones no disponibles."
 
+#: sui_menu.lua:960
+#: desktop_modules/module_reading_goals.lua:573
 msgid "Compact"
 msgstr "Compacto"
 
+#: sui_quickactions.lua:197
+msgid "Confirm"
+msgstr "Confirmar"
+
+#: sui_config.lua:116
 msgid "Continue"
 msgstr "Continuar"
 
+#: desktop_modules/module_collections.lua:527
+msgid "Cover for \"%s\""
+msgstr "Portada de \"%s\""
+
+#: desktop_modules/module_collections.lua:564
+#: desktop_modules/module_collections.lua:566
+#: desktop_modules/module_currently.lua:447
+#: desktop_modules/module_currently.lua:449
+#: desktop_modules/module_new_books.lua:218
+#: desktop_modules/module_new_books.lua:220
+#: desktop_modules/module_recent.lua:239
+#: desktop_modules/module_recent.lua:241
+msgid "Cover size"
+msgstr "Tamaño de portada"
+
+#: sui_quickactions.lua:878
 msgid "Create Quick Action"
 msgstr "Crear acción"
 
+#: desktop_modules/module_currently.lua:232
+#: desktop_modules/module_currently.lua:233
 msgid "Currently Reading"
 msgstr "Leyendo"
 
+#: sui_config.lua:637
 msgid "Custom"
 msgstr "Personalizar"
+
+#: sui_menu.lua:933
+msgid "Custom Title Bar"
+msgstr "Barra de título personalizada"
+
+#: sui_menu.lua:944
+msgid "Custom Title Bar will be %s after restart.\n\nRestart now?"
+msgstr "La barra de título personalizada será %s después de reiniciar.\n\n¿Reiniciar ahora?"
 
 msgid "Custom Text"
 msgstr "Personalizar texto"
 
+#: desktop_modules/module_reading_goals.lua:606
 msgid "Daily Goal"
 msgstr "Objetivo diario"
 
+#: desktop_modules/module_reading_goals.lua:398
 msgid "Daily Reading Goal"
 msgstr "Objetivo de lectura al día"
 
+#: desktop_modules/module_reading_stats.lua:65
 msgid "Daily avg — Pages"
 msgstr "Promedio diario — Páginas"
 
+#: desktop_modules/module_reading_stats.lua:64
 msgid "Daily avg — Time"
 msgstr "Promedio diario — Tiempo"
+
+#: desktop_modules/module_clock.lua:51
+msgid "December"
+msgstr "Diciembre"
 
 msgid "Date"
 msgstr "Fecha"
 
+#: sui_menu.lua:297
+#: sui_menu.lua:326
+#: sui_menu.lua:961
+#: sui_quickactions.lua:347
+#: desktop_modules/module_quick_actions.lua:266
+#: desktop_modules/module_quick_actions.lua:271
+#: desktop_modules/module_reading_goals.lua:565
 msgid "Default"
 msgstr "Predeterminado"
 
+#: sui_quickactions.lua:610
+#: sui_quickactions.lua:629
 msgid "Default (Folder)"
 msgstr "Predeterminado (Carpeta)"
 
+#: sui_quickactions.lua:656
 msgid "Default (Plugin)"
 msgstr "Predeterminado (Complemento)"
 
+#: sui_quickactions.lua:684
 msgid "Default (System)"
 msgstr "Predeterminado (Sistema)"
 
+#: desktop_modules/module_quote.lua:976
+msgid "Default Quotes"
+msgstr "Citas Predeterminadas"
+
+#: sui_quickactions.lua:955
+#: sui_quickactions.lua:960
 msgid "Delete"
 msgstr "Eliminar"
 
+#: sui_quickactions.lua:959
+msgid "Delete quick action \"%s\"?"
+msgstr "¿Eliminar la acción rápida \"%s\"?"
+
+#: sui_quickactions.lua:409
 msgid "Dictionary Lookup"
 msgstr "Buscar en el diccionario"
 
+#: sui_menu.lua:1025
 msgid "Digital Goal  (%s)"
 msgstr "Objetivo digital  (%s)"
 
+#: sui_menu.lua:1025
 msgid "Digital: %d books in %s"
 msgstr "Digital: %d libros en %s"
 
+#: sui_menu.lua:1384
+msgid "Disable \"Lock Scale\" first to set a custom label scale."
+msgstr "Desactiva \"Escala bloqueada\" primero para establecer una escala de etiqueta personalizada."
+
+#: sui_config.lua:1547
+msgid "Disable \"Lock Scale\" first to set a per-module scale."
+msgstr "Desactiva \"Escala bloqueada\" primero para establecer una escala por módulo."
+
+#: sui_config.lua:144
 msgid "Disk Usage"
 msgstr "Uso del disco"
 
+#: sui_quickactions.lua:1014
 msgid "Dispatcher not available."
 msgstr "Servicio no disponible."
 
+#: sui_quickactions.lua:945
 msgid "Edit"
 msgstr "Editar"
 
+#: sui_quickactions.lua:511
 msgid "Edit Quick Action"
 msgstr "Editar acción"
 
+#: sui_menu.lua:1292
 msgid "Enable at least 2 modules to arrange."
 msgstr "Habilite al menos 2 módulos para organizar."
 
+#: sui_quickactions.lua:271
+msgid "Enter the Unicode codepoint (hex) of a Nerd Fonts symbol.\nYou can look up codes with wakamaifondue.com using the file:\n  /koreader/fonts/nerdfonts/symbols.ttf\nLeave blank and press OK to remove a Nerd Font icon."
+msgstr "Introduzca el punto de código Unicode (hex) de un símbolo de Nerd Fonts.\nPuede buscar códigos con wakamaifondue.com usando el archivo:\n  /koreader/fonts/nerdfonts/symbols.ttf\nDeje en blanco y presione OK para eliminar un ícono de Nerd Font."
+
+#: sui_menu.lua:324
 msgid "Extra Small"
 msgstr "Muy pequeño"
 
+#: sui_config.lua:117
+#: sui_quickactions.lua:405
 msgid "Favorites"
 msgstr "Favoritos"
 
+#: sui_bottombar.lua:1149
 msgid "Favorites not available."
 msgstr "Favoritos no disponibles."
 
+#: desktop_modules/module_clock.lua:49
+msgid "February"
+msgstr "Febrero"
+
+#: sui_bottombar.lua:867
+msgid "Fetching bookmarks\xe2\x80\xa6"
+msgstr "Recuperando marcadores\xe2\x80\xa6"
+
+#: sui_quickactions.lua:407
 msgid "File Search"
 msgstr "Búsqueda de archivos"
 
+#: desktop_modules/module_quick_actions.lua:266
+#: desktop_modules/module_quick_actions.lua:280
+#: desktop_modules/module_reading_stats.lua:504
+msgid "Flat"
+msgstr "Plano"
+
+#: sui_quickactions.lua:700
 msgid "Folder"
 msgstr "Carpeta"
 
+#: sui_menu.lua:1578
+msgid "Folder Covers"
+msgstr "Portadas de Carpetas"
+
+#: sui_menu.lua:1640
+msgid "Folder Name"
+msgstr "Nombre de la Carpeta"
+
+#: sui_quickactions.lua:408
 msgid "Folder Shortcuts"
-msgstr "Accesos directos"
+msgstr "Accesos Directos"
+
+#: sui_foldercovers.lua:436
+msgid "Folder cover"
+msgstr "Portada de carpeta"
 
 msgid "Folder not found:\n%s"
 msgstr "Carpeta no encontrada:\n%s"
 
+#: desktop_modules/module_clock.lua:46
+msgid "Friday"
+msgstr "Viernes"
+
+#: sui_bottombar.lua:1253
 msgid "Frontlight not available on this device."
 msgstr "La luz frontal no está disponible en este dispositivo."
+
+#: sui_menu.lua:1358
+msgid "Global scale for all modules.\nIndividual overrides in Module Settings take precedence.\n100% is the default size."
+msgstr "Escala global para todos los módulos.\nLas configuraciones individuales en Ajustes de módulo tienen prioridad.\n100% es el tamaño predeterminado."
+
+#: sui_menu.lua:645
+msgid "Height of the bottom navigation bar.\n100% is the default size."
+msgstr "Altura de la barra de navegación inferior.\n100% es el tamaño predeterminado."
+
+#: sui_menu.lua:587
+msgid "Height of the top status bar.\n100% is the default size."
+msgstr "Altura de la barra de estado superior.\n100% es el tamaño predeterminado."
+
+#: sui_menu.lua:728
+#: sui_menu.lua:1605
+#: sui_menu.lua:1643
+msgid "Hidden"
+msgstr "Oculto"
+
+#: sui_menu.lua:1132
+msgid "Hide Text"
+msgstr "Ocultar Texto"
+
+#: sui_menu.lua:1702
+msgid "Hide selection underline"
+msgstr "Ocultar el subrayado de selección"
 
 msgid "Header"
 msgstr "Encabezado"
@@ -231,329 +583,985 @@ msgstr "Encabezado"
 msgid "Header Text"
 msgstr "Texto del encabezado"
 
+#: sui_bottombar.lua:890
+#: sui_config.lua:115
+#: sui_quickactions.lua:403
 msgid "History"
 msgstr "Historial"
 
+#: sui_bottombar.lua:1125
 msgid "History not available."
 msgstr "Historial no disponible."
 
+#: sui_config.lua:113
 msgid "Home"
 msgstr "Inicio"
 
+#: sui_menu.lua:1449
+#: sui_menu.lua:1543
+#: sui_patches.lua:289
+#: sui_patches.lua:293
+#: sui_patches.lua:306
 msgid "Home Screen"
 msgstr "Pantalla de inicio"
 
+#: sui_bottombar.lua:907
+msgid "Home folder"
+msgstr "Carpeta de inicio"
+
+#: sui_bottombar.lua:909
+msgid "Home folder + subfolders"
+msgstr "Carpeta de inicio + subcarpetas"
+
+#: sui_homescreen.lua:446
 msgid "Homescreen"
 msgstr "Pantalla de inicio"
 
+#: sui_bottombar.lua:1144
 msgid "Homescreen not available."
 msgstr "Pantalla de inicio no disponible."
 
+#: sui_quickactions.lua:520
+#: sui_quickactions.lua:524
 msgid "Icon"
 msgstr "Icono"
 
+#: sui_menu.lua:690
+#: sui_menu.lua:693
+msgid "Icon Size"
+msgstr "Tamaño del icono"
+
+#: sui_menu.lua:691
+msgid "Icon Size — %d%%"
+msgstr "Tamaño del icono  —  %d%%"
+
+#: sui_quickactions.lua:515
 msgid "Icon: Default"
 msgstr "Icono: Predeterminado"
 
+#: sui_menu.lua:101
 msgid "Icons"
 msgstr "Iconos"
 
+#: sui_menu.lua:102
 msgid "Icons only"
 msgstr "Solo iconos"
 
+#: sui_menu.lua:853
 msgid "Invalid arrangement.\nKeep items between the Left and Right separators."
 msgstr "Organización inválida.\nMantén los elementos dentro de los separadores Izquierda y Derecha."
 
+#: sui_menu.lua:525
+msgid "Invalid arrangement.\nKeep the Left, Center and Right separators in order."
+msgstr "Organización inválida.\nMantén los separadores Izquierda, Centro y Derecha en orden."
+
+#: sui_quickactions.lua:318
+msgid "Invalid input. Please enter 1–6 hexadecimal digits (0–9, A–F)."
+msgstr "Entrada inválida. Por favor, ingrese 1–6 dígitos hexadecimales (0–9, A–F)."
+
+#: desktop_modules/module_currently.lua:671
+#: sui_menu.lua:606
 msgid "Items"
 msgstr "Elementos"
 
+#: desktop_modules/module_clock.lua:49
+msgid "January"
+msgstr "Enero"
+
+#: desktop_modules/module_clock.lua:50
+msgid "July"
+msgstr "Julio"
+
+#: desktop_modules/module_clock.lua:50
+msgid "June"
+msgstr "Junio"
+
+#: sui_menu.lua:1392
+msgid "Label Scale"
+msgstr "Escala de etiquetas"
+
+#: sui_menu.lua:710
+#: sui_menu.lua:713
+msgid "Label Size"
+msgstr "Tamaño de etiquetas"
+
+#: sui_menu.lua:711
+msgid "Label Size — %d%%"
+msgstr "Tamaño de etiquetas — %d%%"
+
+#: sui_menu.lua:1377
+msgid "Labels"
+msgstr "Etiquetas"
+
+#: sui_menu.lua:962
 msgid "Large"
 msgstr "Grande"
 
+#: sui_menu.lua:310
+#: sui_menu.lua:340
+#: sui_menu.lua:398
+#: sui_menu.lua:570
+#: sui_menu.lua:627
+#: sui_menu.lua:948
+#: sui_menu.lua:1524
+#: sui_updater.lua:184
 msgid "Later"
 msgstr "Más tarde"
 
+#: sui_menu.lua:492
+#: sui_menu.lua:823
 msgid "Left"
 msgstr "Izquierda"
 
+#: sui_config.lua:112
+#: sui_config.lua:485
+#: sui_menu.lua:1564
+#: sui_titlebar.lua:568
 msgid "Library"
 msgstr "Biblioteca"
 
+#: sui_menu.lua:966
+msgid "Library Buttons"
+msgstr "Botones de Biblioteca"
+
+#: desktop_modules/module_reading_stats.lua:514
+msgid "List"
+msgstr "Lista"
+
+#: sui_menu.lua:1338
+msgid "Lock Scale"
+msgstr "Bloquear Escala"
+
+#: desktop_modules/module_clock.lua:49
+msgid "March"
+msgstr "Marzo"
+
+#: sui_menu.lua:1095
 msgid "Maximum %d actions per module reached. Remove one first."
 msgstr "Máximo %d acciones por módulo. Elimine una primero."
 
+#: sui_menu.lua:1152
 msgid "Maximum %d modules active. Disable one first."
 msgstr "Máximo %d módulos activos. Deshabilite uno primero."
 
+#: sui_quickactions.lua:883
 msgid "Maximum %d quick actions reached. Delete one first."
 msgstr "Máximo %d acciones rápidas permitidas. Elimine una primero."
 
+#: desktop_modules/module_reading_stats.lua:481
 msgid "Maximum %d stats per row. Remove one first."
 msgstr "Máximo %d estatísticas por fila. Elimine una primero."
 
+#: sui_menu.lua:270
 msgid "Maximum %d tabs reached. Remove one first."
 msgstr "Máximo %d pestañas permitidas. Elimine una primero."
 
+#: desktop_modules/module_collections.lua:616
 msgid "Maximum 5 collections. Remove one first."
 msgstr "Máximo de 5 colecciones. Elimine una primero."
 
+#: desktop_modules/module_clock.lua:50
+msgid "May"
+msgstr "Mayo"
+
+#: sui_titlebar.lua:53
+#: sui_titlebar.lua:58
+msgid "Menu"
+msgstr "Menú"
+
+#: sui_menu.lua:260
+msgid "Minimum 1 tab required in navpager mode."
+msgstr "Se necesita un mínimo de 1 pestaña en modo navegador de páginas."
+
+#: sui_menu.lua:261
 msgid "Minimum 2 tabs required. Select another tab first."
 msgstr "Mínimo de 2 pestañas requeridas. Seleccione otra pestaña más."
 
+#: desktop_modules/module_reading_goals.lua:399
 msgid "Minutes per day:"
 msgstr "Minutos por día:"
 
+#: sui_menu.lua:1355
+msgid "Module Scale"
+msgstr "Escala de módulo"
+
+#: sui_menu.lua:1314
 msgid "Module Settings"
 msgstr "Configuración del módulo"
 
+#: sui_menu.lua:1326
 msgid "Module limit disabled. Enabling too many modules may slow down the homescreen significantly and modules may be clipped at the bottom of the page."
 msgstr "Límite de módulos desactivado. Habilitar demasiados módulos puede ralentizar significativamente la pantalla de inicio y los módulos pueden recortarse en la parte inferior de la página."
 
+#: sui_menu.lua:1349
+msgid "Modules"
+msgstr "Módulos"
+
+#: sui_menu.lua:1271
 msgid "Modules  (%d — no limit)"
 msgstr "Módulos  (%d — sin límite)"
 
+#: sui_menu.lua:1385
+msgid "Modules  (%d)"
+msgstr "Módulos  (%d)"
+
+#: sui_menu.lua:1275
 msgid "Modules  (%d/%d — %d left)"
 msgstr "Módulos  (%d/%d — %d restantes)"
 
+#: sui_menu.lua:1274
 msgid "Modules  (%d/%d — at limit)"
 msgstr "Módulos  (%d/%d — en el límite)"
 
+#: desktop_modules/module_clock.lua:45
+msgid "Monday"
+msgstr "Lunes"
+
+#: desktop_modules/module_quote.lua:996
+msgid "My Highlights"
+msgstr "Mis Subrayados"
+
+#: sui_quickactions.lua:609
+#: sui_quickactions.lua:628
+#: sui_quickactions.lua:655
+#: sui_quickactions.lua:683
 msgid "Name"
 msgstr "Nombre"
 
+#: sui_menu.lua:1547
+msgid "Navigation Bar"
+msgstr "Barra de navegación"
+
+#: sui_menu.lua:375
+msgid "Navpager"
+msgstr "Navegador de páginas"
+
+#: sui_menu.lua:397
+msgid "Navpager will be %s after restart.\n\nRestart now?"
+msgstr "El navegador de páginas será %s después de reiniciar.\n\n¿Reiniciar ahora?"
+
+#: sui_quickactions.lua:268
+msgid "Nerd Font Icon"
+msgstr "Icono de Nerd Font"
+
+#: sui_quickactions.lua:358
+msgid "Nerd Font symbol…"
+msgstr "Símbolo de Nerd Font…"
+
+#: sui_bottombar.lua:1213
 msgid "Network manager unavailable."
 msgstr "Administrador de red no disponible."
 
+#: desktop_modules/module_new_books.lua:139
+msgid "New"
+msgstr "Nuevo"
+
+#: desktop_modules/module_new_books.lua:46
+#: desktop_modules/module_new_books.lua:47
+msgid "New Books"
+msgstr "Libros Nuevos"
+
+#: sui_quickactions.lua:511
 msgid "New Quick Action"
 msgstr "Nueva acción"
 
+#: sui_quickactions.lua:817
+msgid "New name…"
+msgstr "Nuevo nombre…"
+
+#: sui_bottombar.lua:245
+msgid "Next"
+msgstr "Siguiente"
+
+#: sui_menu.lua:1318
 msgid "No Module Limit  ⚠ not recommended"
 msgstr "Sin límite de módulos  ⚠ no recomendado"
 
+#: sui_bottombar.lua:1171
 msgid "No book in history."
-msgstr "No hay libro alguno en el historial."
+msgstr "Ningún libro en el historial."
 
+#: sui_foldercovers.lua:394
+msgid "No books found in this folder."
+msgstr "No se encontraron libros en esta carpeta."
+
+#: sui_homescreen.lua:116
 msgid "No books opened yet"
 msgstr "Aún no se han abierto libros"
 
+#: desktop_modules/module_collections.lua:586
 msgid "No collections found."
 msgstr "No se encontraron colecciones."
 
+#: desktop_modules/module_collections.lua:322
 msgid "No collections selected"
 msgstr "No hay colecciones seleccionadas"
 
+#: sui_quickactions.lua:1036
 msgid "No folder, collection or plugin configured.\nGo to Simple UI → Settings → Quick Actions to set one."
 msgstr "No se encontró carpeta, colección o complemento configurado.\nVe a Simple UI → Configuración → Acciones rápidas y configura uno."
 
+#: desktop_modules/module_quote.lua:699
+msgid "No highlights found. Open a book and highlight some passages."
+msgstr "No se encontraron resaltados. Abre un libro y resalta algunos pasajes."
+
+#: sui_quickactions.lua:371
 msgid "No icons found in:"
 msgstr "No se encontraron íconos en:"
 
+#: sui_quickactions.lua:645
 msgid "No plugins found."
 msgstr "No se encontraron complementos."
 
+#: desktop_modules/module_quote.lua:665
 msgid "No quotes found."
 msgstr "No se encontraron citas."
 
+#: desktop_modules/module_reading_stats.lua:367
 msgid "No stats selected"
 msgstr "No se seleccionaron estadísticas "
 
+#: sui_quickactions.lua:673
 msgid "No system actions found."
 msgstr "No se encontraron acciones del sistema."
 
+#: desktop_modules/module_clock.lua:51
+msgid "November"
+msgstr "Noviembre"
+
+#: sui_menu.lua:1602
+msgid "Number of Books in Folder"
+msgstr "Número de Libros en la Carpeta"
+
+#: sui_menu.lua:1634
+msgid "Number of Pages"
+msgstr "Número de Páginas"
+
+#: sui_menu.lua:494
+msgid "Number of Pages in Title Bar Always"
+msgstr "Número de Páginas en la Barra de Título Siempre"
+
+#: sui_quickactions.lua:286
 msgid "OK"
 msgstr "OK"
 
+#: desktop_modules/module_clock.lua:51
+msgid "October"
+msgstr "Octubre"
+
+#: sui_menu.lua:296
+#: sui_menu.lua:356
+#: sui_menu.lua:374
+#: sui_menu.lua:561
+#: sui_menu.lua:618
+#: sui_menu.lua:787
+#: sui_menu.lua:933
+#: sui_menu.lua:1449
+#: sui_menu.lua:1506
+#: desktop_modules/module_clock.lua:378
+#: desktop_modules/module_clock.lua:386
 msgid "Off"
 msgstr "Apagado"
 
+#: sui_menu.lua:296
+#: sui_menu.lua:356
+#: sui_menu.lua:374
+#: sui_menu.lua:561
+#: sui_menu.lua:618
+#: sui_menu.lua:787
+#: sui_menu.lua:933
+#: sui_menu.lua:1449
+#: sui_menu.lua:1506
+#: desktop_modules/module_clock.lua:378
+#: desktop_modules/module_clock.lua:386
 msgid "On"
 msgstr "Encendido"
 
+#: desktop_modules/module_quote.lua:891
 msgid "Open"
 msgstr "Abrir"
 
 msgid "Open \"%s\" to see this highlight?"
 msgstr "¿Abrir \"%s\" para ver este resaltado?"
 
+#: sui_homescreen.lua:125
 msgid "Open a book to get started"
 msgstr "Abre un libro para empezar"
 
+#: sui_menu.lua:1598
+msgid "Overlays"
+msgstr "Superposiciones"
+
+#: sui_patches.lua:1125
+#: sui_patches.lua:1239
+msgid "Page %1 of %2"
+msgstr "Página %1 de %2"
+
+#: sui_menu.lua:356
+msgid "Page number in title bar"
+msgstr "Número de página en la barra de título"
+
+#: sui_menu.lua:1548
 msgid "Pagination Bar"
 msgstr "Barra de paginación"
 
+#: sui_menu.lua:339
 msgid "Pagination bar size will change after restart.\n\nRestart now?"
 msgstr "El tamaño de la barra de paginación cambiará después de reiniciar.\n\n¿Reiniciar ahora?"
 
+#: sui_menu.lua:309
 msgid "Pagination bar will be %s after restart.\n\nRestart now?"
 msgstr "La barra de paginación mostrará %s después de reiniciar.\n\n¿Reiniciar ahora?"
+
+#: sui_titlebar.lua:57
+msgid "Path"
+msgstr "Ruta"
+
+#: sui_quickactions.lua:592
+msgid "Path chooser not available."
+msgstr "Selector de ruta no disponible."
+
+#: desktop_modules/module_recent.lua:286
+msgid "Percentage overlay on cover"
+msgstr "Superposición de porcentaje en la cubierta"
+
+#: desktop_modules/module_currently.lua:524
+msgid "Percentage read"
+msgstr "Porcentaje leído"
+
+#: desktop_modules/module_recent.lua:276
+msgid "Percentage text"
+msgstr "Porcentaje del texto"
 
 msgid "Path is not a folder:\n%s"
 msgstr "La ruta no es una carpeta:\n%s"
 
+#: desktop_modules/module_reading_goals.lua:380
 msgid "Physical Books — %s"
 msgstr "Libros físicos — %s"
 
+#: desktop_modules/module_reading_goals.lua:381
 msgid "Physical books read this year:"
 msgstr "Libros físicos leídos este año:"
 
+#: sui_menu.lua:1031
 msgid "Physical: %d books in %s"
 msgstr "Físico: %d libros en %s"
 
+#: sui_quickactions.lua:704
 msgid "Plugin"
-msgstr "Complemento"
+msgstr "Plugin"
 
+#: sui_quickactions.lua:1021
 msgid "Plugin error: %s"
-msgstr "Error del complemento: %s"
+msgstr "Error del plugin: %s"
 
+#: sui_quickactions.lua:1023
 msgid "Plugin not available: %s"
-msgstr "Complemento no disponible: %s"
+msgstr "Plugin no disponible: %s"
 
+#: sui_config.lua:122
 msgid "Power"
-msgstr "Energía"
+msgstr "Encendido"
 
+#: sui_bottombar.lua:245
+msgid "Prev"
+msgstr "Anterior"
+
+#: desktop_modules/module_recent.lua:266
+msgid "Progress bar"
+msgstr "Barra de progreso"
+
+#: desktop_modules/module_currently.lua:499
+msgid "Progress bar style"
+msgstr "Estilo de la barra de progreso"
+
+#: sui_menu.lua:1248
+#: sui_menu.lua:1555
 msgid "Quick Actions"
-msgstr "Acciones rápidas"
+msgstr "Acciones Rápidas"
 
+#: sui_menu.lua:1559
 msgid "Quick Actions  (%d/%d — %d left)"
-msgstr "Acciones rápidas  (%d/%d — %d restantes)"
+msgstr "Acciones Rápidas  (%d/%d — %d restantes)"
 
+#: sui_menu.lua:1557
 msgid "Quick Actions  (%d/%d — at limit)"
-msgstr "Acciones rápidas  (%d/%d — en el límite)"
+msgstr "Acciones Rápidas  (%d/%d — en el límite)"
 
+#: sui_menu.lua:1084
+#: desktop_modules/module_quick_actions.lua:197
 msgid "Quick Actions %d"
-msgstr "Acciones rápidas %d"
+msgstr "Acciones Rápidas %d"
 
+#: sui_bottombar.lua:1420
 msgid "Quit"
 msgstr "Salir"
 
+#: desktop_modules/module_quote.lua:767
 msgid "Quote of the Day"
-msgstr "Cita del día"
+msgstr "Cita del Día"
 
+#: desktop_modules/module_quote.lua:1018
+msgid "Quotes + My Highlights"
+msgstr "Citas + Mis subrayados"
+
+#: sui_config.lua:145
 msgid "RAM Usage"
 msgstr "Uso de RAM"
 
+#: desktop_modules/module_reading_goals.lua:454
+#: desktop_modules/module_reading_goals.lua:455
 msgid "Reading Goals"
-msgstr "Objetivos de lectura"
+msgstr "Objetivos de Lectura"
 
+#: desktop_modules/module_reading_stats.lua:308
 msgid "Reading Stats"
-msgstr "Estadísticas de lectura"
+msgstr "Estadísticas de Lectura"
 
+#: desktop_modules/module_recent.lua:61
+#: desktop_modules/module_recent.lua:62
 msgid "Recent Books"
-msgstr "Libros recientes"
+msgstr "Libros Recientes"
 
+#: sui_quickactions.lua:815
+#: sui_quickactions.lua:873
+msgid "Rename"
+msgstr "Renombrar"
+
+#: sui_menu.lua:378
+msgid "Replaces the pagination bar with Prev/Next arrows at the edges of the bottom bar.\nThe arrows dim when there is no previous or next page.\nWith navpager active, as few as 1 tab and at most 4 tabs can be configured."
+msgstr "Reemplaza la barra de paginación con flechas Anterior/Siguiente en los extremos de la barra inferior.\nLas flechas se atenúan cuando no hay página anterior o siguiente.\nCon el navegador de páginas activo, se pueden configurar entre 1 y 4 pestañas."
+
+#: sui_menu.lua:1420
+#: sui_quickactions.lua:824
+msgid "Reset"
+msgstr "Restablecer"
+
+#: sui_menu.lua:1419
+msgid "Reset all scales to default (100%)? This cannot be undone."
+msgstr "¿Restablecer todas las escalas al valor predeterminado (100%)? Esta acción no se puede deshacer."
+
+#: sui_menu.lua:1414
+msgid "Reset to Default Scale"
+msgstr "Restablecer escala predeterminada"
+
+#: sui_bottombar.lua:1412
+#: sui_menu.lua:310
+#: sui_menu.lua:340
+#: sui_menu.lua:398
+#: sui_menu.lua:570
+#: sui_menu.lua:627
+#: sui_menu.lua:947
+#: sui_menu.lua:1524
+#: sui_updater.lua:183
 msgid "Restart"
 msgstr "Reiniciar"
 
+#: sui_menu.lua:504
+#: sui_menu.lua:831
 msgid "Right"
 msgstr "Derecha"
 
+#: desktop_modules/module_clock.lua:46
+msgid "Saturday"
+msgstr "Sábado"
+
+#: sui_quickactions.lua:567
+#: sui_quickactions.lua:835
+#: desktop_modules/module_reading_goals.lua:366
+#: desktop_modules/module_reading_goals.lua:383
+#: desktop_modules/module_reading_goals.lua:401
 msgid "Save"
 msgstr "Guardar"
 
+#: sui_menu.lua:1334
+#: desktop_modules/module_clock.lua:356
+#: desktop_modules/module_clock.lua:358
+#: desktop_modules/module_collections.lua:432
+#: desktop_modules/module_collections.lua:434
+#: desktop_modules/module_currently.lua:433
+#: desktop_modules/module_currently.lua:435
+#: desktop_modules/module_new_books.lua:204
+#: desktop_modules/module_new_books.lua:206
+#: desktop_modules/module_quick_actions.lua:245
+#: desktop_modules/module_quick_actions.lua:247
+#: desktop_modules/module_quote.lua:938
+#: desktop_modules/module_quote.lua:942
+#: desktop_modules/module_reading_goals.lua:546
+#: desktop_modules/module_reading_goals.lua:548
+#: desktop_modules/module_reading_stats.lua:452
+#: desktop_modules/module_reading_stats.lua:454
+#: desktop_modules/module_recent.lua:225
+#: desktop_modules/module_recent.lua:227
+msgid "Scale"
+msgstr "Escala"
+
+#: desktop_modules/module_currently.lua:463
+msgid "Scale for all text elements (title, author, progress, time).\n100% is the default size."
+msgstr "Escalar todos los elementos de texto (título, autor, progreso, tiempo).\n100% es el tamaño predeterminado."
+
+#: desktop_modules/module_quick_actions.lua:259
+msgid "Scale for the button label text.\n100% is the default size."
+msgstr "Escalar el texto de la etiqueta del botón.\n100% es el tamaño predeterminado."
+
+#: desktop_modules/module_collections.lua:448
+msgid "Scale for the collection name text.\n100% is the default size."
+msgstr "Escalar el nombre de la colección.\n100% es el tamaño predeterminado."
+
+#: desktop_modules/module_collections.lua:567
+msgid "Scale for the collection thumbnails only.\nThe label text follows the module scale.\n100% is the default size."
+msgstr "Escalar solo para las miniaturas de las colecciones.\nEl texto de la etiqueta seguirá la escala del módulo.\n100% es el tamaño predeterminado."
+
+#: desktop_modules/module_currently.lua:450
+msgid "Scale for the cover thumbnail only.\n100% is the default size."
+msgstr "Escalar solo la miniatura de portada.\n100% es el tamaño predeterminado."
+
+#: desktop_modules/module_new_books.lua:221
+#: desktop_modules/module_recent.lua:242
+msgid "Scale for the cover thumbnails only.\nText and progress bar follow the module scale.\n100% is the default size."
+msgstr "Escalar solo las miniaturas de portada.\nEl texto y la barra de progreso siguen la escala del módulo.\n100% es el tamaño predeterminado."
+
+#: desktop_modules/module_new_books.lua:233
+msgid "Scale for the label text.\n100% is the default size."
+msgstr "Escalar el texto de la etiqueta.\n100% es el tamaño predeterminado."
+
+#: desktop_modules/module_recent.lua:256
+msgid "Scale for the percentage read text.\n100% is the default size."
+msgstr "Escalar el texto de porcentaje leído.\n100% es el tamaño predeterminado."
+
+#: desktop_modules/module_clock.lua:359
+#: desktop_modules/module_collections.lua:435
+#: desktop_modules/module_currently.lua:436
+#: desktop_modules/module_new_books.lua:207
+#: desktop_modules/module_quick_actions.lua:248
+#: desktop_modules/module_quote.lua:944
+#: desktop_modules/module_reading_goals.lua:549
+#: desktop_modules/module_reading_stats.lua:455
+#: desktop_modules/module_recent.lua:228
+msgid "Scale for this module.\n100% is the default size."
+msgstr "Escala para este módulo.\n100% es el tamaño predeterminado."
+
+#: sui_menu.lua:1357
+msgid "Scales all modules and labels together.\n100% is the default size."
+msgstr "Escalar todos los módulos y etiquetas.\n100% es el tamaño predeterminado."
+
+#: sui_menu.lua:1393
+msgid "Scales the section label text above each module.\n100% is the default size."
+msgstr "Escalar el texto de la etiqueta de sección sobre cada módulo.\n100% es el tamaño predeterminado."
+
+#: sui_titlebar.lua:55
+msgid "Search"
+msgstr "Buscar"
+
+#: desktop_modules/module_collections.lua:540
 msgid "Select at least 2 collections to arrange."
 msgstr "Seleccione al menos 2 colecciones para organizar."
 
+#: desktop_modules/module_clock.lua:51
+msgid "September"
+msgstr "Septiembre"
+
+#: sui_foldercovers.lua:455
+msgid "Set folder cover…"
+msgstr "Establecer portada de carpeta…"
+
+#: sui_menu.lua:1533
 msgid "Settings"
 msgstr "Configuración"
+
+#: desktop_modules/module_clock.lua:386
+msgid "Show Battery"
+msgstr "Mostrar Batería"
+
+#: desktop_modules/module_clock.lua:454
+msgid "Show Clock"
+msgstr "Mostrar Reloj"
+
+#: desktop_modules/module_clock.lua:378
+msgid "Show Date"
+msgstr "Mostrar Fecha"
+
+#: sui_menu.lua:364
+msgid "Shows \"Page X of Y\" in the title bar subtitle when browsing the library, history or collections.\nNavpager enables this automatically.\nNot available when Navpager is active."
+msgstr "Muestra \"Página X de Y\" en el subtítulo de la barra de título al navegar por la biblioteca, el historial o las colecciones.\nEl navegador de páginas lo activa automáticamente.\nNo disponible cuando el navegador de páginas está activo."
+
+#: desktop_modules/module_currently.lua:502
+msgid "Simple"
+msgstr "Simple"
 
 msgid "Show Labels"
 msgstr "Mostrar etiquetas"
 
+#: main.lua:381
+#: main.lua:394
+#: sui_menu.lua:1502
+#: sui_menu.lua:1506
 msgid "Simple UI"
 msgstr "Simple UI"
 
+#: main.lua:68
+msgid "Simple UI was updated (%s → %s).\n\nA restart is recommended to apply all changes cleanly."
+msgstr "Simple UI se actualizó (%s → %s).\n\nSe recomienda reiniciar para aplicar todos los cambios correctamente."
+
+#: sui_menu.lua:1523
 msgid "Simple UI will be %s after restart.\n\nRestart now?"
 msgstr "Simple UI será %s después de reiniciar.\n\n¿Reiniciar ahora?"
 
+#: sui_menu.lua:580
+#: sui_menu.lua:638
 msgid "Size"
 msgstr "Tamaño"
 
+#: sui_menu.lua:694
+msgid "Size of the tab icons.\n100% is the default size."
+msgstr "Tamaño de los iconos de las pestañas.\n100% es el tamaño predeterminado."
+
+#: sui_menu.lua:714
+msgid "Size of the tab label text.\n100% is the default size."
+msgstr "Tamaño del texto de las etiquetas de las pestañas.\n100% es el tamaño predeterminado."
+
+#: desktop_modules/module_reading_stats.lua:534
+msgid "Size of the text inside the stat cards.\nDoes not affect card size or padding.\n100% is the default size."
+msgstr "Tamaño del texto dentro de las tarjetas de estadísticas.\nNo afecta el tamaño de la tarjeta ni el relleno.\n100% es el tamaño predeterminado."
+
+#: sui_menu.lua:325
 msgid "Small"
 msgstr "Pequeño"
 
+#: desktop_modules/module_quote.lua:970
+msgid "Source"
+msgstr "Fuente"
+
+#: sui_menu.lua:672
+msgid "Space below the bottom navigation bar.\n100% is the default spacing."
+msgstr "Espacio debajo de la barra de navegación inferior.\n100% es el espacio predeterminado."
+
+#: sui_patches.lua:306
+#: sui_patches.lua:308
 msgid "Start with"
 msgstr "Iniciar con"
 
+#: sui_menu.lua:1459
 msgid "Start with Home Screen"
-msgstr "Comenzar en la pantalla de inicio"
+msgstr "Iniciar en la pantalla de inicio"
 
+#: sui_bottombar.lua:956
+#: sui_bottombar.lua:1184
 msgid "Statistics plugin not available."
-msgstr "Complemento de estadísticas no disponible."
+msgstr "Plugin de estadísticas no disponible."
 
+#: sui_config.lua:121
 msgid "Stats"
 msgstr "Estadísticas"
 
+#: sui_menu.lua:1539
+msgid "Status Bar"
+msgstr "Barra de Estado"
+
+#: desktop_modules/module_reading_stats.lua:68
 msgid "Streak"
 msgstr "Racha"
 
+#: sui_menu.lua:971
+msgid "Sub-pages Buttons"
+msgstr "Botones de subpáginas"
+
+#: desktop_modules/module_clock.lua:45
+msgid "Sunday"
+msgstr "Domingo"
+
+#: sui_menu.lua:417
 msgid "Swipe Indicator"
 msgstr "Indicador de deslizamiento"
 
-msgid "System Actions"
-msgstr "Acciones de sistema"
+#: sui_menu.lua:427
+msgid "Hide Wi-Fi icon when off"
+msgstr "Ocultar el icono de Wi-Fi cuando esté apagado"
 
+#: sui_quickactions.lua:706
+msgid "System Actions"
+msgstr "Acciones de Sistema"
+
+#: sui_quickactions.lua:1011
 msgid "System action error: %s"
 msgstr "Error de acción del sistema: %s"
 
+#: sui_menu.lua:752
 msgid "Tabs  (%d/%d — %d left)"
 msgstr "Pestañas  (%d/%d — %d restantes)"
 
+#: sui_menu.lua:750
 msgid "Tabs  (%d/%d — at limit)"
 msgstr "Pestañas  (%d/%d — en el límite)"
 
+#: sui_menu.lua:101
 msgid "Text"
 msgstr "Texto"
 
+#: desktop_modules/module_collections.lua:446
+#: desktop_modules/module_collections.lua:447
+#: desktop_modules/module_currently.lua:461
+#: desktop_modules/module_currently.lua:462
+#: desktop_modules/module_new_books.lua:231
+#: desktop_modules/module_new_books.lua:232
+#: desktop_modules/module_quick_actions.lua:255
+#: desktop_modules/module_quick_actions.lua:258
+#: desktop_modules/module_reading_stats.lua:530
+#: desktop_modules/module_reading_stats.lua:533
+#: desktop_modules/module_recent.lua:254
+#: desktop_modules/module_recent.lua:255
+msgid "Text Size"
+msgstr "Tamaño del texto"
+
+#: desktop_modules/module_reading_stats.lua:531
+msgid "Text Size — %d%%"
+msgstr "Tamaño del texto — %d%%"
+
+#: sui_menu.lua:103
 msgid "Text only"
 msgstr "Solo texto"
 
+#: desktop_modules/module_clock.lua:46
+msgid "Thursday"
+msgstr "Jueves"
+
+#: sui_titlebar.lua:56
+msgid "Title"
+msgstr "Título"
+
+#: sui_menu.lua:1540
+msgid "Title Bar"
+msgstr "Barra de título"
+
+#: desktop_modules/module_reading_goals.lua:491
+#: desktop_modules/module_reading_goals.lua:493
+#: desktop_modules/module_reading_goals.lua:515
+#: desktop_modules/module_reading_goals.lua:517
 msgid "Today"
 msgstr "Hoy"
 
+#: desktop_modules/module_reading_stats.lua:63
 msgid "Today — Pages"
 msgstr "Hoy — Páginas"
 
+#: desktop_modules/module_reading_stats.lua:62
 msgid "Today — Time"
 msgstr "Hoy — Tiempo"
 
+#: sui_menu.lua:1537
+#: sui_menu.lua:1616
+#: sui_menu.lua:1664
+msgid "Top"
+msgstr "Parte superior"
+
+#: sui_menu.lua:561
+#: sui_topbar.lua:473
 msgid "Top Bar"
 msgstr "Barra superior"
 
+#: sui_menu.lua:586
+msgid "Top Bar Size"
+msgstr "Tamaño de la barra superior"
+
+#: sui_menu.lua:569
 msgid "Top Bar will be %s after restart.\n\nRestart now?"
 msgstr "La barra superior será %s después de reiniciar.\n\n¿Reiniciar ahora?"
 
+#: sui_menu.lua:728
+msgid "Top separator"
+msgstr "Separador superior"
+
+#: sui_menu.lua:1653
+msgid "Transparent"
+msgstr "Transparente"
+
+#: desktop_modules/module_clock.lua:45
+msgid "Tuesday"
+msgstr "Martes"
+
+#: sui_menu.lua:741
+#: desktop_modules/module_quick_actions.lua:267
+#: desktop_modules/module_reading_goals.lua:563
+#: desktop_modules/module_reading_stats.lua:491
 msgid "Type"
 msgstr "Tipo"
 
+#: sui_menu.lua:1692
+msgid "Uniformize Covers (2:3)"
+msgstr "Uniformizar portadas (2:3)"
+
+#: sui_menu.lua:728
+msgid "Visible"
+msgstr "Visible"
+
+#: desktop_modules/module_clock.lua:45
+msgid "Wednesday"
+msgstr "Miércoles"
+
+#: sui_config.lua:119
 msgid "Wi-Fi"
 msgstr "Wi-Fi"
 
+#: sui_bottombar.lua:1221
 msgid "Wi-Fi off"
 msgstr "Wi-Fi apagado"
 
+#: sui_config.lua:141
 msgid "WiFi"
 msgstr "WiFi"
 
+#: sui_bottombar.lua:1208
 msgid "WiFi not available on this device."
 msgstr "WiFi no disponible en este dispositivo."
 
+#: sui_quickactions.lua:410
 msgid "Wikipedia Lookup"
 msgstr "Buscar en Wikipedia"
 
+#: desktop_modules/module_currently.lua:512
+msgid "With percentage"
+msgstr "Con porcentaje"
+
+#: desktop_modules/module_quote.lua:701
+msgid "Your highlights"
+msgstr "Tus resaltados"
+
+#: desktop_modules/module_reading_stats.lua:67
 msgid "books finished"
-msgstr "Libros terminados"
+msgstr "libros terminados"
 
+#: desktop_modules/module_reading_stats.lua:64
 msgid "daily avg (7 days)"
-msgstr "Promedio diario (7 días)"
+msgstr "promedio diario (7 días)"
 
+#: desktop_modules/module_reading_stats.lua:69
 msgid "day streak"
 msgstr "racha diaria"
 
+#: desktop_modules/module_reading_stats.lua:69
 msgid "days streak"
 msgstr "días en racha"
 
+#: desktop_modules/module_reading_stats.lua:68
+msgid "no streak"
+msgstr "sin racha"
+
+#: sui_quickactions.lua:769
+msgid "default"
+msgstr "predeterminado"
+
+#: sui_menu.lua:395
+#: sui_menu.lua:569
+#: sui_menu.lua:626
+#: sui_menu.lua:945
+#: sui_menu.lua:1523
 msgid "disabled"
 msgstr "desactivado"
+
+#: sui_quickactions.lua:609
+msgid "e.g. Comics…"
+msgstr "p. ej.: Comics…"
 
 msgid "e.g. Books…"
 msgstr "p. ej.: Libros…"
@@ -561,65 +1569,292 @@ msgstr "p. ej.: Libros…"
 msgid "e.g. My Library"
 msgstr "p. ej.: Mi Biblioteca"
 
+#: sui_quickactions.lua:655
 msgid "e.g. Rakuyomi…"
 msgstr "p. ej.: Rakuyomi…"
 
+#: sui_quickactions.lua:628
 msgid "e.g. Sci-Fi…"
 msgstr "p. ej.: Ciencia ficción…"
 
+#: sui_quickactions.lua:683
 msgid "e.g. Sleep, Refresh…"
 msgstr "p. ej.: Dormir, Actualizar…"
 
+#: sui_menu.lua:395
+#: sui_menu.lua:569
+#: sui_menu.lua:626
+#: sui_menu.lua:945
+#: sui_menu.lua:1523
 msgid "enabled"
 msgstr "activado"
 
+#: sui_quickactions.lua:270
+msgid "hex code, e.g. E001"
+msgstr "código hexadecimal, p. ej.: E001"
+
+#: sui_menu.lua:307
 msgid "hidden"
 msgstr "oculto"
 
+#: sui_quickactions.lua:921
+#: sui_quickactions.lua:937
 msgid "not configured"
 msgstr "no configurado"
 
+#: desktop_modules/module_reading_stats.lua:62
 msgid "of reading today"
 msgstr "de lectura (hoy)"
 
+#: desktop_modules/module_reading_stats.lua:66
 msgid "of reading, all time"
 msgstr "de lectura (total)"
 
+#: desktop_modules/module_reading_stats.lua:63
 msgid "pages read today"
 msgstr "páginas leídas (hoy)"
 
+#: desktop_modules/module_reading_stats.lua:65
 msgid "pages/day (7 days)"
 msgstr "páginas/día (7 días)"
 
+#: sui_menu.lua:307
 msgid "visible"
 msgstr "visible"
 
-msgid "    Size"
-msgstr "    Tamaño"
+#: desktop_modules/module_currently.lua:271
+msgid "Author"
+msgstr "Autor"
 
-msgid "Apply"
-msgstr "Aplicar"
+#: desktop_modules/module_currently.lua:274
+msgid "Days of reading"
+msgstr "Días de lectura"
 
-msgid "Bookmark browser"
-msgstr "Explorador de marcadores"
+#: desktop_modules/module_currently.lua:275
+msgid "Time read"
+msgstr "Tiempo leído"
 
-msgid "Bookmark browser not available."
-msgstr "Explorador de marcadores no disponible."
+#: desktop_modules/module_currently.lua:276
+msgid "Time remaining"
+msgstr "Tiempo restante"
 
-msgid "Bookmarks"
-msgstr "Marcadores"
+#: desktop_modules/module_currently.lua
+msgid "%s left"
+msgstr "%s restante"
 
-msgid "Bottom"
-msgstr "Abajo"
+#: desktop_modules/module_currently.lua
+msgid "1 day"
+msgstr "1 día"
 
-msgid "Bottom Bar Size"
-msgstr "Tamaño de la barra inferior"
+#: desktop_modules/module_currently.lua
+msgid "%d days"
+msgstr "%d días"
 
-msgid "Change Icons"
-msgstr "Cambiar iconos"
+#: desktop_modules/module_currently.lua
+msgid "Stats layout"
+msgstr "Diseño de estadísticas"
 
-msgid "Cover size"
-msgstr "Tamaño de portada"
+
+
+#: sui_menu.lua:356
+msgid "Pagination bar set to Default.\n\nRestart now?"
+msgstr "Barra de paginación configurada por defecto.\n\n¿Reiniciar ahora?"
+
+#: sui_menu.lua:367
+msgid "Navpager enabled.\n\nRestart now?"
+msgstr "Navegador de páginas activado.\n\n¿Reiniciar ahora?"
+
+#: sui_menu.lua:377
+msgid "Pagination bar hidden.\n\nRestart now?"
+msgstr "Barra de paginación ocultada.\n\n¿Reiniciar ahora?"
+
+#: sui_menu.lua:387
+msgid "Dot Pager"
+msgstr "Paginador de Puntos"
+
+#: sui_menu.lua:395
+msgid "Shows a row of dots at the bottom of the homescreen.\nThe active page dot is filled; the others are dimmed.\nAlways active when Navpager is selected."
+msgstr "Muestra una fila de puntos en la parte inferior de la pantalla principal.\nEl punto de la página activa se rellena; los demás quedan oscurecidos.\nSiempre activo cuando se selecciona el Navegador de Páginas."
+
+#: sui_menu.lua:417
+msgid "Uses the standard KOReader pagination bar on the homescreen.\nNot available when Navpager is active."
+msgstr "Usa la barra de paginación estándar de KOReader en la pantalla principal.\nNo disponible cuando el Navegador de Páginas está activo."
+
+#: sui_menu.lua:438
+msgid "Hides the pagination bar on the homescreen.\nNot available when Navpager is active."
+msgstr "Oculta la barra de paginación en la pantalla principal.\nNo disponible cuando el Navegador de Páginas está activo."
+
+#: sui_menu.lua:1566
+msgid "Modules per Page  (%d)"
+msgstr "Módulos por Página  (%d)"
+
+#: sui_menu.lua:1572
+msgid "Modules per Page"
+msgstr "Módulos por Página"
+
+#: sui_menu.lua:1573
+msgid "Maximum number of modules shown on each page.\nSwipe left/right on the Home Screen to turn pages."
+msgstr "Número máximo de módulos mostrados en cada página.\nDesliza a la izquierda/derecha en la pantalla principal para cambiar de página."
+
+#: sui_menu.lua:1834
+msgid "Placeholder cover for bookless folders"
+msgstr "Portada por defecto para carpetas sin libros"
+
+#: sui_menu.lua:1849
+msgid "  Scan subfolders for cover"
+msgstr "  Escanear subcarpetas para la portada"
+
+#: sui_menu.lua
+msgid "Check for Updates"
+msgstr "Comprobar Actualizaciones"
+
+#: sui_menu.lua
+msgid "About"
+msgstr "Acerca de"
+
+#: sui_menu.lua
+msgid "Version: %s"
+msgstr "Versión: %s"
+
+#: sui_menu.lua
+msgid "Author: %s"
+msgstr "Autor: %s"
+
+#: sui_homescreen.lua:407
+#: desktop_modules/module_quote.lua:950
+msgid "Open this file?"
+msgstr "¿Abrir este archivo?"
+
+#: sui_bottombar.lua:1638
+msgid "Sleep"
+msgstr "Suspender"
+
+#: sui_updater.lua:157
+msgid "Downloading Simple UI "
+msgstr "Descargando Simple UI "
+
+#: sui_updater.lua:163
+msgid "Download error: "
+msgstr "Error al descargar: "
+
+#: sui_updater.lua:174
+msgid "Extraction error: "
+msgstr "Error al extraer: "
+
+#: sui_updater.lua:180
+msgid "Simple UI %s successfully installed.\n\nRestart KOReader to apply the update?"
+msgstr "Simple UI %s instalado correctamente.\n\n¿Reiniciar KOReader para aplicar la actualización?"
+
+#: sui_updater.lua:194
+msgid "Checking for updates..."
+msgstr "Comprobando actualizaciones..."
+
+#: sui_updater.lua:200
+msgid "Error checking for updates: "
+msgstr "Error al comprobar actualizaciones: "
+
+#: sui_updater.lua:216
+msgid "Could not retrieve version information."
+msgstr "No se pudo obtener la información de la versión."
+
+#: sui_updater.lua:222
+msgid "Simple UI is up to date (%s)."
+msgstr "Simple UI está actualizado (%s)."
+
+#: sui_updater.lua:233
+msgid "Simple UI %s is available (you have %s).\n\nNo automatic update file was found.\n\nOpen the releases page on GitHub?"
+msgstr "Simple UI %s está disponible (tienes %s).\n\nNo se encontró ningún archivo de actualización automática.\n\n¿Abrir la página de lanzamientos en GitHub?"
+
+#: sui_updater.lua:236
+msgid "Open in browser"
+msgstr "Abrir en el navegador"
+
+#: sui_updater.lua:254
+msgid "Simple UI %s is available!\nCurrent version: %s\n\nDownload and install now?"
+msgstr "Simple UI %s está disponible!\nVersión actual: %s\n\nDescargar e instalar ahora?"
+
+#: sui_updater.lua:257
+msgid "Download and install"
+msgstr "Descargar e instalar"
+
+
+#: sui_menu.lua
+msgid "Return to Book Folder"
+msgstr "Volver a la Carpeta de Libros"
+
+#: sui_menu.lua
+msgid "When enabled, opening the file browser after finishing or closing a book navigates to the folder the book is in, matching native KOReader behaviour.\nWhen disabled (default), SimpleUI always returns to the library root."
+msgstr "Cuando está habilitado, abrir el explorador de archivos después de terminar o cerrar un libro navega a la carpeta del libro, coincidiendo con el comportamiento nativo de KOReader.\nCuando está deshabilitado (por defecto), SimpleUI siempre vuelve a la raíz de la biblioteca."
+
+#: sui_menu.lua
+msgid "Settings on Long Tap"
+msgstr "Ajustes al Mantener Pulsado"
+
+#: sui_menu.lua
+msgid "When enabled, long-pressing a section opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
+msgstr "Cuando está habilitado, mantener pulsado una sección abre su menú de ajustes.\nDeshabilítelo para evitar que el menú de ajustes aparezca al mantener pulsado."
+
+#: sui_menu.lua
+msgid "When enabled, long-pressing the top bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
+msgstr "Cuando está habilitado, mantener pulsado la barra superior abre su menú de ajustes.\nDeshabilítelo para evitar que el menú de ajustes aparezca al mantener pulsado."
+
+#: sui_menu.lua
+msgid "When enabled, long-pressing the bottom bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
+msgstr "Cuando está habilitado, mantener pulsado la barra inferior abre su menú de ajustes.\nDeshabilítelo para evitar que el menú de ajustes aparezca al mantener pulsado."
+
+#: desktop_modules/module_tbr.lua
+msgid "Arrange To Be Read list"
+msgstr "Reorganizar la lista para leer más tarde"
+
+#: desktop_modules/module_tbr.lua
+msgid "Add at least 2 books to arrange."
+msgstr "Añade al menos 2 libros para reorganizar."
+
+#: desktop_modules/module_tbr.lua
+msgid "To Be Read books"
+msgstr "Libros para leer más tarde"
+
+#: desktop_modules/module_tbr.lua
+msgid "No books in To Be Read list."
+msgstr "No hay libros en la lista para leer más tarde."
+
+#: desktop_modules/module_tbr.lua
+msgid "Add to To Be Read"
+msgstr "Añadir a leer más tarde"
+
+#: desktop_modules/module_tbr.lua
+msgid "Remove from To Be Read"
+msgstr "Eliminar de leer más tarde"
+
+#: desktop_modules/module_tbr.lua
+msgid "To Be Read"
+msgstr "Leer más tarde"
+
+#: sui_foldercovers.lua sui_menu.lua
+msgid "Group Books by Series"
+msgstr "Agrupar libros por Series"
+
+#: sui_menu.lua
+msgid "Series Index"
+msgstr "Índice de Series"
+
+#: sui_foldercovers.lua
+msgid "Series cover"
+msgstr "Portada de Series"
+
+#: sui_foldercovers.lua
+msgid "Set series cover…"
+msgstr "Establecer portada de series…"
+
+#: sui_foldercovers.lua
+msgid "No books found in this series."
+msgstr "No se encontraron libros en esta serie."
+
+#: sui_foldercovers.lua
+msgid "Scan subfolders for cover"
+msgstr "Escanear subcarpetas para la portada"
+
+
 
 msgid "Cover size  —  %d%%"
 msgstr "Tamaño de portada  —  %d%%"
@@ -627,83 +1862,11 @@ msgstr "Tamaño de portada  —  %d%%"
 msgid "Fetching bookmarks…"
 msgstr "Cargando marcadores…"
 
-msgid "Global scale for all modules.\nIndividual overrides in Module Settings take precedence.\n100% is the default size."
-msgstr "Escala global para todos los módulos.\nLas configuraciones individuales en Ajustes de módulo tienen prioridad.\n100% es el tamaño predeterminado."
-
-msgid "Height of the bottom navigation bar.\n100% is the default size."
-msgstr "Altura de la barra de navegación inferior.\n100% es el tamaño predeterminado."
-
-msgid "Height of the top status bar.\n100% is the default size."
-msgstr "Altura de la barra de estado superior.\n100% es el tamaño predeterminado."
-
-msgid "Hidden"
-msgstr "Oculto"
-
-msgid "Home folder"
-msgstr "Carpeta de inicio"
-
-msgid "Home folder + subfolders"
-msgstr "Carpeta de inicio + subcarpetas"
-
-msgid "Label Scale"
-msgstr "Escala de etiquetas"
-
 msgid "Labels  —  %d%%"
 msgstr "Etiquetas  —  %d%%"
 
-msgid "Minimum 1 tab required in navpager mode."
-msgstr "Se necesita un mínimo de 1 pestaña en modo navegador de páginas."
-
-msgid "Module Scale"
-msgstr "Escala de módulo"
-
 msgid "Modules  —  %d%%"
 msgstr "Módulos  —  %d%%"
-
-msgid "Navigation Bar"
-msgstr "Barra de navegación"
-
-msgid "Navpager"
-msgstr "Navegador de páginas"
-
-msgid "Navpager will be %s after restart.\n\nRestart now?"
-msgstr "El navegador de páginas será %s después de reiniciar.\n\n¿Reiniciar ahora?"
-
-msgid "New name…"
-msgstr "Nuevo nombre…"
-
-msgid "Next"
-msgstr "Siguiente"
-
-msgid "No highlights found. Open a book and highlight some passages."
-msgstr "No se encontraron resaltados. Abre un libro y resalta algunos pasajes."
-
-msgid "Page %1 of %2"
-msgstr "Página %1 de %2"
-
-msgid "Page number in title bar"
-msgstr "Número de página en la barra de título"
-
-msgid "Prev"
-msgstr "Anterior"
-
-msgid "Rename"
-msgstr "Renombrar"
-
-msgid "Replaces the pagination bar with Prev/Next arrows at the edges of the bottom bar.\nThe arrows dim when there is no previous or next page.\nWith navpager active, as few as 1 tab and at most 4 tabs can be configured."
-msgstr "Reemplaza la barra de paginación con flechas Anterior/Siguiente en los extremos de la barra inferior.\nLas flechas se atenúan cuando no hay página anterior o siguiente.\nCon el navegador de páginas activo, se pueden configurar entre 1 y 4 pestañas."
-
-msgid "Reset"
-msgstr "Restablecer"
-
-msgid "Reset all scales to default (100%)? This cannot be undone."
-msgstr "¿Restablecer todas las escalas al valor predeterminado (100%)? Esta acción no se puede deshacer."
-
-msgid "Reset to Default Scale"
-msgstr "Restablecer escala predeterminada"
-
-msgid "Scale"
-msgstr "Escala"
 
 msgid "Scale  —  %d%%"
 msgstr "Escala  —  %d%%"
@@ -711,193 +1874,17 @@ msgstr "Escala  —  %d%%"
 msgid "Scale  —  %d%% / %d%%"
 msgstr "Escala  —  %d%% / %d%%"
 
-
-msgid "Scale for the collection thumbnails only.\nThe label text follows the module scale.\n100% is the default size."
-msgstr "Escalar solo para las miniaturas de las colecciones.\nEl texto de la etiqueta seguirá la escala del módulo.\n100% es el tamaño predeterminado."
-
-msgid "Scales all modules and labels together.\n100% is the default size."
-msgstr "Escalar todos los módulos y etiquetas.\n100% es el tamaño predeterminado."
-
-msgid "Scales the section label text above each module.\n100% is the default size."
-msgstr "Escalar el texto de la etiqueta de sección sobre cada módulo.\n100% es el tamaño predeterminado."
-
-msgid "Simple UI was updated (%s → %s).\n\nA restart is recommended to apply all changes cleanly."
-msgstr "Simple UI se actualizó (%s → %s).\n\nSe recomienda reiniciar para aplicar todos los cambios correctamente."
-
 msgid "Size  —  %d%%"
 msgstr "Tamaño  —  %d%%"
-
-msgid "Status Bar"
-msgstr "Barra de estado"
-
-msgid "Top"
-msgstr "Arriba"
-
-msgid "Top Bar Size"
-msgstr "Tamaño de la barra superior"
-
-msgid "Top separator"
-msgstr "Separador superior"
-
-msgid "Visible"
-msgstr "Visible"
-
-msgid "Your highlights"
-msgstr "Tus resaltados"
-
-msgid "Arrange Buttons"
-msgstr "Reorganizar botones"
-
-msgid "Back"
-msgstr "Atrás"
-
-msgid "Button Size"
-msgstr "Tamaño de botón"
-
-msgid "Cards"
-msgstr "Tarjetas"
-
-msgid "Close"
-msgstr "Cerrar"
-
-msgid "Cover for \"%s\""
-msgstr "Portada de \"%s\""
-
-msgid "Custom Title Bar"
-msgstr "Barra de título personalizada"
-
-msgid "Custom Title Bar will be %s after restart.\n\nRestart now?"
-msgstr "La barra de título personalizada será %s después de reiniciar.\n\n¿Reiniciar ahora?"
-
-msgid "Delete quick action \"%s\"?"
-msgstr "¿Eliminar la acción rápida \"%s\"?"
-
-msgid "Library Buttons"
-msgstr "Botones de biblioteca"
-
-msgid "List"
-msgstr "Lista"
-
-msgid "Menu"
-msgstr "Menú"
 
 msgid "More Options"
 msgstr "Más opciones"
 
-msgid "Search"
-msgstr "Buscar"
-
-msgid "Show Battery"
-msgstr "Mostrar batería"
-
-msgid "Show Date"
-msgstr "Mostrar fecha"
-
-msgid "Sub-pages Buttons"
-msgstr "Botones de subpáginas"
-
-msgid "Title"
-msgstr "Título"
-
-msgid "Title Bar"
-msgstr "Barra de título"
-
 msgid "Disable \"Linked Scale\" first to set a per-module scale."
 msgstr "Desactiva \"Escala vinculada\" primero para establecer una escala por módulo."
 
-
-msgid "Lock Scale"
-msgstr "Escala bloqueada"
-
-msgid "Disable \"Lock Scale\" first to set a per-module scale."
-msgstr "Desactiva \"Escala bloqueada\" primero para establecer una escala por módulo."
-
-msgid "Disable \"Lock Scale\" first to set a custom label scale."
-msgstr "Desactiva \"Escala bloqueada\" primero para establecer una escala de etiqueta personalizada."
-
-msgid "Text Size"
-msgstr "Tamaño del texto"
-
-msgid "Modules"
-msgstr "Módulos"
-
-msgid "Labels"
-msgstr "Etiquetas"
-
-msgid "Scale for this module.\n100% is the default size."
-msgstr "Escala para este módulo.\n100% es el tamaño predeterminado."
-
-msgid "Scale for the collection name text.\n100% is the default size."
-msgstr "Escalar el nombre de la colección.\n100% es el tamaño predeterminado."
-
-msgid "Scale for the cover thumbnail only.\n100% is the default size."
-msgstr "Escalar solo la miniatura de portada.\n100% es el tamaño predeterminado."
-
-msgid "Scale for all text elements (title, author, progress, time).\n100% is the default size."
-msgstr "Escalar todos los elementos de texto (título, autor, progreso, tiempo).\n100% es el tamaño predeterminado."
-
-msgid "Scale for the button label text.\n100% is the default size."
-msgstr "Escalar el texto de la etiqueta del botón.\n100% es el tamaño predeterminado."
-
-msgid "Scale for the cover thumbnails only.\nText and progress bar follow the module scale.\n100% is the default size."
-msgstr "Escalar solo las miniaturas de portada.\nEl texto y la barra de progreso siguen la escala del módulo.\n100% es el tamaño predeterminado."
-
-msgid "Scale for the percentage read text.\n100% is the default size."
-msgstr "Escalar el texto de porcentaje leído.\n100% es el tamaño predeterminado."
-
-msgid "Source"
-msgstr "Fuente"
-
-msgid "Default Quotes"
-msgstr "Citas predeterminadas"
-
-msgid "My Highlights"
-msgstr "Mis subrayados"
-
-msgid "Quotes + My Highlights"
-msgstr "Citas + Mis subrayados"
-
-msgid "default"
-msgstr "predeterminado"
-
-msgid "Shows \"Page X of Y\" in the title bar subtitle when browsing the library, history or collections.\nNavpager enables this automatically.\nNot available when Navpager is active."
-msgstr "Muestra \"Página X de Y\" en el subtítulo de la barra de título al navegar por la biblioteca, el historial o las colecciones.\nEl navegador de páginas lo activa automáticamente.\nNo disponible cuando el navegador de páginas está activo."
-
-msgid "Icon Size"
-msgstr "Tamaño del icono"
-
-msgid "Icon Size — %d%%"
-msgstr "Tamaño del icono  —  %d%%"
-
-msgid "Label Size"
-msgstr "Tamaño de la etiqueta"
-
-msgid "Label Size — %d%%"
-msgstr "Tamaño de la etiqueta  —  %d%%"
-
-msgid "Size of the tab icons.\n100% is the default size."
-msgstr "Tamaño de los iconos de las pestañas.\n100% es el tamaño predeterminado."
-
-msgid "Size of the tab label text.\n100% is the default size."
-msgstr "Tamaño del texto de las etiquetas de las pestañas.\n100% es el tamaño predeterminado."
-
-msgid "Folder Covers"
-msgstr "Portadas de Carpetas"
-
-msgid "Folder cover"
-msgstr "Portada de carpeta"
-
-msgid "Set folder cover…"
-msgstr "Establecer portada de carpeta…"
-
-msgid "No books found in this folder."
-msgstr "No se encontraron libros en esta carpeta."
-
 msgid "Badge"
 msgstr "Insignia"
-
-msgid "Center"
-msgstr "Centro"
 
 msgid "Label"
 msgstr "Etiqueta"
@@ -905,83 +1892,11 @@ msgstr "Etiqueta"
 msgid "Show label"
 msgstr "Mostrar etiqueta"
 
-msgid "Transparent"
-msgstr "Transparente"
-
-msgid "Hide selection underline"
-msgstr "Ocultar el subrayado"
-
-msgid "Author"
-msgstr "Autor"
-
-msgid "Progress bar"
-msgstr "Barra de progreso"
-
-msgid "Percentage read"
-msgstr "Porcentaje leído"
-
-msgid "Folder Name"
-msgstr "Nombre de la Carpeta"
-
-msgid "Number of Books in Folder"
-msgstr "Número de Libros en la Carpeta"
-
-msgid "Number of Pages"
-msgstr "Número de Páginas"
-
 msgid "Overlay"
 msgstr "Superposición"
-
-msgid "Overlays"
-msgstr "Superposiciones"
-
-msgid "Uniformize Covers (2:3)"
-msgstr "Uniformizar portadas (2:3)"
-
-msgid "Invalid arrangement.\nKeep the Left, Center and Right separators in order."
-msgstr "Organización inválida.\nMantén los separadores Izquierda, Centro y Derecha en orden."
-
-msgid "Invalid arrangement.\nKeep items between the Left and Right separators."
-msgstr "Organización inválida.\nMantén los elementos dentro de los separadores Izquierda y Derecha."
 
 msgid "Fetching bookmarks…"
 msgstr "Cargando marcadores…"
 
-msgid "Path chooser not available."
-msgstr "Selector de ruta no disponible."
-
-msgid "e.g. Comics…"
-msgstr "p. ej.: Cómics…"
-
 msgid "(%d left)"
 msgstr "(%d restante)"
-
-msgid "New Books"
-msgstr "Libros nuevos"
-
-msgid "Hide Wi-Fi icon when off"
-msgstr "Ocultar el icono de Wi‑Fi cuando esté apagado"
-
-msgid "Percentage text"
-msgstr "Porcentaje del texto"
-
-msgid "Percentage overlay on cover"
-msgstr "Porcentaje de la superposición en cubierta"
-
-msgid "Days of reading"
-msgstr "Días de lectura"
-
-msgid "Top Margin  (%d%%)"
-msgstr "Margen superior  (%d%%)"
-
-msgid "Time read"
-msgstr "Tiempo leído"
-
-msgid "Time remaining"
-msgstr "Tiempo restante"
-
-msgid "%d days of reading"
-msgstr "%d días leyendo"
-
-msgid "%s remaining"
-msgstr "%s restante"


### PR DESCRIPTION
I added the missing strings for spanish and I also reordered them to match the `simpleui.pot` file.

Note: strings without a comment `#:` are not present in `simpleui.pot` file and probably could be removed.