### PR TITLE
Module items untranslatable strings

### DIFF
--- a/desktop_modules/module_collections.lua
+++ b/desktop_modules/module_collections.lua
@@ -525,6 +525,7 @@ function M.getMenuItems(ctx_menu)
     local SortWidget  = ctx_menu.SortWidget
     local refresh     = ctx_menu.refresh
     local _lc         = ctx_menu._
+    local N_lc        = _lc.ngettext
 
     local ok_rc, rc  = pcall(require, "readcollection")
     local all_colls  = {}
@@ -685,8 +686,7 @@ function M.getMenuItems(ctx_menu)
                     local cur = M.getSelected()
                     for _loop_, n in ipairs(cur) do if n == _n then return _display_n end end
                     local rem = 4 - #cur
-                    if rem <= 0 then return _display_n .. "  (0 left)" end
-                    if rem <= 2 then return _display_n .. "  (" .. rem .. " left)" end
+                    if rem <= 2 then return _display_n .. string.format(N_lc("  (%d left)", "  (%d left)", rem), rem) end
                     return _display_n
                 end,
                 checked_func = function()

--- a/desktop_modules/module_quick_actions.lua
+++ b/desktop_modules/module_quick_actions.lua
@@ -316,8 +316,7 @@ local function makeSlot(slot)
                 text_func = function()
                     if isSelected(aid) then return _lbl end
                     local rem = MAX_QA - #getItems()
-                    if rem <= 0 then return _lbl .. "  (0 left)" end
-                    if rem <= 2 then return _lbl .. "  (" .. rem .. " left)" end
+                    if rem <= 2 then return _lbl .. string.format(N_("  (%d left)", "  (%d left)", rem), rem) end
                     return _lbl
                 end,
                 checked_func   = function() return isSelected(aid) end,

--- a/desktop_modules/module_reading_stats.lua
+++ b/desktop_modules/module_reading_stats.lua
@@ -504,8 +504,7 @@ function M.getMenuItems(ctx_menu)
             text_func = function()
                 if isSelected(_sid) then return _lbl end
                 local rem = MAX_RS - #getItems()
-                if rem <= 0 then return _lbl .. "  (0 left)" end
-                if rem <= 2 then return _lbl .. "  (" .. rem .. " left)" end
+                if rem <= 2 then return _lbl .. string.format(N_lc("  (%d left)", "  (%d left)", rem), rem) end
                 return _lbl
             end,
             checked_func   = function() return isSelected(_sid) end,

--- a/locale/ro.po
+++ b/locale/ro.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: simpleui\n"
 "Report-Msgid-Bugs-To: yokyroll\n"
-"POT-Creation-Date: 2026-04-10 14:14\n"
-"PO-Revision-Date: 2026-04-10 13:39+0300\n"
+"POT-Creation-Date: 2026-04-11 15:45\n"
+"PO-Revision-Date: 2026-04-11 15:46+0300\n"
 "Last-Translator: Mihai Vasiliu <mihai.vasiliu.93@gmail.com>\n"
 "Language-Team: Romanian\n"
 "Language: ro\n"
@@ -39,27 +39,30 @@ msgstr "  Setează obiectiv  (dezactivat)"
 msgid "%d%%"
 msgstr "%d%%"
 
-#: desktop_modules/module_currently.lua:435
-#: desktop_modules/module_new_books.lua:159
+#: desktop_modules/module_coverdeck.lua:571
+#: desktop_modules/module_currently.lua:529
+#: desktop_modules/module_new_books.lua:182
 #: desktop_modules/module_recent.lua:159
 msgid "%d%% Read"
 msgstr "%d%% citit"
 
-#: desktop_modules/module_currently.lua:511
+#: desktop_modules/module_currently.lua:605
 msgid "%s left"
 msgstr "%s rămas"
 
-#: desktop_modules/module_currently.lua:459
-#: desktop_modules/module_currently.lua:509
+#: desktop_modules/module_coverdeck.lua:576
+#: desktop_modules/module_currently.lua:553
+#: desktop_modules/module_currently.lua:603
 #: desktop_modules/module_reading_goals.lua:433
 msgid "%s read"
 msgstr "%s citit"
 
-#: desktop_modules/module_currently.lua:478
+#: desktop_modules/module_coverdeck.lua:582
+#: desktop_modules/module_currently.lua:572
 msgid "%s remaining"
 msgstr "%s rămas"
 
-#: sui_menu.lua:783
+#: sui_menu.lua:845
 msgid ""
 "A restart is required to apply the new bar size across all layouts.\n"
 "\n"
@@ -70,44 +73,48 @@ msgstr ""
 "\n"
 "Repornești acum?"
 
-#: sui_menu.lua:1944
+#: sui_menu.lua:2174
 msgid "About"
 msgstr "Despre"
 
-#: sui_menu.lua:1257 desktop_modules/module_quick_actions.lua:288
+#: desktop_modules/module_coverdeck.lua:750
+msgid "Above"
+msgstr "Deasupra"
+
+#: sui_menu.lua:1319 desktop_modules/module_quick_actions.lua:288
 msgid "Add at least 2 actions to arrange."
 msgstr "Adaugă cel puțin 2 acțiuni pentru a le putea aranja."
 
-#: desktop_modules/module_tbr.lua:277
+#: desktop_modules/module_tbr.lua:409
 msgid "Add at least 2 books to arrange."
 msgstr "Adaugă cel puțin 2 cărți pentru a le putea aranja."
 
-#: desktop_modules/module_reading_stats.lua:486
+#: desktop_modules/module_reading_stats.lua:485
 msgid "Add at least 2 stats to arrange."
 msgstr "Adaugă cel puțin 2 statistici pentru a le putea aranja."
 
-#: desktop_modules/module_tbr.lua:133
+#: desktop_modules/module_tbr.lua:265
 msgid "Add to To Be Read"
 msgstr "Adaugă la „De citit”"
 
-#: desktop_modules/module_reading_stats.lua:67
-msgid "All time — Books"
-msgstr "Din tot timpul — Cărți"
-
 #: desktop_modules/module_reading_stats.lua:66
+msgid "All time — Books"
+msgstr "Dintotdeauna — Cărți"
+
+#: desktop_modules/module_reading_stats.lua:65
 msgid "All time — Time"
-msgstr "Din tot timpul — Timp"
+msgstr "Dintotdeauna — Timp"
 
 #: desktop_modules/module_reading_goals.lua:607
 msgid "Annual Goal"
 msgstr "Obiectiv anual"
 
-#: sui_menu.lua:1167 desktop_modules/module_reading_goals.lua:353
+#: sui_menu.lua:1229 desktop_modules/module_reading_goals.lua:353
 msgid "Annual Reading Goal"
 msgstr "Obiectiv anual de citit"
 
-#: sui_config.lua:1560 sui_config.lua:1641 sui_menu.lua:703 sui_menu.lua:773
-#: sui_menu.lua:1485 sui_menu.lua:1520 sui_menu.lua:1632
+#: sui_config.lua:1626 sui_config.lua:1707 sui_menu.lua:765 sui_menu.lua:835
+#: sui_menu.lua:1736 sui_menu.lua:1771
 msgid "Apply"
 msgstr "Aplică"
 
@@ -115,43 +122,48 @@ msgstr "Aplică"
 msgid "April"
 msgstr "aprilie"
 
-#: desktop_modules/module_reading_stats.lua:483
+#: desktop_modules/module_reading_stats.lua:482
 msgid "Arrange"
 msgstr "Aranjează"
 
-#: sui_menu.lua:1261 desktop_modules/module_quick_actions.lua:300
+#: sui_menu.lua:1323 desktop_modules/module_quick_actions.lua:300
 msgid "Arrange %s"
 msgstr "Aranjează %s"
 
-#: sui_menu.lua:983 sui_menu.lua:1034 sui_menu.lua:1049
+#: sui_menu.lua:1045 sui_menu.lua:1096 sui_menu.lua:1111
 msgid "Arrange Buttons"
 msgstr "Aranjează butoanele"
 
-#: desktop_modules/module_collections.lua:538
-#: desktop_modules/module_collections.lua:551
+#: desktop_modules/module_collections.lua:622
+#: desktop_modules/module_collections.lua:635
 msgid "Arrange Collections"
 msgstr "Aranjează colecțiile"
 
-#: sui_menu.lua:593 sui_menu.lua:621 sui_menu.lua:1251
-#: desktop_modules/module_currently.lua:715
-#: desktop_modules/module_currently.lua:739
+#: sui_menu.lua:600 sui_menu.lua:629 sui_menu.lua:1313
+#: desktop_modules/module_currently.lua:863
+#: desktop_modules/module_currently.lua:887
 #: desktop_modules/module_quick_actions.lua:279
 msgid "Arrange Items"
 msgstr "Aranjează elementele"
 
-#: sui_menu.lua:1417 sui_menu.lua:1433
+#: sui_menu.lua:1578
 msgid "Arrange Modules"
 msgstr "Aranjează modulele"
 
-#: desktop_modules/module_reading_stats.lua:492
+#: desktop_modules/module_reading_stats.lua:491
 msgid "Arrange Reading Stats"
 msgstr "Aranjează statisticile de citit"
 
-#: desktop_modules/module_tbr.lua:270 desktop_modules/module_tbr.lua:289
+#: desktop_modules/module_coverdeck.lua:774
+#: desktop_modules/module_coverdeck.lua:787
+msgid "Arrange Statistics"
+msgstr "Aranjează statisticile"
+
+#: desktop_modules/module_tbr.lua:402 desktop_modules/module_tbr.lua:421
 msgid "Arrange To Be Read list"
 msgstr "Aranjează lista de citit"
 
-#: sui_menu.lua:194 sui_menu.lua:204
+#: sui_menu.lua:195 sui_menu.lua:205
 msgid "Arrange tabs"
 msgstr "Aranjează filele"
 
@@ -159,16 +171,16 @@ msgstr "Aranjează filele"
 msgid "August"
 msgstr "august"
 
-#: desktop_modules/module_currently.lua:265
+#: desktop_modules/module_currently.lua:266
 msgid "Author"
 msgstr "Autor"
 
-#: sui_menu.lua:1960
+#: sui_menu.lua:2190
 msgid "Author: %s"
 msgstr "Autor: %s"
 
-#: sui_foldercovers.lua:508 sui_foldercovers.lua:573
-#: desktop_modules/module_collections.lua:499
+#: sui_foldercovers.lua:540 sui_foldercovers.lua:605
+#: desktop_modules/module_collections.lua:583
 msgid "Auto (first book)"
 msgstr "Auto (prima carte)"
 
@@ -176,17 +188,21 @@ msgstr "Auto (prima carte)"
 msgid "Back"
 msgstr "Înapoi"
 
-#: desktop_modules/module_collections.lua:578
+#: desktop_modules/module_collections.lua:662
 msgid "Badge position: Bottom"
 msgstr "Poziția insignei: jos"
 
-#: desktop_modules/module_collections.lua:579
+#: desktop_modules/module_collections.lua:663
 msgid "Badge position: Top"
 msgstr "Poziția insignei: sus"
 
 #: sui_config.lua:162
 msgid "Battery"
 msgstr "Baterie"
+
+#: desktop_modules/module_coverdeck.lua:758
+msgid "Below"
+msgstr "Dedesubt"
 
 #: sui_quickactions.lua:569
 msgid "Book Info"
@@ -202,39 +218,39 @@ msgstr "Navigatorul de semne de carte nu este disponibil."
 
 #: sui_config.lua:137
 msgid "Bookmarks"
-msgstr "Semne de carte"
+msgstr "Marcaje"
 
 #: desktop_modules/module_reading_goals.lua:354
 msgid "Books to read in %s:"
 msgstr "Cărți de citit în %s:"
 
-#: sui_menu.lua:1724 sui_menu.lua:1818 sui_menu.lua:1880
+#: sui_menu.lua:1941 sui_menu.lua:2036 sui_menu.lua:2098
 msgid "Bottom"
-msgstr "Subsol"
+msgstr "Zona inferioară"
 
-#: sui_bottombar.lua:843 sui_menu.lua:740
+#: sui_bottombar.lua:843 sui_menu.lua:802
 msgid "Bottom Bar"
-msgstr "Bara din subsol"
+msgstr "Bara de jos"
 
-#: sui_menu.lua:766
+#: sui_menu.lua:828
 msgid "Bottom Bar Size"
-msgstr "Mărime bară din subsol"
+msgstr "Mărime bară de jos"
 
-#: sui_menu.lua:748
+#: sui_menu.lua:810
 msgid ""
 "Bottom Bar will be %s after restart.\n"
 "\n"
 "Restart now?"
 msgstr ""
-"Bara din subsol va fi %s după repornire.\n"
+"Bara de jos va fi %s după repornire.\n"
 "\n"
 "Repornești acum?"
 
-#: sui_menu.lua:799 sui_menu.lua:802
+#: sui_menu.lua:861 sui_menu.lua:864
 msgid "Bottom Margin"
 msgstr "Marginea de jos"
 
-#: sui_menu.lua:800
+#: sui_menu.lua:862
 msgid "Bottom Margin — %d%%"
 msgstr "Marginea de jos — %d%%"
 
@@ -242,30 +258,30 @@ msgstr "Marginea de jos — %d%%"
 msgid "Brightness"
 msgstr "Luminozitate"
 
-#: sui_menu.lua:1099
+#: sui_menu.lua:1161
 msgid "Button Size"
 msgstr "Mărime buton"
 
-#: sui_bottombar.lua:1060 sui_bottombar.lua:1745 sui_config.lua:1561
-#: sui_config.lua:1642 sui_foldercovers.lua:537 sui_foldercovers.lua:604
-#: sui_menu.lua:704 sui_menu.lua:774 sui_menu.lua:1486 sui_menu.lua:1521
-#: sui_menu.lua:1633 sui_quickactions.lua:358 sui_quickactions.lua:444
+#: sui_bottombar.lua:1060 sui_bottombar.lua:1745 sui_config.lua:1627
+#: sui_config.lua:1708 sui_foldercovers.lua:569 sui_foldercovers.lua:636
+#: sui_menu.lua:562 sui_menu.lua:766 sui_menu.lua:836 sui_menu.lua:1737
+#: sui_menu.lua:1772 sui_quickactions.lua:358 sui_quickactions.lua:444
 #: sui_quickactions.lua:552 sui_quickactions.lua:756 sui_quickactions.lua:827
 #: sui_quickactions.lua:855 sui_quickactions.lua:883 sui_quickactions.lua:899
-#: sui_quickactions.lua:1011 sui_quickactions.lua:1153 sui_updater.lua:316
-#: sui_updater.lua:337 desktop_modules/module_collections.lua:525
-#: desktop_modules/module_quote.lua:952
+#: sui_quickactions.lua:1011 sui_quickactions.lua:1153 sui_updater.lua:421
+#: sui_updater.lua:438 desktop_modules/module_collections.lua:609
+#: desktop_modules/module_quote.lua:959
 #: desktop_modules/module_reading_goals.lua:357
 #: desktop_modules/module_reading_goals.lua:373
 #: desktop_modules/module_reading_goals.lua:390
 msgid "Cancel"
 msgstr "Anulează"
 
-#: desktop_modules/module_reading_stats.lua:434
+#: desktop_modules/module_reading_stats.lua:433
 msgid "Cards"
 msgstr "Carduri"
 
-#: sui_menu.lua:608 sui_menu.lua:1872
+#: sui_menu.lua:616 sui_menu.lua:2090
 msgid "Center"
 msgstr "Centru"
 
@@ -273,13 +289,13 @@ msgstr "Centru"
 msgid "Change Icons"
 msgstr "Schimbă pictogramele"
 
-#: sui_menu.lua:1965
+#: sui_menu.lua:2195
 msgid "Check for Updates"
 msgstr "Verifică pentru actualizări"
 
-#: sui_updater.lua:272
-msgid "Checking for updates..."
-msgstr "Se verifică pentru actualizări..."
+#: sui_updater.lua:460
+msgid "Checking for updates…"
+msgstr "Se verifică pentru actualizări…"
 
 #: sui_config.lua:159 desktop_modules/module_clock.lua:227
 msgid "Clock"
@@ -297,8 +313,8 @@ msgstr "Codul se află în afara intervalului Unicode valid (0–10FFFF)."
 msgid "Collection"
 msgstr "Colecție"
 
-#: desktop_modules/module_collections.lua:486
-#: desktop_modules/module_collections.lua:492
+#: desktop_modules/module_collections.lua:570
+#: desktop_modules/module_collections.lua:576
 msgid "Collection is empty."
 msgstr "Colecția este goală."
 
@@ -307,18 +323,22 @@ msgid "Collection not available: %s"
 msgstr "Colecția nu este disponibilă: %s"
 
 #: sui_bottombar.lua:1046 sui_config.lua:133 sui_quickactions.lua:571
-#: desktop_modules/module_collections.lua:291
-#: desktop_modules/module_collections.lua:292
-#: desktop_modules/module_collections.lua:311
-#: desktop_modules/module_collections.lua:536
+#: desktop_modules/module_collections.lua:298
+#: desktop_modules/module_collections.lua:299
+#: desktop_modules/module_collections.lua:318
+#: desktop_modules/module_collections.lua:620
 msgid "Collections"
 msgstr "Colecții"
+
+#: sui_patches.lua:906
+msgid "Collections (%1)"
+msgstr "Colecții (%1)"
 
 #: sui_bottombar.lua:1323
 msgid "Collections not available."
 msgstr "Colecțiile nu sunt disponibile."
 
-#: sui_menu.lua:1103 desktop_modules/module_currently.lua:816
+#: sui_menu.lua:1165 desktop_modules/module_currently.lua:964
 #: desktop_modules/module_reading_goals.lua:594
 msgid "Compact"
 msgstr "Compact"
@@ -331,20 +351,22 @@ msgstr "Confirmă"
 msgid "Continue"
 msgstr "Continuă"
 
-#: sui_updater.lua:295
-msgid "Could not retrieve version information."
-msgstr "Nu s-a putut prelua informația de versiune."
+#: desktop_modules/module_coverdeck.lua:325
+msgid "Cover Deck"
+msgstr "Pachet de coperți"
 
-#: desktop_modules/module_collections.lua:529
+#: desktop_modules/module_collections.lua:613
 msgid "Cover for \"%s\""
 msgstr "Copertă pentru „%s”"
 
-#: desktop_modules/module_collections.lua:567
-#: desktop_modules/module_collections.lua:569
-#: desktop_modules/module_currently.lua:663
-#: desktop_modules/module_currently.lua:665
-#: desktop_modules/module_new_books.lua:236
-#: desktop_modules/module_new_books.lua:238
+#: desktop_modules/module_collections.lua:651
+#: desktop_modules/module_collections.lua:653
+#: desktop_modules/module_coverdeck.lua:707
+#: desktop_modules/module_coverdeck.lua:708
+#: desktop_modules/module_currently.lua:811
+#: desktop_modules/module_currently.lua:813
+#: desktop_modules/module_new_books.lua:260
+#: desktop_modules/module_new_books.lua:262
 #: desktop_modules/module_recent.lua:256 desktop_modules/module_recent.lua:258
 msgid "Cover size"
 msgstr "Mărime copertă"
@@ -353,22 +375,26 @@ msgstr "Mărime copertă"
 msgid "Create Quick Action"
 msgstr "Creează o acțiune rapidă"
 
-#: sui_config.lua:1669 desktop_modules/module_currently.lua:295
-#: desktop_modules/module_currently.lua:296
-#: desktop_modules/module_currently.lua:310
-#: desktop_modules/module_currently.lua:833
+#: sui_config.lua:1735 desktop_modules/module_currently.lua:296
+#: desktop_modules/module_currently.lua:297
+#: desktop_modules/module_currently.lua:402
+#: desktop_modules/module_currently.lua:981
 msgid "Currently Reading"
 msgstr "Carte în curs"
 
-#: sui_config.lua:525
+#: sui_config.lua:555
 msgid "Custom"
 msgstr "Personalizat"
 
-#: sui_menu.lua:1076
+#: sui_config.lua:165 sui_menu.lua:554
+msgid "Custom Text"
+msgstr "Text personalizat"
+
+#: sui_menu.lua:1138
 msgid "Custom Title Bar"
 msgstr "Bară de titlu personalizată"
 
-#: sui_menu.lua:1087
+#: sui_menu.lua:1149
 msgid ""
 "Custom Title Bar will be %s after restart.\n"
 "\n"
@@ -386,15 +412,16 @@ msgstr "Obiectiv zilnic"
 msgid "Daily Reading Goal"
 msgstr "Obiectiv zilnic de citit"
 
-#: desktop_modules/module_reading_stats.lua:65
+#: desktop_modules/module_reading_stats.lua:64
 msgid "Daily avg — Pages"
 msgstr "Media zilnică — Pagini"
 
-#: desktop_modules/module_reading_stats.lua:64
+#: desktop_modules/module_reading_stats.lua:63
 msgid "Daily avg — Time"
 msgstr "Media zilnică — Timp"
 
-#: desktop_modules/module_currently.lua:268
+#: desktop_modules/module_coverdeck.lua:76
+#: desktop_modules/module_currently.lua:269
 msgid "Days of reading"
 msgstr "Zile de citire"
 
@@ -402,10 +429,10 @@ msgstr "Zile de citire"
 msgid "December"
 msgstr "decembrie"
 
-#: sui_menu.lua:352 sui_menu.lua:481 sui_menu.lua:1104 sui_quickactions.lua:512
-#: desktop_modules/module_currently.lua:806
-#: desktop_modules/module_quick_actions.lua:402
-#: desktop_modules/module_quick_actions.lua:407
+#: sui_menu.lua:352 sui_menu.lua:481 sui_menu.lua:1166 sui_quickactions.lua:512
+#: desktop_modules/module_currently.lua:954
+#: desktop_modules/module_quick_actions.lua:401
+#: desktop_modules/module_quick_actions.lua:406
 #: desktop_modules/module_reading_goals.lua:586
 msgid "Default"
 msgstr "Implicit"
@@ -422,7 +449,7 @@ msgstr "Implicit (plugin)"
 msgid "Default (System)"
 msgstr "Implicit (sistem)"
 
-#: desktop_modules/module_quote.lua:1040
+#: desktop_modules/module_quote.lua:1042
 msgid "Default Quotes"
 msgstr "Citate implicite"
 
@@ -438,17 +465,17 @@ msgstr "Ștergi acțiunea rapidă „%s”?"
 msgid "Dictionary Lookup"
 msgstr "Căutare în dicționar"
 
-#: sui_menu.lua:1168
+#: sui_menu.lua:1230
 msgid "Digital Goal  (%s)"
 msgstr "Obiectiv digital  (%s)"
 
-#: sui_menu.lua:1505
+#: sui_menu.lua:1756
 msgid "Disable \"Lock Scale\" first to set a custom label scale."
 msgstr ""
 "Dezactivează mai întâi „Blochează scalarea” pentru a seta o scalare pentru "
 "etichete."
 
-#: sui_config.lua:1545
+#: sui_config.lua:1611
 msgid "Disable \"Lock Scale\" first to set a per-module scale."
 msgstr ""
 "Dezactivează mai întâi „Blochează scalarea” pentru a seta o scalare per "
@@ -464,31 +491,31 @@ msgstr "Dispecerul nu este disponibil."
 
 #: sui_menu.lua:389
 msgid "Dot Pager"
-msgstr "Paginare cu punct"
+msgstr "Paginare cu puncte"
 
-#: sui_updater.lua:336
+#: sui_updater.lua:437
 msgid "Download and install"
 msgstr "Descarcă și instalează"
 
-#: sui_updater.lua:228
+#: sui_updater.lua:348
 msgid "Download error: "
 msgstr "Eroare descărcare: "
 
-#: sui_updater.lua:222
-msgid "Downloading Simple UI "
-msgstr "Se descarcă Simple UI "
+#: sui_updater.lua:323
+msgid "Downloading Simple UI %s…"
+msgstr "Se descarcă Simple UI %s…"
 
 #: sui_quickactions.lua:1137
 msgid "Edit"
 msgstr "Editează"
 
+#: sui_menu.lua:546 sui_menu.lua:548
+msgid "Edit Custom Text"
+msgstr "Editează text personalizat"
+
 #: sui_quickactions.lua:702
 msgid "Edit Quick Action"
 msgstr "Editează acțiunile rapide"
-
-#: sui_menu.lua:1429
-msgid "Enable at least 2 modules to arrange."
-msgstr "Activează cel puțin 2 module pentru a le aranja."
 
 #: sui_quickactions.lua:441
 msgid ""
@@ -502,15 +529,19 @@ msgstr ""
 "  /koreader/fonts/nerdfonts/symbols.ttf\n"
 "Lasă spațiul gol și apasă OK pentru a șterge pictograma Nerd Fonts."
 
-#: sui_updater.lua:279
+#: sui_updater.lua:466
+msgid "Error checking for updates."
+msgstr "Eroare la verificarea pentru actualizări."
+
+#: sui_updater.lua:471
 msgid "Error checking for updates: "
-msgstr "Eroare la verificarea pentru actualizări:"
+msgstr "Eroare la verificarea pentru actualizări: "
 
 #: sui_menu.lua:457
 msgid "Extra Small"
 msgstr "Extra mic"
 
-#: sui_updater.lua:239
+#: sui_updater.lua:350
 msgid "Extraction error: "
 msgstr "Eroare extracție: "
 
@@ -534,9 +565,9 @@ msgstr "Se preiau semnele de carte…"
 msgid "File Search"
 msgstr "Căutare de fișiere"
 
-#: desktop_modules/module_quick_actions.lua:402
-#: desktop_modules/module_quick_actions.lua:416
-#: desktop_modules/module_reading_stats.lua:444
+#: desktop_modules/module_quick_actions.lua:401
+#: desktop_modules/module_quick_actions.lua:415
+#: desktop_modules/module_reading_stats.lua:443
 msgid "Flat"
 msgstr "Plat"
 
@@ -544,19 +575,23 @@ msgstr "Plat"
 msgid "Folder"
 msgstr "Dosar"
 
-#: sui_menu.lua:1762
+#: sui_menu.lua:1979
 msgid "Folder Covers"
 msgstr "Coperți dosare"
 
-#: sui_menu.lua:1840
+#: sui_menu.lua:2058
 msgid "Folder Name"
 msgstr "Nume dosar"
+
+#: sui_menu.lua:2110
+msgid "Folder Name Text Size"
+msgstr "Mărime text nume dosar"
 
 #: sui_quickactions.lua:573
 msgid "Folder Shortcuts"
 msgstr "Scurtături dosare"
 
-#: sui_foldercovers.lua:609
+#: sui_foldercovers.lua:641
 msgid "Folder cover"
 msgstr "Copertă dosar"
 
@@ -572,7 +607,7 @@ msgstr "Iluminarea nu este disponibilă pe acest dispozitiv."
 msgid "General"
 msgstr "General"
 
-#: sui_menu.lua:1479
+#: sui_menu.lua:1730
 msgid ""
 "Global scale for all modules.\n"
 "Individual overrides in Module Settings take precedence.\n"
@@ -582,32 +617,32 @@ msgstr ""
 "Setările individuale din „Setări module” au prioritate.\n"
 "Dimensiunea implicită este 100%."
 
-#: sui_menu.lua:1782
+#: sui_menu.lua:1999
 msgid "Group Books by Series"
 msgstr "Grupează cărțile după serie"
 
-#: sui_menu.lua:767
+#: sui_menu.lua:829
 msgid ""
 "Height of the bottom navigation bar.\n"
 "100% is the default size."
 msgstr ""
-"Înălțimea barei de navigare din subsol.\n"
+"Înălțimea barei de navigare de jos.\n"
 "Înălțimea implicită este 100%."
 
-#: sui_menu.lua:697
+#: sui_menu.lua:759
 msgid ""
 "Height of the top status bar.\n"
 "100% is the default size."
 msgstr ""
-"Înălțimea barei de stare din antet.\n"
+"Înălțimea barei de stare de sus.\n"
 "Înălțimea implicită este 100%."
 
-#: sui_menu.lua:373 sui_menu.lua:432 sui_menu.lua:859 sui_menu.lua:1799
-#: sui_menu.lua:1843
+#: sui_menu.lua:373 sui_menu.lua:432 sui_menu.lua:921 sui_menu.lua:2017
+#: sui_menu.lua:2061
 msgid "Hidden"
 msgstr "Ascuns"
 
-#: sui_menu.lua:1285 desktop_modules/module_quick_actions.lua:330
+#: sui_menu.lua:1346 desktop_modules/module_quick_actions.lua:329
 msgid "Hide Text"
 msgstr "Ascunde textul"
 
@@ -615,7 +650,7 @@ msgstr "Ascunde textul"
 msgid "Hide Wi-Fi icon when off"
 msgstr "Ascunde pictograma Wi-Fi când este oprit"
 
-#: sui_menu.lua:1902
+#: sui_menu.lua:2132
 msgid "Hide selection underline"
 msgstr "Ascunde sublinierea selecției"
 
@@ -639,8 +674,8 @@ msgstr "Istoricul nu este disponibil."
 msgid "Home"
 msgstr "Acasă"
 
-#: sui_menu.lua:386 sui_menu.lua:1570 sui_menu.lua:1722 sui_patches.lua:521
-#: sui_patches.lua:525 sui_patches.lua:538
+#: sui_menu.lua:386 sui_menu.lua:1821 sui_menu.lua:1939 sui_patches.lua:503
+#: sui_patches.lua:526
 msgid "Home Screen"
 msgstr "Ecranul Acasă"
 
@@ -652,7 +687,7 @@ msgstr "Dosarul Acasă"
 msgid "Home folder + subfolders"
 msgstr "Dosarul Acasă + subdosare"
 
-#: sui_homescreen.lua:983
+#: sui_homescreen.lua:1041
 msgid "Homescreen"
 msgstr "Ecranul Acasă"
 
@@ -664,11 +699,11 @@ msgstr "Ecranul Acasă nu este disponibil."
 msgid "Icon"
 msgstr "Pictogramă"
 
-#: sui_menu.lua:821 sui_menu.lua:824
+#: sui_menu.lua:883 sui_menu.lua:886
 msgid "Icon Size"
 msgstr "Mărime pictograme"
 
-#: sui_menu.lua:822
+#: sui_menu.lua:884
 msgid "Icon Size — %d%%"
 msgstr "Mărime pictograme — %d%%"
 
@@ -676,15 +711,15 @@ msgstr "Mărime pictograme — %d%%"
 msgid "Icon: Default"
 msgstr "Pictogramă: Implicit"
 
-#: sui_menu.lua:102
+#: sui_menu.lua:103
 msgid "Icons"
 msgstr "Pictograme"
 
-#: sui_menu.lua:103
+#: sui_menu.lua:104
 msgid "Icons only"
 msgstr "Doar pictograme"
 
-#: sui_menu.lua:996
+#: sui_menu.lua:1058
 msgid ""
 "Invalid arrangement.\n"
 "Keep items between the Left and Right separators."
@@ -692,7 +727,7 @@ msgstr ""
 "Aranjament invalid.\n"
 "Păstrează elementele între separatoarele stânga și dreapta."
 
-#: sui_menu.lua:635
+#: sui_menu.lua:643
 msgid ""
 "Invalid arrangement.\n"
 "Keep the Left, Center and Right separators in order."
@@ -704,8 +739,9 @@ msgstr ""
 msgid "Invalid input. Please enter 1–6 hexadecimal digits (0–9, A–F)."
 msgstr "Intrare invalidă. Introdu 1–6 cifre hexazecimale (0–9, A–F)."
 
-#: sui_menu.lua:716 sui_menu.lua:1295 desktop_modules/module_currently.lua:835
-#: desktop_modules/module_quick_actions.lua:340
+#: sui_menu.lua:778 sui_menu.lua:1356 desktop_modules/module_coverdeck.lua:769
+#: desktop_modules/module_currently.lua:983
+#: desktop_modules/module_quick_actions.lua:339
 msgid "Items"
 msgstr "Elemente"
 
@@ -725,48 +761,48 @@ msgstr "iunie"
 msgid "KOReader"
 msgstr "KOReader"
 
-#: sui_menu.lua:1513
+#: sui_menu.lua:1764
 msgid "Label Scale"
 msgstr "Scalare etichete"
 
-#: sui_menu.lua:841 sui_menu.lua:844
+#: sui_menu.lua:903 sui_menu.lua:906
 msgid "Label Size"
 msgstr "Mărime etichete"
 
-#: sui_menu.lua:842
+#: sui_menu.lua:904
 msgid "Label Size — %d%%"
 msgstr "Mărime etichete — %d%%"
 
-#: sui_menu.lua:1498
+#: sui_menu.lua:1749
 msgid "Labels"
 msgstr "Etichete"
 
-#: sui_menu.lua:1105
+#: sui_menu.lua:1167
 msgid "Large"
 msgstr "Mare"
 
-#: sui_menu.lua:337 sui_menu.lua:680 sui_menu.lua:749 sui_menu.lua:785
-#: sui_menu.lua:1091 sui_menu.lua:1703 sui_updater.lua:249
+#: sui_menu.lua:337 sui_menu.lua:742 sui_menu.lua:811 sui_menu.lua:847
+#: sui_menu.lua:1153 sui_menu.lua:1920 sui_updater.lua:361
 msgid "Later"
 msgstr "Mai târziu"
 
-#: sui_menu.lua:602 sui_menu.lua:966
+#: sui_menu.lua:610 sui_menu.lua:1028
 msgid "Left"
 msgstr "Stânga"
 
-#: sui_config.lua:131 sui_config.lua:373 sui_menu.lua:1743 sui_titlebar.lua:666
+#: sui_config.lua:131 sui_config.lua:403 sui_menu.lua:1960 sui_titlebar.lua:720
 msgid "Library"
 msgstr "Bibliotecă"
 
-#: sui_menu.lua:1109
+#: sui_menu.lua:1171
 msgid "Library Buttons"
 msgstr "Butoane bibliotecă"
 
-#: desktop_modules/module_reading_stats.lua:454
+#: desktop_modules/module_reading_stats.lua:453
 msgid "List"
 msgstr "Listă"
 
-#: sui_menu.lua:1459
+#: sui_menu.lua:1710
 msgid "Lock Scale"
 msgstr "Blochează scalarea"
 
@@ -774,17 +810,9 @@ msgstr "Blochează scalarea"
 msgid "March"
 msgstr "martie"
 
-#: desktop_modules/module_collections.lua:619
+#: desktop_modules/module_collections.lua:709
 msgid "Maximum 5 collections. Remove one first."
 msgstr "Maxim 5 colecții. Șterge una mai întâi."
-
-#: sui_menu.lua:1627
-msgid ""
-"Maximum number of modules shown on each page.\n"
-"Swipe left/right on the Home Screen to turn pages."
-msgstr ""
-"Numărul maxim de module afișat pe fiecare pagină.\n"
-"Glisează stânga/dreapta pe ecranul Acasă pentru a întoarce paginile."
 
 #: desktop_modules/module_clock.lua:55
 msgid "May"
@@ -806,35 +834,27 @@ msgstr "Minim 2 file necesare. Alege mai întâi altă filă."
 msgid "Minutes per day:"
 msgstr "Minute pe zi:"
 
-#: sui_menu.lua:1476
+#: sui_menu.lua:1727
 msgid "Module Scale"
 msgstr "Scalare module"
 
-#: sui_menu.lua:1451
+#: sui_menu.lua:1702
 msgid "Module Settings"
 msgstr "Setări modul"
 
-#: sui_menu.lua:1470
+#: sui_menu.lua:1721
 msgid "Modules"
 msgstr "Module"
 
-#: sui_menu.lua:1412
+#: sui_menu.lua:1473
 msgid "Modules  (%d)"
 msgstr "Module  (%d)"
-
-#: sui_menu.lua:1626
-msgid "Modules per Page"
-msgstr "Module per pagină"
-
-#: sui_menu.lua:1620
-msgid "Modules per Page  (%d)"
-msgstr "Module per pagină  (%d)"
 
 #: desktop_modules/module_clock.lua:50
 msgid "Monday"
 msgstr "luni"
 
-#: desktop_modules/module_quote.lua:1060
+#: desktop_modules/module_quote.lua:1062
 msgid "My Highlights"
 msgstr "Evidențierile mele"
 
@@ -843,7 +863,7 @@ msgstr "Evidențierile mele"
 msgid "Name"
 msgstr "Nume"
 
-#: sui_menu.lua:1726
+#: sui_menu.lua:1943
 msgid "Navigation Bar"
 msgstr "Bara de navigare"
 
@@ -873,14 +893,14 @@ msgstr "Simbol Nerd Font…"
 msgid "Network manager unavailable."
 msgstr "Managerul de rețea nu este disponibil."
 
-#: desktop_modules/module_new_books.lua:157
+#: desktop_modules/module_new_books.lua:180
 msgid "New"
 msgstr "Nou"
 
 #: desktop_modules/module_new_books.lua:46
 #: desktop_modules/module_new_books.lua:47
 #: desktop_modules/module_new_books.lua:107
-#: desktop_modules/module_new_books.lua:256
+#: desktop_modules/module_new_books.lua:280
 msgid "New Books"
 msgstr "Cărți noi"
 
@@ -894,21 +914,31 @@ msgstr "Nume nou…"
 
 #: sui_bottombar.lua:293
 msgid "Next"
-msgstr "Următorul"
+msgstr "Urm."
+
+#: sui_updater.lua:419
+msgid ""
+"No automatic update file was found.\n"
+"\n"
+"Open the releases page on GitHub?"
+msgstr ""
+"Nu a fost găsit niciun fișier pentru actualizare automată.\n"
+"\n"
+"Deschizi pagina de release-uri pe GitHub?"
 
 #: sui_bottombar.lua:1395
 msgid "No book in history."
 msgstr "Nicio carte în istoric."
 
-#: sui_foldercovers.lua:562
+#: sui_foldercovers.lua:594
 msgid "No books found in this folder."
 msgstr "Nicio carte găsită în acest dosar."
 
-#: sui_foldercovers.lua:497
+#: sui_foldercovers.lua:529
 msgid "No books found in this series."
 msgstr "Nicio carte găsită în această serie."
 
-#: desktop_modules/module_tbr.lua:312
+#: desktop_modules/module_tbr.lua:455
 msgid "No books in To Be Read list."
 msgstr "Nicio carte în lista de citit."
 
@@ -916,11 +946,11 @@ msgstr "Nicio carte în lista de citit."
 msgid "No books opened yet"
 msgstr "Nicio carte deschisă încă"
 
-#: desktop_modules/module_collections.lua:589
+#: desktop_modules/module_collections.lua:673
 msgid "No collections found."
 msgstr "Nicio colecție găsită."
 
-#: desktop_modules/module_collections.lua:324
+#: desktop_modules/module_collections.lua:378
 msgid "No collections selected"
 msgstr "Nicio colecție selectată"
 
@@ -932,7 +962,7 @@ msgstr ""
 "Nu a fost configurat niciun dosar, colecție sau plugin.\n"
 "Accesează Simple UI → Setări → Acțiuni rapide pentru a seta una."
 
-#: desktop_modules/module_quote.lua:745
+#: desktop_modules/module_quote.lua:746
 msgid "No highlights found. Open a book and highlight some passages."
 msgstr ""
 "Nicio evidențiere găsită. Deschide o carte și evidențiează niște pasaje."
@@ -945,11 +975,11 @@ msgstr "Nicio pictogramă găsită în:"
 msgid "No plugins found."
 msgstr "Niciun plugin găsit."
 
-#: desktop_modules/module_quote.lua:711
+#: desktop_modules/module_quote.lua:712
 msgid "No quotes found."
 msgstr "Niciun citat găsit."
 
-#: desktop_modules/module_reading_stats.lua:287
+#: desktop_modules/module_reading_stats.lua:286
 msgid "No stats selected"
 msgstr "Nicio statistică selectată"
 
@@ -961,11 +991,11 @@ msgstr "Nicio acțiune de sistem găsită."
 msgid "November"
 msgstr "noiembrie"
 
-#: sui_menu.lua:1796
+#: sui_menu.lua:2014
 msgid "Number of Books in Folder"
 msgstr "Numărul de cărți din dosar"
 
-#: sui_menu.lua:1828
+#: sui_menu.lua:1478 sui_menu.lua:2046
 msgid "Number of Pages"
 msgstr "Numărul de pagini"
 
@@ -981,17 +1011,17 @@ msgstr "OK"
 msgid "October"
 msgstr "octombrie"
 
-#: sui_menu.lua:671 sui_menu.lua:740 sui_menu.lua:930 sui_menu.lua:1076
-#: sui_menu.lua:1570 sui_menu.lua:1685
+#: sui_menu.lua:733 sui_menu.lua:802 sui_menu.lua:992 sui_menu.lua:1138
+#: sui_menu.lua:1821 sui_menu.lua:1902
 msgid "Off"
 msgstr "Dezactivat"
 
-#: sui_menu.lua:671 sui_menu.lua:740 sui_menu.lua:930 sui_menu.lua:1076
-#: sui_menu.lua:1570 sui_menu.lua:1685
+#: sui_menu.lua:733 sui_menu.lua:802 sui_menu.lua:992 sui_menu.lua:1138
+#: sui_menu.lua:1821 sui_menu.lua:1902
 msgid "On"
 msgstr "Activat"
 
-#: sui_homescreen.lua:408 desktop_modules/module_quote.lua:951
+#: sui_homescreen.lua:420 desktop_modules/module_quote.lua:958
 msgid "Open"
 msgstr "Deschide"
 
@@ -999,23 +1029,23 @@ msgstr "Deschide"
 msgid "Open a book to get started"
 msgstr "Deschide o carte pentru a începe"
 
-#: sui_updater.lua:315
+#: sui_updater.lua:420
 msgid "Open in browser"
 msgstr "Deschide în navigator"
 
-#: sui_homescreen.lua:407 desktop_modules/module_quote.lua:950
+#: sui_homescreen.lua:419 desktop_modules/module_quote.lua:957
 msgid "Open this file?"
 msgstr "Deschizi această carte?"
 
-#: sui_menu.lua:1792
+#: sui_menu.lua:2010
 msgid "Overlays"
 msgstr "Overlay-uri"
 
-#: sui_homescreen.lua:1517 sui_patches.lua:1449
+#: sui_homescreen.lua:1611 sui_patches.lua:1567
 msgid "Page %1 of %2"
 msgstr "Pagina %1 din %2"
 
-#: sui_menu.lua:1727
+#: sui_menu.lua:1944
 msgid "Pagination Bar"
 msgstr "Bara de paginare"
 
@@ -1057,8 +1087,9 @@ msgstr "Selectorul de căi nu este disponibil."
 msgid "Percentage overlay on cover"
 msgstr "Overlay de procentaj pe copertă"
 
-#: desktop_modules/module_currently.lua:267
-#: desktop_modules/module_currently.lua:763
+#: desktop_modules/module_coverdeck.lua:75
+#: desktop_modules/module_currently.lua:268
+#: desktop_modules/module_currently.lua:911
 msgid "Percentage read"
 msgstr "Procentaj citit"
 
@@ -1074,7 +1105,7 @@ msgstr "Cărți fizice — %s"
 msgid "Physical books read this year:"
 msgstr "Cărți fizice citite anul acesta:"
 
-#: sui_menu.lua:1909
+#: sui_menu.lua:2139
 msgid "Placeholder cover for bookless folders"
 msgstr "Copertă implicită pentru dosarele fără cărți"
 
@@ -1096,30 +1127,30 @@ msgstr "Alimentare"
 
 #: sui_bottombar.lua:293
 msgid "Prev"
-msgstr "Anteriorul"
+msgstr "Ant."
 
-#: desktop_modules/module_currently.lua:266
+#: desktop_modules/module_currently.lua:267
 #: desktop_modules/module_recent.lua:284
 msgid "Progress bar"
 msgstr "Bara de progres"
 
-#: desktop_modules/module_currently.lua:775
+#: desktop_modules/module_currently.lua:923
 msgid "Progress bar style"
 msgstr "Stilul barei de progres"
 
-#: sui_menu.lua:1390 sui_menu.lua:1734
+#: sui_menu.lua:1451 sui_menu.lua:1951
 msgid "Quick Actions"
 msgstr "Acțiuni rapide"
 
-#: sui_menu.lua:1738
+#: sui_menu.lua:1955
 msgid "Quick Actions  (%d/%d — %d left)"
 msgstr "Acțiuni rapide  (%d/%d — %d rămase)"
 
-#: sui_menu.lua:1736
+#: sui_menu.lua:1953
 msgid "Quick Actions  (%d/%d — at limit)"
 msgstr "Acțiuni rapide  (%d/%d — la limită)"
 
-#: sui_menu.lua:1227 desktop_modules/module_quick_actions.lua:198
+#: sui_menu.lua:1289 desktop_modules/module_quick_actions.lua:198
 #: desktop_modules/module_quick_actions.lua:244
 msgid "Quick Actions %d"
 msgstr "Acțiuni rapide %d"
@@ -1128,11 +1159,11 @@ msgstr "Acțiuni rapide %d"
 msgid "Quit"
 msgstr "Ieșire"
 
-#: desktop_modules/module_quote.lua:821
+#: desktop_modules/module_quote.lua:822
 msgid "Quote of the Day"
 msgstr "Citatul zilei"
 
-#: desktop_modules/module_quote.lua:1082
+#: desktop_modules/module_quote.lua:1084
 msgid "Quotes + My Highlights"
 msgstr "Citate + Evidențierile mele"
 
@@ -1147,16 +1178,17 @@ msgstr "Utilizare RAM"
 msgid "Reading Goals"
 msgstr "Obiective citire"
 
-#: desktop_modules/module_reading_stats.lua:219
+#: desktop_modules/module_reading_stats.lua:218
 msgid "Reading Stats"
 msgstr "Statistici citire"
 
+#: desktop_modules/module_coverdeck.lua:728
 #: desktop_modules/module_recent.lua:62 desktop_modules/module_recent.lua:63
 #: desktop_modules/module_recent.lua:72 desktop_modules/module_recent.lua:281
 msgid "Recent Books"
 msgstr "Cărți recente"
 
-#: desktop_modules/module_tbr.lua:133
+#: desktop_modules/module_tbr.lua:265
 msgid "Remove from To Be Read"
 msgstr "Elimină din „De citit”"
 
@@ -1172,35 +1204,35 @@ msgid ""
 "With navpager active, as few as 1 tab and at most 4 tabs can be configured."
 msgstr ""
 "Înlocuiește bara de paginare cu săgețile „Anteriorul/Următorul” amplasate la "
-"marginile barei din subsol.\n"
+"marginile barei de jos.\n"
 "Săgețile se estompează atunci când nu există nicio pagină anterioară sau "
 "următoare.\n"
 "Când Navpager este activ, se pot configura între 1 și 4 file."
 
-#: sui_menu.lua:1541 sui_quickactions.lua:1015
+#: sui_menu.lua:1792 sui_quickactions.lua:1015
 msgid "Reset"
 msgstr "Resetează"
 
-#: sui_menu.lua:1540
+#: sui_menu.lua:1791
 msgid "Reset all scales to default (100%)? This cannot be undone."
 msgstr ""
 "Resetezi toate scalările la valoarea implicită (100%)? Această acțiune nu "
 "poate fi anulată."
 
-#: sui_menu.lua:1535
+#: sui_menu.lua:1786
 msgid "Reset to Default Scale"
 msgstr "Resetează la scalarea implicită"
 
-#: sui_bottombar.lua:1715 sui_menu.lua:337 sui_menu.lua:680 sui_menu.lua:749
-#: sui_menu.lua:784 sui_menu.lua:1090 sui_menu.lua:1703 sui_updater.lua:248
+#: sui_bottombar.lua:1715 sui_menu.lua:337 sui_menu.lua:742 sui_menu.lua:811
+#: sui_menu.lua:846 sui_menu.lua:1152 sui_menu.lua:1920 sui_updater.lua:360
 msgid "Restart"
-msgstr "Repornește"
+msgstr "Repornire"
 
-#: sui_menu.lua:1590
+#: sui_menu.lua:1841
 msgid "Return to Book Folder"
 msgstr "Întoarce-te la dosarul cărții"
 
-#: sui_menu.lua:614 sui_menu.lua:974
+#: sui_menu.lua:622 sui_menu.lua:1036
 msgid "Right"
 msgstr "Dreapta"
 
@@ -1215,27 +1247,29 @@ msgstr "sâmbătă"
 msgid "Save"
 msgstr "Salvează"
 
-#: sui_menu.lua:1455 desktop_modules/module_clock.lua:433
+#: sui_menu.lua:1706 desktop_modules/module_clock.lua:433
 #: desktop_modules/module_clock.lua:435
-#: desktop_modules/module_collections.lua:434
-#: desktop_modules/module_collections.lua:436
-#: desktop_modules/module_currently.lua:649
-#: desktop_modules/module_currently.lua:651
-#: desktop_modules/module_new_books.lua:222
-#: desktop_modules/module_new_books.lua:224
-#: desktop_modules/module_quick_actions.lua:381
-#: desktop_modules/module_quick_actions.lua:383
-#: desktop_modules/module_quote.lua:1002 desktop_modules/module_quote.lua:1006
+#: desktop_modules/module_collections.lua:500
+#: desktop_modules/module_collections.lua:502
+#: desktop_modules/module_coverdeck.lua:698
+#: desktop_modules/module_coverdeck.lua:700
+#: desktop_modules/module_currently.lua:797
+#: desktop_modules/module_currently.lua:799
+#: desktop_modules/module_new_books.lua:246
+#: desktop_modules/module_new_books.lua:248
+#: desktop_modules/module_quick_actions.lua:380
+#: desktop_modules/module_quick_actions.lua:382
+#: desktop_modules/module_quote.lua:1004 desktop_modules/module_quote.lua:1008
 #: desktop_modules/module_reading_goals.lua:566
 #: desktop_modules/module_reading_goals.lua:568
-#: desktop_modules/module_reading_stats.lua:390
-#: desktop_modules/module_reading_stats.lua:392
+#: desktop_modules/module_reading_stats.lua:389
+#: desktop_modules/module_reading_stats.lua:391
 #: desktop_modules/module_recent.lua:242 desktop_modules/module_recent.lua:244
-#: desktop_modules/module_tbr.lua:230 desktop_modules/module_tbr.lua:232
+#: desktop_modules/module_tbr.lua:362 desktop_modules/module_tbr.lua:364
 msgid "Scale"
 msgstr "Scalare"
 
-#: desktop_modules/module_currently.lua:679
+#: desktop_modules/module_currently.lua:827
 msgid ""
 "Scale for all text elements (title, author, progress, time).\n"
 "100% is the default size."
@@ -1243,7 +1277,7 @@ msgstr ""
 "Scalare pentru toate elementele text (titlu, autor, progres, timp).\n"
 "Mărimea implicită este 100%."
 
-#: desktop_modules/module_quick_actions.lua:395
+#: desktop_modules/module_quick_actions.lua:394
 msgid ""
 "Scale for the button label text.\n"
 "100% is the default size."
@@ -1251,7 +1285,7 @@ msgstr ""
 "Scalare pentru eticheta butoanelor.\n"
 "Mărimea implicită este 100%."
 
-#: desktop_modules/module_collections.lua:450
+#: desktop_modules/module_collections.lua:516
 msgid ""
 "Scale for the collection name text.\n"
 "100% is the default size."
@@ -1259,7 +1293,7 @@ msgstr ""
 "Scalare pentru textul numelui colecției.\n"
 "Mărimea implicită este 100%."
 
-#: desktop_modules/module_collections.lua:570
+#: desktop_modules/module_collections.lua:654
 msgid ""
 "Scale for the collection thumbnails only.\n"
 "The label text follows the module scale.\n"
@@ -1269,7 +1303,7 @@ msgstr ""
 "Textul etichetei urmează scalarea modulului.\n"
 "Mărimea implicită este 100%."
 
-#: desktop_modules/module_currently.lua:666
+#: desktop_modules/module_currently.lua:814
 msgid ""
 "Scale for the cover thumbnail only.\n"
 "100% is the default size."
@@ -1277,7 +1311,15 @@ msgstr ""
 "Scalare doar pentru miniatura coperții.\n"
 "Mărimea implicită este 100%."
 
-#: desktop_modules/module_new_books.lua:239
+#: desktop_modules/module_coverdeck.lua:709
+msgid ""
+"Scale for the cover thumbnails only.\n"
+"100% is the default size."
+msgstr ""
+"Scalare doar pentru miniaturile coperților.\n"
+"Mărimea implicită este 100%."
+
+#: desktop_modules/module_new_books.lua:263
 #: desktop_modules/module_recent.lua:259
 msgid ""
 "Scale for the cover thumbnails only.\n"
@@ -1288,7 +1330,15 @@ msgstr ""
 "Textul și bara de progres folosesc aceeași scalare ca modulul\n"
 "Mărimea implicită este 100%."
 
-#: desktop_modules/module_new_books.lua:251
+#: sui_menu.lua:2111
+msgid ""
+"Scale for the folder name overlay text.\n"
+"100% is the default size."
+msgstr ""
+"Scalare pentru textul suprapus cu numele dosarului.\n"
+"Mărimea implicită este 100%."
+
+#: desktop_modules/module_new_books.lua:275
 msgid ""
 "Scale for the label text.\n"
 "100% is the default size."
@@ -1304,15 +1354,19 @@ msgstr ""
 "Scalare pentru textul de procentaj citit.\n"
 "Mărimea implicită este 100%."
 
+#: desktop_modules/module_coverdeck.lua:701
+msgid "Scale for this module."
+msgstr "Scalare pentru acest modul."
+
 #: desktop_modules/module_clock.lua:436
-#: desktop_modules/module_collections.lua:437
-#: desktop_modules/module_currently.lua:652
-#: desktop_modules/module_new_books.lua:225
-#: desktop_modules/module_quick_actions.lua:384
-#: desktop_modules/module_quote.lua:1008
+#: desktop_modules/module_collections.lua:503
+#: desktop_modules/module_currently.lua:800
+#: desktop_modules/module_new_books.lua:249
+#: desktop_modules/module_quick_actions.lua:383
+#: desktop_modules/module_quote.lua:1010
 #: desktop_modules/module_reading_goals.lua:569
-#: desktop_modules/module_reading_stats.lua:393
-#: desktop_modules/module_recent.lua:245 desktop_modules/module_tbr.lua:233
+#: desktop_modules/module_reading_stats.lua:392
+#: desktop_modules/module_recent.lua:245 desktop_modules/module_tbr.lua:365
 msgid ""
 "Scale for this module.\n"
 "100% is the default size."
@@ -1320,7 +1374,15 @@ msgstr ""
 "Scalare pentru acest modul.\n"
 "Mărimea implicită este 100%."
 
-#: sui_menu.lua:1478
+#: desktop_modules/module_coverdeck.lua:717
+msgid ""
+"Scale for title and statistics text.\n"
+"100% is the default size."
+msgstr ""
+"Scalare pentru textul titlului și statisticilor.\n"
+"Mărimea implicită este 100%."
+
+#: sui_menu.lua:1729
 msgid ""
 "Scales all modules and labels together.\n"
 "100% is the default size."
@@ -1328,7 +1390,7 @@ msgstr ""
 "Scalează toate modulele și etichetele împreună.\n"
 "Mărimea implicită este 100%."
 
-#: sui_menu.lua:1514
+#: sui_menu.lua:1765
 msgid ""
 "Scales the section label text above each module.\n"
 "100% is the default size."
@@ -1336,7 +1398,7 @@ msgstr ""
 "Scalează textul etichetei de secțiune de deasupra fiecărui modul.\n"
 "Mărimea implicită este 100%."
 
-#: sui_menu.lua:1924
+#: sui_menu.lua:2154
 msgid "Scan subfolders for cover"
 msgstr "Scanează subdosarele pentru copertă"
 
@@ -1344,7 +1406,7 @@ msgstr "Scanează subdosarele pentru copertă"
 msgid "Search"
 msgstr "Caută"
 
-#: desktop_modules/module_collections.lua:543
+#: desktop_modules/module_collections.lua:627
 msgid "Select at least 2 collections to arrange."
 msgstr "Selectează cel puțin 2 colecții pentru a le aranja."
 
@@ -1352,27 +1414,31 @@ msgstr "Selectează cel puțin 2 colecții pentru a le aranja."
 msgid "September"
 msgstr "septembrie"
 
-#: sui_menu.lua:1834
+#: sui_menu.lua:2052
 msgid "Series Index"
 msgstr "Index serie"
 
-#: sui_foldercovers.lua:542
+#: sui_foldercovers.lua:574
 msgid "Series cover"
 msgstr "Copertă serie"
 
-#: sui_foldercovers.lua:632
+#: sui_menu.lua:567
+msgid "Set"
+msgstr "Setează"
+
+#: sui_foldercovers.lua:664
 msgid "Set folder cover…"
 msgstr "Setează copertă dosar…"
 
-#: sui_foldercovers.lua:632
+#: sui_foldercovers.lua:664
 msgid "Set series cover…"
 msgstr "Setează copertă serie…"
 
-#: sui_menu.lua:1712
+#: sui_menu.lua:1929
 msgid "Settings"
 msgstr "Setări"
 
-#: sui_menu.lua:718 sui_menu.lua:888 sui_menu.lua:1605
+#: sui_menu.lua:780 sui_menu.lua:950 sui_menu.lua:1853
 msgid "Settings on Long Tap"
 msgstr "Setări la atingere lungă"
 
@@ -1388,7 +1454,7 @@ msgstr "Arată ceasul"
 msgid "Show Date"
 msgstr "Arată data"
 
-#: sui_config.lua:1682
+#: sui_config.lua:1748
 msgid "Show section label"
 msgstr "Arată eticheta secțiunii"
 
@@ -1414,41 +1480,23 @@ msgstr ""
 "Punctul paginii active este plin; celelalte sunt estompate.\n"
 "Mereu activ când Navpager este selectat."
 
-#: desktop_modules/module_currently.lua:778
+#: desktop_modules/module_currently.lua:926
 msgid "Simple"
 msgstr "Simplu"
 
-#: main.lua:491 main.lua:504 sui_menu.lua:1681 sui_menu.lua:1685
+#: main.lua:541 main.lua:554 sui_menu.lua:1898 sui_menu.lua:1902
 msgid "Simple UI"
 msgstr "Simple UI"
 
-#: sui_updater.lua:312
-msgid ""
-"Simple UI %s is available (you have %s).\n"
-"\n"
-"No automatic update file was found.\n"
-"\n"
-"Open the releases page on GitHub?"
-msgstr ""
-"Simple UI %s este disponibil (ai acum %s).\n"
-"\n"
-"Nu a fost găsit niciun fișier pentru actualizare automată.\n"
-"\n"
-"Deschizi pagina de release-uri pe GitHub?"
-
-#: sui_updater.lua:333
+#: sui_updater.lua:407
 msgid ""
 "Simple UI %s is available!\n"
-"Current version: %s\n"
-"\n"
-"Download and install now?"
+"You have %s."
 msgstr ""
 "Simple UI %s este disponibil!\n"
-"Versiunea curentă: %s\n"
-"\n"
-"Descarci și instalezi acum?"
+"Momentan folosești %s."
 
-#: sui_updater.lua:245
+#: sui_updater.lua:357
 msgid ""
 "Simple UI %s successfully installed.\n"
 "\n"
@@ -1458,11 +1506,11 @@ msgstr ""
 "\n"
 "Repornești KOReader pentru a aplica actualizarea?"
 
-#: sui_updater.lua:301
+#: sui_updater.lua:399
 msgid "Simple UI is up to date (%s)."
 msgstr "Simple UI este la zi (%s)."
 
-#: sui_menu.lua:1702
+#: sui_menu.lua:1919
 msgid ""
 "Simple UI will be %s after restart.\n"
 "\n"
@@ -1472,11 +1520,11 @@ msgstr ""
 "\n"
 "Repornești acum?"
 
-#: sui_menu.lua:453 sui_menu.lua:690 sui_menu.lua:760
+#: sui_menu.lua:453 sui_menu.lua:752 sui_menu.lua:822
 msgid "Size"
 msgstr "Mărime"
 
-#: sui_menu.lua:825
+#: sui_menu.lua:887
 msgid ""
 "Size of the tab icons.\n"
 "100% is the default size."
@@ -1484,7 +1532,7 @@ msgstr ""
 "Mărimea pictogramelor filelor.\n"
 "Mărimea implicită este 100%."
 
-#: sui_menu.lua:845
+#: sui_menu.lua:907
 msgid ""
 "Size of the tab label text.\n"
 "100% is the default size."
@@ -1492,7 +1540,7 @@ msgstr ""
 "Mărimea etichetelor filelor.\n"
 "Mărimea implicită este 100%."
 
-#: desktop_modules/module_reading_stats.lua:474
+#: desktop_modules/module_reading_stats.lua:473
 msgid ""
 "Size of the text inside the stat cards.\n"
 "Does not affect card size or padding.\n"
@@ -1510,23 +1558,24 @@ msgstr "Ațipire"
 msgid "Small"
 msgstr "Mic"
 
-#: desktop_modules/module_quote.lua:1034
+#: desktop_modules/module_coverdeck.lua:725
+#: desktop_modules/module_quote.lua:1036
 msgid "Source"
 msgstr "Sursă"
 
-#: sui_menu.lua:803
+#: sui_menu.lua:865
 msgid ""
 "Space below the bottom navigation bar.\n"
 "100% is the default spacing."
 msgstr ""
-"Spațiu de sub bara de navigare din subsol.\n"
+"Spațiu de sub bara de navigare de jos.\n"
 "Mărimea implicită este 100%."
 
-#: sui_patches.lua:538 sui_patches.lua:540
+#: sui_patches.lua:526 sui_patches.lua:528
 msgid "Start with"
 msgstr "Pornește cu"
 
-#: sui_menu.lua:1580
+#: sui_menu.lua:1831
 msgid "Start with Home Screen"
 msgstr "Pornește cu ecranul Acasă"
 
@@ -1538,19 +1587,19 @@ msgstr "Plugin-ul de statistici nu este disponibil."
 msgid "Stats"
 msgstr "Statistici"
 
-#: desktop_modules/module_currently.lua:803
+#: desktop_modules/module_currently.lua:951
 msgid "Stats layout"
 msgstr "Aspectul statisticilor"
 
-#: sui_menu.lua:1718
+#: sui_menu.lua:1935
 msgid "Status Bar"
 msgstr "Bara de stare"
 
-#: desktop_modules/module_reading_stats.lua:68
+#: desktop_modules/module_reading_stats.lua:67
 msgid "Streak"
 msgstr "Serie"
 
-#: sui_menu.lua:1114
+#: sui_menu.lua:1176
 msgid "Sub-pages Buttons"
 msgstr "Butoane pentru subpagini"
 
@@ -1570,68 +1619,89 @@ msgstr "Acțiuni de sistem"
 msgid "System action error: %s"
 msgstr "Eroare acțiune de sistem: %s"
 
-#: sui_menu.lua:883
+#: sui_menu.lua:945
 msgid "Tabs  (%d/%d — %d left)"
 msgstr "File  (%d/%d — %d rămase)"
 
-#: sui_menu.lua:881
+#: sui_menu.lua:943
 msgid "Tabs  (%d/%d — at limit)"
 msgstr "File  (%d/%d — la limită)"
 
-#: sui_menu.lua:102
+#: sui_menu.lua:103
 msgid "Text"
 msgstr "Text"
 
-#: desktop_modules/module_collections.lua:448
-#: desktop_modules/module_collections.lua:449
-#: desktop_modules/module_currently.lua:677
-#: desktop_modules/module_currently.lua:678
-#: desktop_modules/module_new_books.lua:249
-#: desktop_modules/module_new_books.lua:250
-#: desktop_modules/module_quick_actions.lua:391
-#: desktop_modules/module_quick_actions.lua:394
-#: desktop_modules/module_reading_stats.lua:470
-#: desktop_modules/module_reading_stats.lua:473
+#: desktop_modules/module_collections.lua:514
+#: desktop_modules/module_collections.lua:515
+#: desktop_modules/module_currently.lua:825
+#: desktop_modules/module_currently.lua:826
+#: desktop_modules/module_new_books.lua:273
+#: desktop_modules/module_new_books.lua:274
+#: desktop_modules/module_quick_actions.lua:390
+#: desktop_modules/module_quick_actions.lua:393
+#: desktop_modules/module_reading_stats.lua:469
+#: desktop_modules/module_reading_stats.lua:472
 #: desktop_modules/module_recent.lua:271 desktop_modules/module_recent.lua:272
 msgid "Text Size"
 msgstr "Mărime text"
 
-#: desktop_modules/module_reading_stats.lua:471
+#: desktop_modules/module_reading_stats.lua:470
 msgid "Text Size — %d%%"
 msgstr "Mărime text — %d%%"
 
-#: sui_menu.lua:104
+#: sui_menu.lua:105
 msgid "Text only"
 msgstr "Doar text"
+
+#: sui_menu.lua:2108 desktop_modules/module_coverdeck.lua:715
+#: desktop_modules/module_coverdeck.lua:716
+msgid "Text size"
+msgstr "Mărime text"
+
+#: sui_patches.lua:675
+msgid "The «To Be Read» collection cannot be renamed."
+msgstr "Colecția „De citit” nu poate fi redenumită."
 
 #: desktop_modules/module_clock.lua:51
 msgid "Thursday"
 msgstr "joi"
 
-#: desktop_modules/module_currently.lua:269
+#: desktop_modules/module_coverdeck.lua:77
+#: desktop_modules/module_currently.lua:270
 msgid "Time read"
 msgstr "Timp citit"
 
-#: desktop_modules/module_currently.lua:270
+#: desktop_modules/module_coverdeck.lua:78
+#: desktop_modules/module_currently.lua:271
 msgid "Time remaining"
 msgstr "Timp rămas"
 
-#: sui_titlebar.lua:57 desktop_modules/module_currently.lua:264
+#: sui_titlebar.lua:57 desktop_modules/module_currently.lua:265
 msgid "Title"
 msgstr "Titlu"
 
-#: sui_menu.lua:1719
+#: sui_menu.lua:1936
 msgid "Title Bar"
 msgstr "Bara de titlu"
 
-#: desktop_modules/module_tbr.lua:108 desktop_modules/module_tbr.lua:109
-#: desktop_modules/module_tbr.lua:148 desktop_modules/module_tbr.lua:266
+#: desktop_modules/module_coverdeck.lua:747
+msgid "Title Position"
+msgstr "Poziție titlu"
+
+#: desktop_modules/module_coverdeck.lua:736 desktop_modules/module_tbr.lua:229
+#: desktop_modules/module_tbr.lua:230 desktop_modules/module_tbr.lua:244
+#: desktop_modules/module_tbr.lua:280 desktop_modules/module_tbr.lua:398
 msgid "To Be Read"
 msgstr "De citit"
 
-#: desktop_modules/module_tbr.lua:307
+#: desktop_modules/module_tbr.lua:450
 msgid "To Be Read books"
 msgstr "Cărți de citit"
+
+#: sui_patches.lua:723 sui_patches.lua:762 sui_patches.lua:794
+#: sui_patches.lua:835
+msgid "To Be Read list is full (max. 5 books)."
+msgstr "Lista „De citit” este plină (max. 5 cărți)."
 
 #: desktop_modules/module_reading_goals.lua:509
 #: desktop_modules/module_reading_goals.lua:511
@@ -1640,45 +1710,45 @@ msgstr "Cărți de citit"
 msgid "Today"
 msgstr "Astăzi"
 
-#: desktop_modules/module_reading_stats.lua:63
+#: desktop_modules/module_reading_stats.lua:62
 msgid "Today — Pages"
 msgstr "Astăzi — Pagini"
 
-#: desktop_modules/module_reading_stats.lua:62
+#: desktop_modules/module_reading_stats.lua:61
 msgid "Today — Time"
 msgstr "Astăzi — Timp"
 
-#: sui_menu.lua:1716 sui_menu.lua:1810 sui_menu.lua:1864
+#: sui_menu.lua:1933 sui_menu.lua:2028 sui_menu.lua:2082
 msgid "Top"
-msgstr "Antet"
+msgstr "Zona superioară"
 
-#: sui_menu.lua:671 sui_topbar.lua:497
+#: sui_menu.lua:733 sui_topbar.lua:507
 msgid "Top Bar"
-msgstr "Bara din antet"
+msgstr "Bara de sus"
 
-#: sui_menu.lua:696
+#: sui_menu.lua:758
 msgid "Top Bar Size"
-msgstr "Mărimea barei din antet"
+msgstr "Mărimea barei de sus"
 
-#: sui_menu.lua:679
+#: sui_menu.lua:741
 msgid ""
 "Top Bar will be %s after restart.\n"
 "\n"
 "Restart now?"
 msgstr ""
-"Bara din antet va fi %s după o repornire.\n"
+"Bara de sus va fi %s după o repornire.\n"
 "\n"
 "Repornești acum?"
 
-#: sui_homescreen.lua:1587
+#: sui_homescreen.lua:1681
 msgid "Top Margin  (%d%%)"
 msgstr "Marginea de sus  (%d%%)"
 
-#: sui_menu.lua:859
+#: sui_menu.lua:921
 msgid "Top separator"
-msgstr "Separator antet"
+msgstr "Separator superior"
 
-#: sui_menu.lua:1853
+#: sui_menu.lua:2071
 msgid "Transparent"
 msgstr "Transparent"
 
@@ -1686,17 +1756,25 @@ msgstr "Transparent"
 msgid "Tuesday"
 msgstr "marți"
 
-#: sui_menu.lua:872 desktop_modules/module_quick_actions.lua:403
+#: sui_menu.lua:934 desktop_modules/module_quick_actions.lua:402
 #: desktop_modules/module_reading_goals.lua:584
-#: desktop_modules/module_reading_stats.lua:431
+#: desktop_modules/module_reading_stats.lua:430
 msgid "Type"
 msgstr "Stil"
 
-#: sui_menu.lua:1892
+#: sui_menu.lua:2122
 msgid "Uniformize Covers (2:3)"
 msgstr "Uniformizează coperțile (2:3)"
 
-#: sui_menu.lua:1970
+#: sui_updater.lua:377
+msgid "Update cancelled."
+msgstr "Actualizarea a fost anulată."
+
+#: sui_updater.lua:487
+msgid "Update check cancelled."
+msgstr "Verificarea pentru actualizări a fost anulată."
+
+#: sui_menu.lua:2200
 msgid "Updater module not found."
 msgstr "Modulul de actualizare nu a fost găsit."
 
@@ -1708,11 +1786,11 @@ msgstr ""
 "Folosește bara de paginare standard a KOReader pe ecranul Acasă.\n"
 "Nu este disponibilă când Navpager este activ."
 
-#: sui_menu.lua:1955
+#: sui_menu.lua:2185
 msgid "Version: %s"
 msgstr "Versiune: %s"
 
-#: sui_homescreen.lua:1590
+#: sui_homescreen.lua:1684
 msgid ""
 "Vertical space above this module.\n"
 "100% is the default spacing."
@@ -1720,7 +1798,7 @@ msgstr ""
 "Spațiu vertical deasupra acestui modul.\n"
 "Mărimea implicită este 100%."
 
-#: sui_menu.lua:859
+#: sui_menu.lua:921
 msgid "Visible"
 msgstr "Vizibil"
 
@@ -1728,7 +1806,11 @@ msgstr "Vizibil"
 msgid "Wednesday"
 msgstr "miercuri"
 
-#: sui_menu.lua:1606
+#: sui_updater.lua:412
+msgid "What's new:"
+msgstr "Ce este nou:"
+
+#: sui_menu.lua:1854
 msgid ""
 "When enabled, long-pressing a section opens its settings menu.\n"
 "Disable this to prevent the settings menu from appearing on long tap."
@@ -1738,31 +1820,32 @@ msgstr ""
 "Dezactivează asta pentru a preveni apariția meniului de setări la apăsarea "
 "lungă."
 
-#: sui_menu.lua:889
+#: sui_menu.lua:951
 msgid ""
 "When enabled, long-pressing the bottom bar opens its settings menu.\n"
 "Disable this to prevent the settings menu from appearing on long tap."
 msgstr ""
-"Când este activată, apăsarea lungă pe bara din subsol va deschide meniul de "
+"Când este activată, apăsarea lungă pe bara de jos va deschide meniul de "
 "setări al acesteia.\n"
 "Dezactivează asta pentru a preveni apariția meniului de setări la apăsarea "
 "lungă."
 
-#: sui_menu.lua:719
+#: sui_menu.lua:781
 msgid ""
 "When enabled, long-pressing the top bar opens its settings menu.\n"
 "Disable this to prevent the settings menu from appearing on long tap."
 msgstr ""
-"Când este activată, apăsarea lungă pe bara din antet va deschide meniul de "
+"Când este activată, apăsarea lungă pe bara de sus va deschide meniul de "
 "setări al acesteia.\n"
 "Dezactivează asta pentru a preveni apariția meniului de setări la apăsarea "
 "lungă."
 
-#: sui_menu.lua:1591
+#: sui_menu.lua:1842
 msgid ""
 "When enabled, opening the file browser after finishing or closing a book "
 "navigates to the folder the book is in, matching native KOReader behaviour.\n"
-"When disabled (default), SimpleUI always returns to the library root."
+"When disabled (default), SimpleUI always returns to the library root.\n"
+"This option works independently of \"Start with Home Screen\"."
 msgstr ""
 "Când este activată, deschiderea navigatorului de fișiere după terminarea sau "
 "închiderea unei cărți va naviga către dosarul în care se află cartea, exact "
@@ -1790,27 +1873,37 @@ msgstr "WiFi nu este disponibil pe acest dispozitiv."
 msgid "Wikipedia Lookup"
 msgstr "Căutare pe Wikipedia"
 
-#: desktop_modules/module_currently.lua:788
+#: desktop_modules/module_currently.lua:936
 msgid "With percentage"
 msgstr "Cu procentaj"
 
-#: desktop_modules/module_quote.lua:747
+#: desktop_modules/module_quote.lua:748
 msgid "Your highlights"
 msgstr "Evidențierile tale"
 
-#: desktop_modules/module_reading_stats.lua:67
+#: sui_updater.lua:410
+msgid ""
+"\n"
+"\n"
+"Download and install now?"
+msgstr ""
+"\n"
+"\n"
+"Descarci și instalezi acum?"
+
+#: desktop_modules/module_reading_stats.lua:66
 msgid "books finished"
 msgstr "cărți terminate"
 
-#: desktop_modules/module_reading_stats.lua:64
+#: desktop_modules/module_reading_stats.lua:63
 msgid "daily avg (7 days)"
 msgstr "media zilnică (7 zile)"
 
-#: desktop_modules/module_reading_stats.lua:69
+#: desktop_modules/module_reading_stats.lua:68
 msgid "day streak"
 msgstr "zi în serie"
 
-#: desktop_modules/module_reading_stats.lua:69
+#: desktop_modules/module_reading_stats.lua:68
 msgid "days streak"
 msgstr "zile în serie"
 
@@ -1818,7 +1911,7 @@ msgstr "zile în serie"
 msgid "default"
 msgstr "implicit"
 
-#: sui_menu.lua:679 sui_menu.lua:748 sui_menu.lua:1088 sui_menu.lua:1702
+#: sui_menu.lua:741 sui_menu.lua:810 sui_menu.lua:1150 sui_menu.lua:1919
 msgid "disabled"
 msgstr "dezactivat"
 
@@ -1838,7 +1931,7 @@ msgstr "ex: Sci-Fi…"
 msgid "e.g. Sleep, Refresh…"
 msgstr "ex: Ațipire, Reîmprospătare…"
 
-#: sui_menu.lua:679 sui_menu.lua:748 sui_menu.lua:1088 sui_menu.lua:1702
+#: sui_menu.lua:741 sui_menu.lua:810 sui_menu.lua:1150 sui_menu.lua:1919
 msgid "enabled"
 msgstr "activat"
 
@@ -1846,7 +1939,7 @@ msgstr "activat"
 msgid "hex code, e.g. E001"
 msgstr "cod hex, ex: E001"
 
-#: desktop_modules/module_reading_stats.lua:69
+#: desktop_modules/module_reading_stats.lua:68
 msgid "no streak"
 msgstr "nicio serie"
 
@@ -1854,21 +1947,31 @@ msgstr "nicio serie"
 msgid "not configured"
 msgstr "neconfigurat"
 
-#: desktop_modules/module_reading_stats.lua:62
+#: desktop_modules/module_reading_stats.lua:61
 msgid "of reading today"
 msgstr "de citit astăzi"
 
-#: desktop_modules/module_reading_stats.lua:66
+#: desktop_modules/module_reading_stats.lua:65
 msgid "of reading, all time"
 msgstr "de citit, din tot timpul"
 
-#: desktop_modules/module_reading_stats.lua:63
+#: desktop_modules/module_reading_stats.lua:62
 msgid "pages read today"
 msgstr "pagini citite astăzi"
 
-#: desktop_modules/module_reading_stats.lua:65
+#: desktop_modules/module_reading_stats.lua:64
 msgid "pages/day (7 days)"
 msgstr "pagini/zi (7 zile)"
+
+#: sui_menu.lua:238 sui_menu.lua:1336
+#: desktop_modules/module_collections.lua:689
+#: desktop_modules/module_quick_actions.lua:319
+#: desktop_modules/module_reading_stats.lua:507
+msgid "  (%d left)"
+msgid_plural "  (%d left)"
+msgstr[0] "  (%s rămasă)"
+msgstr[1] "  (%s rămase)"
+msgstr[2] "  (%s rămase)"
 
 #: desktop_modules/module_reading_goals.lua:617
 msgid "  Set Goal  (%d book in %s)"
@@ -1884,8 +1987,9 @@ msgstr[0] "%d carte"
 msgstr[1] "%d cărți"
 msgstr[2] "%d de cărți"
 
-#: desktop_modules/module_currently.lua:446
-#: desktop_modules/module_currently.lua:513
+#: desktop_modules/module_coverdeck.lua:574
+#: desktop_modules/module_currently.lua:540
+#: desktop_modules/module_currently.lua:607
 msgid "%d day of reading"
 msgid_plural "%d days of reading"
 msgstr[0] "%d zi de citit"
@@ -1899,21 +2003,38 @@ msgstr[0] "%d/%d carte"
 msgstr[1] "%d/%d cărți"
 msgstr[2] "%d/%d de cărți"
 
-#: sui_menu.lua:1168
+#: sui_menu.lua:1230
 msgid "Digital: %d book in %s"
 msgid_plural "Digital: %d books in %s"
 msgstr[0] "Digital: %d carte în %s"
 msgstr[1] "Digital: %d cărți în %s"
 msgstr[2] "Digital: %d de cărți în %s"
 
-#: sui_menu.lua:1174
+#: sui_menu.lua:1236
 msgid "Physical: %d book in %s"
 msgid_plural "Physical: %d books in %s"
 msgstr[0] "Fizic: %d carte în %s"
 msgstr[1] "Fizic: %d cărți în %s"
 msgstr[2] "Fizic: %d de cărți în %s"
 
-#: sui_menu.lua:1238 desktop_modules/module_quick_actions.lua:262
+#: sui_menu.lua:556
+msgid ""
+"Text shown in the top bar.\n"
+"Maximum %d character."
+msgid_plural ""
+"Text shown in the top bar.\n"
+"Maximum %d characters."
+msgstr[0] ""
+"Textul afișat în bara superioară.\n"
+"Maxim %d caracter."
+msgstr[1] ""
+"Textul afișat în bara superioară.\n"
+"Maxim %d caractere."
+msgstr[2] ""
+"Textul afișat în bara superioară.\n"
+"Maxim %d de caractere."
+
+#: sui_menu.lua:1300 desktop_modules/module_quick_actions.lua:262
 msgid "The maximum of %d action per module has been reached. Remove one first."
 msgid_plural ""
 "The maximum of %d actions per module has been reached. Remove one first."
@@ -1935,7 +2056,7 @@ msgstr[1] ""
 msgstr[2] ""
 "Numărul maxim de %d de acțiuni rapide a fost atins. Șterge una mai întâi."
 
-#: desktop_modules/module_reading_stats.lua:420
+#: desktop_modules/module_reading_stats.lua:419
 msgid "The maximum of %d stat per row has been reached. Remove one first."
 msgid_plural ""
 "The maximum of %d stats per row has been reached. Remove one first."
@@ -1958,6 +2079,36 @@ msgstr[2] "Numărul maxim de %d de file a fost atins. Șterge una mai întâi."
 
 #~ msgid "1 day of reading"
 #~ msgstr "1 zi de citit"
+
+#~ msgid "Could not retrieve version information."
+#~ msgstr "Nu s-a putut prelua informația de versiune."
+
+#~ msgid "Enable at least 2 modules to arrange."
+#~ msgstr "Activează cel puțin 2 module pentru a le aranja."
+
+#~ msgid ""
+#~ "Maximum number of modules shown on each page.\n"
+#~ "Swipe left/right on the Home Screen to turn pages."
+#~ msgstr ""
+#~ "Numărul maxim de module afișat pe fiecare pagină.\n"
+#~ "Glisează stânga/dreapta pe ecranul Acasă pentru a întoarce paginile."
+
+#~ msgid "Modules per Page"
+#~ msgstr "Module per pagină"
+
+#~ msgid "Modules per Page  (%d)"
+#~ msgstr "Module per pagină  (%d)"
+
+#~ msgid ""
+#~ "Simple UI %s is available!\n"
+#~ "Current version: %s\n"
+#~ "\n"
+#~ "Download and install now?"
+#~ msgstr ""
+#~ "Simple UI %s este disponibil!\n"
+#~ "Versiunea curentă: %s\n"
+#~ "\n"
+#~ "Descarci și instalezi acum?"
 
 #~ msgid "Maximum %d stats per row. Remove one first."
 #~ msgstr ""
@@ -2020,9 +2171,6 @@ msgstr[2] "Numărul maxim de %d de file a fost atins. Șterge una mai întâi."
 
 #~ msgid "%s TO GO"
 #~ msgstr "%s DE PARCURS"
-
-#~ msgid "Custom Text"
-#~ msgstr "Text personalizat"
 
 #~ msgid "Date"
 #~ msgstr "Dată"

--- a/locale/ro_MD.po
+++ b/locale/ro_MD.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: simpleui\n"
 "Report-Msgid-Bugs-To: yokyroll\n"
-"POT-Creation-Date: 2026-04-10 14:14\n"
-"PO-Revision-Date: 2026-04-10 14:18+0300\n"
+"POT-Creation-Date: 2026-04-11 15:45\n"
+"PO-Revision-Date: 2026-04-11 15:46+0300\n"
 "Last-Translator: Mihai Vasiliu <mihai.vasiliu.93@gmail.com>\n"
 "Language-Team: Moldavian\n"
 "Language: ro_MD\n"
@@ -39,27 +39,30 @@ msgstr "  Setează obiectiv  (dezactivat)"
 msgid "%d%%"
 msgstr "%d%%"
 
-#: desktop_modules/module_currently.lua:435
-#: desktop_modules/module_new_books.lua:159
+#: desktop_modules/module_coverdeck.lua:571
+#: desktop_modules/module_currently.lua:529
+#: desktop_modules/module_new_books.lua:182
 #: desktop_modules/module_recent.lua:159
 msgid "%d%% Read"
 msgstr "%d%% citit"
 
-#: desktop_modules/module_currently.lua:511
+#: desktop_modules/module_currently.lua:605
 msgid "%s left"
 msgstr "%s rămas"
 
-#: desktop_modules/module_currently.lua:459
-#: desktop_modules/module_currently.lua:509
+#: desktop_modules/module_coverdeck.lua:576
+#: desktop_modules/module_currently.lua:553
+#: desktop_modules/module_currently.lua:603
 #: desktop_modules/module_reading_goals.lua:433
 msgid "%s read"
 msgstr "%s citit"
 
-#: desktop_modules/module_currently.lua:478
+#: desktop_modules/module_coverdeck.lua:582
+#: desktop_modules/module_currently.lua:572
 msgid "%s remaining"
 msgstr "%s rămas"
 
-#: sui_menu.lua:783
+#: sui_menu.lua:845
 msgid ""
 "A restart is required to apply the new bar size across all layouts.\n"
 "\n"
@@ -70,44 +73,48 @@ msgstr ""
 "\n"
 "Repornești acum?"
 
-#: sui_menu.lua:1944
+#: sui_menu.lua:2174
 msgid "About"
 msgstr "Despre"
 
-#: sui_menu.lua:1257 desktop_modules/module_quick_actions.lua:288
+#: desktop_modules/module_coverdeck.lua:750
+msgid "Above"
+msgstr "Deasupra"
+
+#: sui_menu.lua:1319 desktop_modules/module_quick_actions.lua:288
 msgid "Add at least 2 actions to arrange."
 msgstr "Adaugă cel puțin 2 acțiuni pentru a le putea aranja."
 
-#: desktop_modules/module_tbr.lua:277
+#: desktop_modules/module_tbr.lua:409
 msgid "Add at least 2 books to arrange."
 msgstr "Adaugă cel puțin 2 cărți pentru a le putea aranja."
 
-#: desktop_modules/module_reading_stats.lua:486
+#: desktop_modules/module_reading_stats.lua:485
 msgid "Add at least 2 stats to arrange."
 msgstr "Adaugă cel puțin 2 statistici pentru a le putea aranja."
 
-#: desktop_modules/module_tbr.lua:133
+#: desktop_modules/module_tbr.lua:265
 msgid "Add to To Be Read"
 msgstr "Adaugă la „De citit”"
 
-#: desktop_modules/module_reading_stats.lua:67
-msgid "All time — Books"
-msgstr "Din tot timpul — Cărți"
-
 #: desktop_modules/module_reading_stats.lua:66
+msgid "All time — Books"
+msgstr "Dintotdeauna — Cărți"
+
+#: desktop_modules/module_reading_stats.lua:65
 msgid "All time — Time"
-msgstr "Din tot timpul — Timp"
+msgstr "Dintotdeauna — Timp"
 
 #: desktop_modules/module_reading_goals.lua:607
 msgid "Annual Goal"
 msgstr "Obiectiv anual"
 
-#: sui_menu.lua:1167 desktop_modules/module_reading_goals.lua:353
+#: sui_menu.lua:1229 desktop_modules/module_reading_goals.lua:353
 msgid "Annual Reading Goal"
 msgstr "Obiectiv anual de citit"
 
-#: sui_config.lua:1560 sui_config.lua:1641 sui_menu.lua:703 sui_menu.lua:773
-#: sui_menu.lua:1485 sui_menu.lua:1520 sui_menu.lua:1632
+#: sui_config.lua:1626 sui_config.lua:1707 sui_menu.lua:765 sui_menu.lua:835
+#: sui_menu.lua:1736 sui_menu.lua:1771
 msgid "Apply"
 msgstr "Aplică"
 
@@ -115,43 +122,48 @@ msgstr "Aplică"
 msgid "April"
 msgstr "aprilie"
 
-#: desktop_modules/module_reading_stats.lua:483
+#: desktop_modules/module_reading_stats.lua:482
 msgid "Arrange"
 msgstr "Aranjează"
 
-#: sui_menu.lua:1261 desktop_modules/module_quick_actions.lua:300
+#: sui_menu.lua:1323 desktop_modules/module_quick_actions.lua:300
 msgid "Arrange %s"
 msgstr "Aranjează %s"
 
-#: sui_menu.lua:983 sui_menu.lua:1034 sui_menu.lua:1049
+#: sui_menu.lua:1045 sui_menu.lua:1096 sui_menu.lua:1111
 msgid "Arrange Buttons"
 msgstr "Aranjează butoanele"
 
-#: desktop_modules/module_collections.lua:538
-#: desktop_modules/module_collections.lua:551
+#: desktop_modules/module_collections.lua:622
+#: desktop_modules/module_collections.lua:635
 msgid "Arrange Collections"
 msgstr "Aranjează colecțiile"
 
-#: sui_menu.lua:593 sui_menu.lua:621 sui_menu.lua:1251
-#: desktop_modules/module_currently.lua:715
-#: desktop_modules/module_currently.lua:739
+#: sui_menu.lua:600 sui_menu.lua:629 sui_menu.lua:1313
+#: desktop_modules/module_currently.lua:863
+#: desktop_modules/module_currently.lua:887
 #: desktop_modules/module_quick_actions.lua:279
 msgid "Arrange Items"
 msgstr "Aranjează elementele"
 
-#: sui_menu.lua:1417 sui_menu.lua:1433
+#: sui_menu.lua:1578
 msgid "Arrange Modules"
 msgstr "Aranjează modulele"
 
-#: desktop_modules/module_reading_stats.lua:492
+#: desktop_modules/module_reading_stats.lua:491
 msgid "Arrange Reading Stats"
 msgstr "Aranjează statisticile de citit"
 
-#: desktop_modules/module_tbr.lua:270 desktop_modules/module_tbr.lua:289
+#: desktop_modules/module_coverdeck.lua:774
+#: desktop_modules/module_coverdeck.lua:787
+msgid "Arrange Statistics"
+msgstr "Aranjează statisticile"
+
+#: desktop_modules/module_tbr.lua:402 desktop_modules/module_tbr.lua:421
 msgid "Arrange To Be Read list"
 msgstr "Aranjează lista de citit"
 
-#: sui_menu.lua:194 sui_menu.lua:204
+#: sui_menu.lua:195 sui_menu.lua:205
 msgid "Arrange tabs"
 msgstr "Aranjează filele"
 
@@ -159,16 +171,16 @@ msgstr "Aranjează filele"
 msgid "August"
 msgstr "august"
 
-#: desktop_modules/module_currently.lua:265
+#: desktop_modules/module_currently.lua:266
 msgid "Author"
 msgstr "Autor"
 
-#: sui_menu.lua:1960
+#: sui_menu.lua:2190
 msgid "Author: %s"
 msgstr "Autor: %s"
 
-#: sui_foldercovers.lua:508 sui_foldercovers.lua:573
-#: desktop_modules/module_collections.lua:499
+#: sui_foldercovers.lua:540 sui_foldercovers.lua:605
+#: desktop_modules/module_collections.lua:583
 msgid "Auto (first book)"
 msgstr "Auto (prima carte)"
 
@@ -176,17 +188,21 @@ msgstr "Auto (prima carte)"
 msgid "Back"
 msgstr "Înapoi"
 
-#: desktop_modules/module_collections.lua:578
+#: desktop_modules/module_collections.lua:662
 msgid "Badge position: Bottom"
 msgstr "Poziția insignei: jos"
 
-#: desktop_modules/module_collections.lua:579
+#: desktop_modules/module_collections.lua:663
 msgid "Badge position: Top"
 msgstr "Poziția insignei: sus"
 
 #: sui_config.lua:162
 msgid "Battery"
 msgstr "Baterie"
+
+#: desktop_modules/module_coverdeck.lua:758
+msgid "Below"
+msgstr "Dedesubt"
 
 #: sui_quickactions.lua:569
 msgid "Book Info"
@@ -202,39 +218,39 @@ msgstr "Navigatorul de semne de carte nu este disponibil."
 
 #: sui_config.lua:137
 msgid "Bookmarks"
-msgstr "Semne de carte"
+msgstr "Marcaje"
 
 #: desktop_modules/module_reading_goals.lua:354
 msgid "Books to read in %s:"
 msgstr "Cărți de citit în %s:"
 
-#: sui_menu.lua:1724 sui_menu.lua:1818 sui_menu.lua:1880
+#: sui_menu.lua:1941 sui_menu.lua:2036 sui_menu.lua:2098
 msgid "Bottom"
-msgstr "Subsol"
+msgstr "Zona inferioară"
 
-#: sui_bottombar.lua:843 sui_menu.lua:740
+#: sui_bottombar.lua:843 sui_menu.lua:802
 msgid "Bottom Bar"
-msgstr "Bara din subsol"
+msgstr "Bara de jos"
 
-#: sui_menu.lua:766
+#: sui_menu.lua:828
 msgid "Bottom Bar Size"
-msgstr "Mărime bară din subsol"
+msgstr "Mărime bară de jos"
 
-#: sui_menu.lua:748
+#: sui_menu.lua:810
 msgid ""
 "Bottom Bar will be %s after restart.\n"
 "\n"
 "Restart now?"
 msgstr ""
-"Bara din subsol va fi %s după repornire.\n"
+"Bara de jos va fi %s după repornire.\n"
 "\n"
 "Repornești acum?"
 
-#: sui_menu.lua:799 sui_menu.lua:802
+#: sui_menu.lua:861 sui_menu.lua:864
 msgid "Bottom Margin"
 msgstr "Marginea de jos"
 
-#: sui_menu.lua:800
+#: sui_menu.lua:862
 msgid "Bottom Margin — %d%%"
 msgstr "Marginea de jos — %d%%"
 
@@ -242,30 +258,30 @@ msgstr "Marginea de jos — %d%%"
 msgid "Brightness"
 msgstr "Luminozitate"
 
-#: sui_menu.lua:1099
+#: sui_menu.lua:1161
 msgid "Button Size"
 msgstr "Mărime buton"
 
-#: sui_bottombar.lua:1060 sui_bottombar.lua:1745 sui_config.lua:1561
-#: sui_config.lua:1642 sui_foldercovers.lua:537 sui_foldercovers.lua:604
-#: sui_menu.lua:704 sui_menu.lua:774 sui_menu.lua:1486 sui_menu.lua:1521
-#: sui_menu.lua:1633 sui_quickactions.lua:358 sui_quickactions.lua:444
+#: sui_bottombar.lua:1060 sui_bottombar.lua:1745 sui_config.lua:1627
+#: sui_config.lua:1708 sui_foldercovers.lua:569 sui_foldercovers.lua:636
+#: sui_menu.lua:562 sui_menu.lua:766 sui_menu.lua:836 sui_menu.lua:1737
+#: sui_menu.lua:1772 sui_quickactions.lua:358 sui_quickactions.lua:444
 #: sui_quickactions.lua:552 sui_quickactions.lua:756 sui_quickactions.lua:827
 #: sui_quickactions.lua:855 sui_quickactions.lua:883 sui_quickactions.lua:899
-#: sui_quickactions.lua:1011 sui_quickactions.lua:1153 sui_updater.lua:316
-#: sui_updater.lua:337 desktop_modules/module_collections.lua:525
-#: desktop_modules/module_quote.lua:952
+#: sui_quickactions.lua:1011 sui_quickactions.lua:1153 sui_updater.lua:421
+#: sui_updater.lua:438 desktop_modules/module_collections.lua:609
+#: desktop_modules/module_quote.lua:959
 #: desktop_modules/module_reading_goals.lua:357
 #: desktop_modules/module_reading_goals.lua:373
 #: desktop_modules/module_reading_goals.lua:390
 msgid "Cancel"
 msgstr "Anulează"
 
-#: desktop_modules/module_reading_stats.lua:434
+#: desktop_modules/module_reading_stats.lua:433
 msgid "Cards"
 msgstr "Carduri"
 
-#: sui_menu.lua:608 sui_menu.lua:1872
+#: sui_menu.lua:616 sui_menu.lua:2090
 msgid "Center"
 msgstr "Centru"
 
@@ -273,13 +289,13 @@ msgstr "Centru"
 msgid "Change Icons"
 msgstr "Schimbă pictogramele"
 
-#: sui_menu.lua:1965
+#: sui_menu.lua:2195
 msgid "Check for Updates"
 msgstr "Verifică pentru actualizări"
 
-#: sui_updater.lua:272
-msgid "Checking for updates..."
-msgstr "Se verifică pentru actualizări..."
+#: sui_updater.lua:460
+msgid "Checking for updates…"
+msgstr "Se verifică pentru actualizări…"
 
 #: sui_config.lua:159 desktop_modules/module_clock.lua:227
 msgid "Clock"
@@ -297,8 +313,8 @@ msgstr "Codul se află în afara intervalului Unicode valid (0–10FFFF)."
 msgid "Collection"
 msgstr "Colecție"
 
-#: desktop_modules/module_collections.lua:486
-#: desktop_modules/module_collections.lua:492
+#: desktop_modules/module_collections.lua:570
+#: desktop_modules/module_collections.lua:576
 msgid "Collection is empty."
 msgstr "Colecția este goală."
 
@@ -307,18 +323,22 @@ msgid "Collection not available: %s"
 msgstr "Colecția nu este disponibilă: %s"
 
 #: sui_bottombar.lua:1046 sui_config.lua:133 sui_quickactions.lua:571
-#: desktop_modules/module_collections.lua:291
-#: desktop_modules/module_collections.lua:292
-#: desktop_modules/module_collections.lua:311
-#: desktop_modules/module_collections.lua:536
+#: desktop_modules/module_collections.lua:298
+#: desktop_modules/module_collections.lua:299
+#: desktop_modules/module_collections.lua:318
+#: desktop_modules/module_collections.lua:620
 msgid "Collections"
 msgstr "Colecții"
+
+#: sui_patches.lua:906
+msgid "Collections (%1)"
+msgstr "Colecții (%1)"
 
 #: sui_bottombar.lua:1323
 msgid "Collections not available."
 msgstr "Colecțiile nu sînt disponibile."
 
-#: sui_menu.lua:1103 desktop_modules/module_currently.lua:816
+#: sui_menu.lua:1165 desktop_modules/module_currently.lua:964
 #: desktop_modules/module_reading_goals.lua:594
 msgid "Compact"
 msgstr "Compact"
@@ -331,20 +351,22 @@ msgstr "Confirmă"
 msgid "Continue"
 msgstr "Continuă"
 
-#: sui_updater.lua:295
-msgid "Could not retrieve version information."
-msgstr "Nu s-a putut prelua informația de versiune."
+#: desktop_modules/module_coverdeck.lua:325
+msgid "Cover Deck"
+msgstr "Pachet de coperți"
 
-#: desktop_modules/module_collections.lua:529
+#: desktop_modules/module_collections.lua:613
 msgid "Cover for \"%s\""
 msgstr "Copertă pentru „%s”"
 
-#: desktop_modules/module_collections.lua:567
-#: desktop_modules/module_collections.lua:569
-#: desktop_modules/module_currently.lua:663
-#: desktop_modules/module_currently.lua:665
-#: desktop_modules/module_new_books.lua:236
-#: desktop_modules/module_new_books.lua:238
+#: desktop_modules/module_collections.lua:651
+#: desktop_modules/module_collections.lua:653
+#: desktop_modules/module_coverdeck.lua:707
+#: desktop_modules/module_coverdeck.lua:708
+#: desktop_modules/module_currently.lua:811
+#: desktop_modules/module_currently.lua:813
+#: desktop_modules/module_new_books.lua:260
+#: desktop_modules/module_new_books.lua:262
 #: desktop_modules/module_recent.lua:256 desktop_modules/module_recent.lua:258
 msgid "Cover size"
 msgstr "Mărime copertă"
@@ -353,22 +375,26 @@ msgstr "Mărime copertă"
 msgid "Create Quick Action"
 msgstr "Creează o acțiune rapidă"
 
-#: sui_config.lua:1669 desktop_modules/module_currently.lua:295
-#: desktop_modules/module_currently.lua:296
-#: desktop_modules/module_currently.lua:310
-#: desktop_modules/module_currently.lua:833
+#: sui_config.lua:1735 desktop_modules/module_currently.lua:296
+#: desktop_modules/module_currently.lua:297
+#: desktop_modules/module_currently.lua:402
+#: desktop_modules/module_currently.lua:981
 msgid "Currently Reading"
 msgstr "Carte în curs"
 
-#: sui_config.lua:525
+#: sui_config.lua:555
 msgid "Custom"
 msgstr "Personalizat"
 
-#: sui_menu.lua:1076
+#: sui_config.lua:165 sui_menu.lua:554
+msgid "Custom Text"
+msgstr "Text personalizat"
+
+#: sui_menu.lua:1138
 msgid "Custom Title Bar"
 msgstr "Bară de titlu personalizată"
 
-#: sui_menu.lua:1087
+#: sui_menu.lua:1149
 msgid ""
 "Custom Title Bar will be %s after restart.\n"
 "\n"
@@ -386,15 +412,16 @@ msgstr "Obiectiv zilnic"
 msgid "Daily Reading Goal"
 msgstr "Obiectiv zilnic de citit"
 
-#: desktop_modules/module_reading_stats.lua:65
+#: desktop_modules/module_reading_stats.lua:64
 msgid "Daily avg — Pages"
 msgstr "Media zilnică — Pagini"
 
-#: desktop_modules/module_reading_stats.lua:64
+#: desktop_modules/module_reading_stats.lua:63
 msgid "Daily avg — Time"
 msgstr "Media zilnică — Timp"
 
-#: desktop_modules/module_currently.lua:268
+#: desktop_modules/module_coverdeck.lua:76
+#: desktop_modules/module_currently.lua:269
 msgid "Days of reading"
 msgstr "Zile de citire"
 
@@ -402,10 +429,10 @@ msgstr "Zile de citire"
 msgid "December"
 msgstr "decembrie"
 
-#: sui_menu.lua:352 sui_menu.lua:481 sui_menu.lua:1104 sui_quickactions.lua:512
-#: desktop_modules/module_currently.lua:806
-#: desktop_modules/module_quick_actions.lua:402
-#: desktop_modules/module_quick_actions.lua:407
+#: sui_menu.lua:352 sui_menu.lua:481 sui_menu.lua:1166 sui_quickactions.lua:512
+#: desktop_modules/module_currently.lua:954
+#: desktop_modules/module_quick_actions.lua:401
+#: desktop_modules/module_quick_actions.lua:406
 #: desktop_modules/module_reading_goals.lua:586
 msgid "Default"
 msgstr "Implicit"
@@ -422,7 +449,7 @@ msgstr "Implicit (plugin)"
 msgid "Default (System)"
 msgstr "Implicit (sistem)"
 
-#: desktop_modules/module_quote.lua:1040
+#: desktop_modules/module_quote.lua:1042
 msgid "Default Quotes"
 msgstr "Citate implicite"
 
@@ -438,17 +465,17 @@ msgstr "Ștergi acțiunea rapidă „%s”?"
 msgid "Dictionary Lookup"
 msgstr "Căutare în dicționar"
 
-#: sui_menu.lua:1168
+#: sui_menu.lua:1230
 msgid "Digital Goal  (%s)"
 msgstr "Obiectiv digital  (%s)"
 
-#: sui_menu.lua:1505
+#: sui_menu.lua:1756
 msgid "Disable \"Lock Scale\" first to set a custom label scale."
 msgstr ""
 "Dezactivează mai întîi „Blochează scalarea” pentru a seta o scalare pentru "
 "etichete."
 
-#: sui_config.lua:1545
+#: sui_config.lua:1611
 msgid "Disable \"Lock Scale\" first to set a per-module scale."
 msgstr ""
 "Dezactivează mai întîi „Blochează scalarea” pentru a seta o scalare per "
@@ -464,31 +491,31 @@ msgstr "Dispecerul nu este disponibil."
 
 #: sui_menu.lua:389
 msgid "Dot Pager"
-msgstr "Paginare cu punct"
+msgstr "Paginare cu puncte"
 
-#: sui_updater.lua:336
+#: sui_updater.lua:437
 msgid "Download and install"
 msgstr "Descarcă și instalează"
 
-#: sui_updater.lua:228
+#: sui_updater.lua:348
 msgid "Download error: "
 msgstr "Eroare descărcare: "
 
-#: sui_updater.lua:222
-msgid "Downloading Simple UI "
-msgstr "Se descarcă Simple UI "
+#: sui_updater.lua:323
+msgid "Downloading Simple UI %s…"
+msgstr "Se descarcă Simple UI %s…"
 
 #: sui_quickactions.lua:1137
 msgid "Edit"
 msgstr "Editează"
 
+#: sui_menu.lua:546 sui_menu.lua:548
+msgid "Edit Custom Text"
+msgstr "Editează text personalizat"
+
 #: sui_quickactions.lua:702
 msgid "Edit Quick Action"
 msgstr "Editează acțiunile rapide"
-
-#: sui_menu.lua:1429
-msgid "Enable at least 2 modules to arrange."
-msgstr "Activează cel puțin 2 module pentru a le aranja."
 
 #: sui_quickactions.lua:441
 msgid ""
@@ -502,15 +529,19 @@ msgstr ""
 "  /koreader/fonts/nerdfonts/symbols.ttf\n"
 "Lasă spațiul gol și apasă OK pentru a șterge pictograma Nerd Fonts."
 
-#: sui_updater.lua:279
+#: sui_updater.lua:466
+msgid "Error checking for updates."
+msgstr "Eroare la verificarea pentru actualizări."
+
+#: sui_updater.lua:471
 msgid "Error checking for updates: "
-msgstr "Eroare la verificarea pentru actualizări:"
+msgstr "Eroare la verificarea pentru actualizări: "
 
 #: sui_menu.lua:457
 msgid "Extra Small"
 msgstr "Extra mic"
 
-#: sui_updater.lua:239
+#: sui_updater.lua:350
 msgid "Extraction error: "
 msgstr "Eroare extracție: "
 
@@ -534,9 +565,9 @@ msgstr "Se preiau semnele de carte…"
 msgid "File Search"
 msgstr "Căutare de fișiere"
 
-#: desktop_modules/module_quick_actions.lua:402
-#: desktop_modules/module_quick_actions.lua:416
-#: desktop_modules/module_reading_stats.lua:444
+#: desktop_modules/module_quick_actions.lua:401
+#: desktop_modules/module_quick_actions.lua:415
+#: desktop_modules/module_reading_stats.lua:443
 msgid "Flat"
 msgstr "Plat"
 
@@ -544,19 +575,23 @@ msgstr "Plat"
 msgid "Folder"
 msgstr "Dosar"
 
-#: sui_menu.lua:1762
+#: sui_menu.lua:1979
 msgid "Folder Covers"
 msgstr "Coperți dosare"
 
-#: sui_menu.lua:1840
+#: sui_menu.lua:2058
 msgid "Folder Name"
 msgstr "Nume dosar"
+
+#: sui_menu.lua:2110
+msgid "Folder Name Text Size"
+msgstr "Mărime text nume dosar"
 
 #: sui_quickactions.lua:573
 msgid "Folder Shortcuts"
 msgstr "Scurtături dosare"
 
-#: sui_foldercovers.lua:609
+#: sui_foldercovers.lua:641
 msgid "Folder cover"
 msgstr "Copertă dosar"
 
@@ -572,7 +607,7 @@ msgstr "Iluminarea nu este disponibilă pe acest dispozitiv."
 msgid "General"
 msgstr "General"
 
-#: sui_menu.lua:1479
+#: sui_menu.lua:1730
 msgid ""
 "Global scale for all modules.\n"
 "Individual overrides in Module Settings take precedence.\n"
@@ -582,32 +617,32 @@ msgstr ""
 "Setările individuale din „Setări module” au prioritate.\n"
 "Dimensiunea implicită este 100%."
 
-#: sui_menu.lua:1782
+#: sui_menu.lua:1999
 msgid "Group Books by Series"
 msgstr "Grupează cărțile după serie"
 
-#: sui_menu.lua:767
+#: sui_menu.lua:829
 msgid ""
 "Height of the bottom navigation bar.\n"
 "100% is the default size."
 msgstr ""
-"Înălțimea barei de navigare din subsol.\n"
+"Înălțimea barei de navigare de jos.\n"
 "Înălțimea implicită este 100%."
 
-#: sui_menu.lua:697
+#: sui_menu.lua:759
 msgid ""
 "Height of the top status bar.\n"
 "100% is the default size."
 msgstr ""
-"Înălțimea barei de stare din antet.\n"
+"Înălțimea barei de stare de sus.\n"
 "Înălțimea implicită este 100%."
 
-#: sui_menu.lua:373 sui_menu.lua:432 sui_menu.lua:859 sui_menu.lua:1799
-#: sui_menu.lua:1843
+#: sui_menu.lua:373 sui_menu.lua:432 sui_menu.lua:921 sui_menu.lua:2017
+#: sui_menu.lua:2061
 msgid "Hidden"
 msgstr "Ascuns"
 
-#: sui_menu.lua:1285 desktop_modules/module_quick_actions.lua:330
+#: sui_menu.lua:1346 desktop_modules/module_quick_actions.lua:329
 msgid "Hide Text"
 msgstr "Ascunde textul"
 
@@ -615,7 +650,7 @@ msgstr "Ascunde textul"
 msgid "Hide Wi-Fi icon when off"
 msgstr "Ascunde pictograma Wi-Fi cînd este oprit"
 
-#: sui_menu.lua:1902
+#: sui_menu.lua:2132
 msgid "Hide selection underline"
 msgstr "Ascunde sublinierea selecției"
 
@@ -639,8 +674,8 @@ msgstr "Istoricul nu este disponibil."
 msgid "Home"
 msgstr "Acasă"
 
-#: sui_menu.lua:386 sui_menu.lua:1570 sui_menu.lua:1722 sui_patches.lua:521
-#: sui_patches.lua:525 sui_patches.lua:538
+#: sui_menu.lua:386 sui_menu.lua:1821 sui_menu.lua:1939 sui_patches.lua:503
+#: sui_patches.lua:526
 msgid "Home Screen"
 msgstr "Ecranul Acasă"
 
@@ -652,7 +687,7 @@ msgstr "Dosarul Acasă"
 msgid "Home folder + subfolders"
 msgstr "Dosarul Acasă + subdosare"
 
-#: sui_homescreen.lua:983
+#: sui_homescreen.lua:1041
 msgid "Homescreen"
 msgstr "Ecranul Acasă"
 
@@ -664,11 +699,11 @@ msgstr "Ecranul Acasă nu este disponibil."
 msgid "Icon"
 msgstr "Pictogramă"
 
-#: sui_menu.lua:821 sui_menu.lua:824
+#: sui_menu.lua:883 sui_menu.lua:886
 msgid "Icon Size"
 msgstr "Mărime pictograme"
 
-#: sui_menu.lua:822
+#: sui_menu.lua:884
 msgid "Icon Size — %d%%"
 msgstr "Mărime pictograme — %d%%"
 
@@ -676,15 +711,15 @@ msgstr "Mărime pictograme — %d%%"
 msgid "Icon: Default"
 msgstr "Pictogramă: Implicit"
 
-#: sui_menu.lua:102
+#: sui_menu.lua:103
 msgid "Icons"
 msgstr "Pictograme"
 
-#: sui_menu.lua:103
+#: sui_menu.lua:104
 msgid "Icons only"
 msgstr "Doar pictograme"
 
-#: sui_menu.lua:996
+#: sui_menu.lua:1058
 msgid ""
 "Invalid arrangement.\n"
 "Keep items between the Left and Right separators."
@@ -692,7 +727,7 @@ msgstr ""
 "Aranjament invalid.\n"
 "Păstrează elementele între separatoarele stînga și dreapta."
 
-#: sui_menu.lua:635
+#: sui_menu.lua:643
 msgid ""
 "Invalid arrangement.\n"
 "Keep the Left, Center and Right separators in order."
@@ -704,8 +739,9 @@ msgstr ""
 msgid "Invalid input. Please enter 1–6 hexadecimal digits (0–9, A–F)."
 msgstr "Intrare invalidă. Întrodu 1–6 cifre hexazecimale (0–9, A–F)."
 
-#: sui_menu.lua:716 sui_menu.lua:1295 desktop_modules/module_currently.lua:835
-#: desktop_modules/module_quick_actions.lua:340
+#: sui_menu.lua:778 sui_menu.lua:1356 desktop_modules/module_coverdeck.lua:769
+#: desktop_modules/module_currently.lua:983
+#: desktop_modules/module_quick_actions.lua:339
 msgid "Items"
 msgstr "Elemente"
 
@@ -725,48 +761,48 @@ msgstr "iunie"
 msgid "KOReader"
 msgstr "KOReader"
 
-#: sui_menu.lua:1513
+#: sui_menu.lua:1764
 msgid "Label Scale"
 msgstr "Scalare etichete"
 
-#: sui_menu.lua:841 sui_menu.lua:844
+#: sui_menu.lua:903 sui_menu.lua:906
 msgid "Label Size"
 msgstr "Mărime etichete"
 
-#: sui_menu.lua:842
+#: sui_menu.lua:904
 msgid "Label Size — %d%%"
 msgstr "Mărime etichete — %d%%"
 
-#: sui_menu.lua:1498
+#: sui_menu.lua:1749
 msgid "Labels"
 msgstr "Etichete"
 
-#: sui_menu.lua:1105
+#: sui_menu.lua:1167
 msgid "Large"
 msgstr "Mare"
 
-#: sui_menu.lua:337 sui_menu.lua:680 sui_menu.lua:749 sui_menu.lua:785
-#: sui_menu.lua:1091 sui_menu.lua:1703 sui_updater.lua:249
+#: sui_menu.lua:337 sui_menu.lua:742 sui_menu.lua:811 sui_menu.lua:847
+#: sui_menu.lua:1153 sui_menu.lua:1920 sui_updater.lua:361
 msgid "Later"
 msgstr "Mai tîrziu"
 
-#: sui_menu.lua:602 sui_menu.lua:966
+#: sui_menu.lua:610 sui_menu.lua:1028
 msgid "Left"
 msgstr "Stînga"
 
-#: sui_config.lua:131 sui_config.lua:373 sui_menu.lua:1743 sui_titlebar.lua:666
+#: sui_config.lua:131 sui_config.lua:403 sui_menu.lua:1960 sui_titlebar.lua:720
 msgid "Library"
 msgstr "Bibliotecă"
 
-#: sui_menu.lua:1109
+#: sui_menu.lua:1171
 msgid "Library Buttons"
 msgstr "Butoane bibliotecă"
 
-#: desktop_modules/module_reading_stats.lua:454
+#: desktop_modules/module_reading_stats.lua:453
 msgid "List"
 msgstr "Listă"
 
-#: sui_menu.lua:1459
+#: sui_menu.lua:1710
 msgid "Lock Scale"
 msgstr "Blochează scalarea"
 
@@ -774,17 +810,9 @@ msgstr "Blochează scalarea"
 msgid "March"
 msgstr "martie"
 
-#: desktop_modules/module_collections.lua:619
+#: desktop_modules/module_collections.lua:709
 msgid "Maximum 5 collections. Remove one first."
 msgstr "Maxim 5 colecții. Șterge una mai întîi."
-
-#: sui_menu.lua:1627
-msgid ""
-"Maximum number of modules shown on each page.\n"
-"Swipe left/right on the Home Screen to turn pages."
-msgstr ""
-"Numărul maxim de module afișat pe fiecare pagină.\n"
-"Glisează stînga/dreapta pe ecranul Acasă pentru a întoarce paginile."
 
 #: desktop_modules/module_clock.lua:55
 msgid "May"
@@ -806,35 +834,27 @@ msgstr "Minim 2 file necesare. Alege mai întîi altă filă."
 msgid "Minutes per day:"
 msgstr "Minute pe zi:"
 
-#: sui_menu.lua:1476
+#: sui_menu.lua:1727
 msgid "Module Scale"
 msgstr "Scalare module"
 
-#: sui_menu.lua:1451
+#: sui_menu.lua:1702
 msgid "Module Settings"
 msgstr "Setări modul"
 
-#: sui_menu.lua:1470
+#: sui_menu.lua:1721
 msgid "Modules"
 msgstr "Module"
 
-#: sui_menu.lua:1412
+#: sui_menu.lua:1473
 msgid "Modules  (%d)"
 msgstr "Module  (%d)"
-
-#: sui_menu.lua:1626
-msgid "Modules per Page"
-msgstr "Module per pagină"
-
-#: sui_menu.lua:1620
-msgid "Modules per Page  (%d)"
-msgstr "Module per pagină  (%d)"
 
 #: desktop_modules/module_clock.lua:50
 msgid "Monday"
 msgstr "luni"
 
-#: desktop_modules/module_quote.lua:1060
+#: desktop_modules/module_quote.lua:1062
 msgid "My Highlights"
 msgstr "Evidențierile mele"
 
@@ -843,7 +863,7 @@ msgstr "Evidențierile mele"
 msgid "Name"
 msgstr "Nume"
 
-#: sui_menu.lua:1726
+#: sui_menu.lua:1943
 msgid "Navigation Bar"
 msgstr "Bara de navigare"
 
@@ -873,14 +893,14 @@ msgstr "Simbol Nerd Font…"
 msgid "Network manager unavailable."
 msgstr "Managerul de rețea nu este disponibil."
 
-#: desktop_modules/module_new_books.lua:157
+#: desktop_modules/module_new_books.lua:180
 msgid "New"
 msgstr "Nou"
 
 #: desktop_modules/module_new_books.lua:46
 #: desktop_modules/module_new_books.lua:47
 #: desktop_modules/module_new_books.lua:107
-#: desktop_modules/module_new_books.lua:256
+#: desktop_modules/module_new_books.lua:280
 msgid "New Books"
 msgstr "Cărți noi"
 
@@ -894,21 +914,31 @@ msgstr "Nume nou…"
 
 #: sui_bottombar.lua:293
 msgid "Next"
-msgstr "Următorul"
+msgstr "Urm."
+
+#: sui_updater.lua:419
+msgid ""
+"No automatic update file was found.\n"
+"\n"
+"Open the releases page on GitHub?"
+msgstr ""
+"Nu a fost găsit niciun fișier pentru actualizare automată.\n"
+"\n"
+"Deschizi pagina de release-uri pe GitHub?"
 
 #: sui_bottombar.lua:1395
 msgid "No book in history."
 msgstr "Nicio carte în istoric."
 
-#: sui_foldercovers.lua:562
+#: sui_foldercovers.lua:594
 msgid "No books found in this folder."
 msgstr "Nicio carte găsită în acest dosar."
 
-#: sui_foldercovers.lua:497
+#: sui_foldercovers.lua:529
 msgid "No books found in this series."
 msgstr "Nicio carte găsită în această serie."
 
-#: desktop_modules/module_tbr.lua:312
+#: desktop_modules/module_tbr.lua:455
 msgid "No books in To Be Read list."
 msgstr "Nicio carte în lista de citit."
 
@@ -916,11 +946,11 @@ msgstr "Nicio carte în lista de citit."
 msgid "No books opened yet"
 msgstr "Nicio carte deschisă încă"
 
-#: desktop_modules/module_collections.lua:589
+#: desktop_modules/module_collections.lua:673
 msgid "No collections found."
 msgstr "Nicio colecție găsită."
 
-#: desktop_modules/module_collections.lua:324
+#: desktop_modules/module_collections.lua:378
 msgid "No collections selected"
 msgstr "Nicio colecție selectată"
 
@@ -932,7 +962,7 @@ msgstr ""
 "Nu a fost configurat niciun dosar, colecție sau plugin.\n"
 "Accesează Simple UI → Setări → Acțiuni rapide pentru a seta una."
 
-#: desktop_modules/module_quote.lua:745
+#: desktop_modules/module_quote.lua:746
 msgid "No highlights found. Open a book and highlight some passages."
 msgstr ""
 "Nicio evidențiere găsită. Deschide o carte și evidențiează niște pasaje."
@@ -945,11 +975,11 @@ msgstr "Nicio pictogramă găsită în:"
 msgid "No plugins found."
 msgstr "Niciun plugin găsit."
 
-#: desktop_modules/module_quote.lua:711
+#: desktop_modules/module_quote.lua:712
 msgid "No quotes found."
 msgstr "Niciun citat găsit."
 
-#: desktop_modules/module_reading_stats.lua:287
+#: desktop_modules/module_reading_stats.lua:286
 msgid "No stats selected"
 msgstr "Nicio statistică selectată"
 
@@ -961,11 +991,11 @@ msgstr "Nicio acțiune de sistem găsită."
 msgid "November"
 msgstr "noiembrie"
 
-#: sui_menu.lua:1796
+#: sui_menu.lua:2014
 msgid "Number of Books in Folder"
 msgstr "Numărul de cărți din dosar"
 
-#: sui_menu.lua:1828
+#: sui_menu.lua:1478 sui_menu.lua:2046
 msgid "Number of Pages"
 msgstr "Numărul de pagini"
 
@@ -981,17 +1011,17 @@ msgstr "OK"
 msgid "October"
 msgstr "octombrie"
 
-#: sui_menu.lua:671 sui_menu.lua:740 sui_menu.lua:930 sui_menu.lua:1076
-#: sui_menu.lua:1570 sui_menu.lua:1685
+#: sui_menu.lua:733 sui_menu.lua:802 sui_menu.lua:992 sui_menu.lua:1138
+#: sui_menu.lua:1821 sui_menu.lua:1902
 msgid "Off"
 msgstr "Dezactivat"
 
-#: sui_menu.lua:671 sui_menu.lua:740 sui_menu.lua:930 sui_menu.lua:1076
-#: sui_menu.lua:1570 sui_menu.lua:1685
+#: sui_menu.lua:733 sui_menu.lua:802 sui_menu.lua:992 sui_menu.lua:1138
+#: sui_menu.lua:1821 sui_menu.lua:1902
 msgid "On"
 msgstr "Activat"
 
-#: sui_homescreen.lua:408 desktop_modules/module_quote.lua:951
+#: sui_homescreen.lua:420 desktop_modules/module_quote.lua:958
 msgid "Open"
 msgstr "Deschide"
 
@@ -999,23 +1029,23 @@ msgstr "Deschide"
 msgid "Open a book to get started"
 msgstr "Deschide o carte pentru a începe"
 
-#: sui_updater.lua:315
+#: sui_updater.lua:420
 msgid "Open in browser"
 msgstr "Deschide în navigator"
 
-#: sui_homescreen.lua:407 desktop_modules/module_quote.lua:950
+#: sui_homescreen.lua:419 desktop_modules/module_quote.lua:957
 msgid "Open this file?"
 msgstr "Deschizi această carte?"
 
-#: sui_menu.lua:1792
+#: sui_menu.lua:2010
 msgid "Overlays"
 msgstr "Overlay-uri"
 
-#: sui_homescreen.lua:1517 sui_patches.lua:1449
+#: sui_homescreen.lua:1611 sui_patches.lua:1567
 msgid "Page %1 of %2"
 msgstr "Pagina %1 din %2"
 
-#: sui_menu.lua:1727
+#: sui_menu.lua:1944
 msgid "Pagination Bar"
 msgstr "Bara de paginare"
 
@@ -1057,8 +1087,9 @@ msgstr "Selectorul de căi nu este disponibil."
 msgid "Percentage overlay on cover"
 msgstr "Overlay de procentaj pe copertă"
 
-#: desktop_modules/module_currently.lua:267
-#: desktop_modules/module_currently.lua:763
+#: desktop_modules/module_coverdeck.lua:75
+#: desktop_modules/module_currently.lua:268
+#: desktop_modules/module_currently.lua:911
 msgid "Percentage read"
 msgstr "Procentaj citit"
 
@@ -1074,7 +1105,7 @@ msgstr "Cărți fizice — %s"
 msgid "Physical books read this year:"
 msgstr "Cărți fizice citite anul acesta:"
 
-#: sui_menu.lua:1909
+#: sui_menu.lua:2139
 msgid "Placeholder cover for bookless folders"
 msgstr "Copertă implicită pentru dosarele fără cărți"
 
@@ -1096,30 +1127,30 @@ msgstr "Alimentare"
 
 #: sui_bottombar.lua:293
 msgid "Prev"
-msgstr "Anteriorul"
+msgstr "Ant."
 
-#: desktop_modules/module_currently.lua:266
+#: desktop_modules/module_currently.lua:267
 #: desktop_modules/module_recent.lua:284
 msgid "Progress bar"
 msgstr "Bara de progres"
 
-#: desktop_modules/module_currently.lua:775
+#: desktop_modules/module_currently.lua:923
 msgid "Progress bar style"
 msgstr "Stilul barei de progres"
 
-#: sui_menu.lua:1390 sui_menu.lua:1734
+#: sui_menu.lua:1451 sui_menu.lua:1951
 msgid "Quick Actions"
 msgstr "Acțiuni rapide"
 
-#: sui_menu.lua:1738
+#: sui_menu.lua:1955
 msgid "Quick Actions  (%d/%d — %d left)"
 msgstr "Acțiuni rapide  (%d/%d — %d rămase)"
 
-#: sui_menu.lua:1736
+#: sui_menu.lua:1953
 msgid "Quick Actions  (%d/%d — at limit)"
 msgstr "Acțiuni rapide  (%d/%d — la limită)"
 
-#: sui_menu.lua:1227 desktop_modules/module_quick_actions.lua:198
+#: sui_menu.lua:1289 desktop_modules/module_quick_actions.lua:198
 #: desktop_modules/module_quick_actions.lua:244
 msgid "Quick Actions %d"
 msgstr "Acțiuni rapide %d"
@@ -1128,11 +1159,11 @@ msgstr "Acțiuni rapide %d"
 msgid "Quit"
 msgstr "Ieșire"
 
-#: desktop_modules/module_quote.lua:821
+#: desktop_modules/module_quote.lua:822
 msgid "Quote of the Day"
 msgstr "Citatul zilei"
 
-#: desktop_modules/module_quote.lua:1082
+#: desktop_modules/module_quote.lua:1084
 msgid "Quotes + My Highlights"
 msgstr "Citate + Evidențierile mele"
 
@@ -1147,16 +1178,17 @@ msgstr "Utilizare RAM"
 msgid "Reading Goals"
 msgstr "Obiective citire"
 
-#: desktop_modules/module_reading_stats.lua:219
+#: desktop_modules/module_reading_stats.lua:218
 msgid "Reading Stats"
 msgstr "Statistici citire"
 
+#: desktop_modules/module_coverdeck.lua:728
 #: desktop_modules/module_recent.lua:62 desktop_modules/module_recent.lua:63
 #: desktop_modules/module_recent.lua:72 desktop_modules/module_recent.lua:281
 msgid "Recent Books"
 msgstr "Cărți recente"
 
-#: desktop_modules/module_tbr.lua:133
+#: desktop_modules/module_tbr.lua:265
 msgid "Remove from To Be Read"
 msgstr "Elimină din „De citit”"
 
@@ -1172,35 +1204,35 @@ msgid ""
 "With navpager active, as few as 1 tab and at most 4 tabs can be configured."
 msgstr ""
 "Înlocuiește bara de paginare cu săgețile „Anteriorul/Următorul” amplasate la "
-"marginile barei din subsol.\n"
+"marginile barei de jos.\n"
 "Săgețile se estompează atunci cînd nu există nicio pagină anterioară sau "
 "următoare.\n"
 "Cînd Navpager este activ, se pot configura între 1 și 4 file."
 
-#: sui_menu.lua:1541 sui_quickactions.lua:1015
+#: sui_menu.lua:1792 sui_quickactions.lua:1015
 msgid "Reset"
 msgstr "Resetează"
 
-#: sui_menu.lua:1540
+#: sui_menu.lua:1791
 msgid "Reset all scales to default (100%)? This cannot be undone."
 msgstr ""
 "Resetezi toate scalările la valoarea implicită (100%)? Această acțiune nu "
 "poate fi anulată."
 
-#: sui_menu.lua:1535
+#: sui_menu.lua:1786
 msgid "Reset to Default Scale"
 msgstr "Resetează la scalarea implicită"
 
-#: sui_bottombar.lua:1715 sui_menu.lua:337 sui_menu.lua:680 sui_menu.lua:749
-#: sui_menu.lua:784 sui_menu.lua:1090 sui_menu.lua:1703 sui_updater.lua:248
+#: sui_bottombar.lua:1715 sui_menu.lua:337 sui_menu.lua:742 sui_menu.lua:811
+#: sui_menu.lua:846 sui_menu.lua:1152 sui_menu.lua:1920 sui_updater.lua:360
 msgid "Restart"
-msgstr "Repornește"
+msgstr "Repornire"
 
-#: sui_menu.lua:1590
+#: sui_menu.lua:1841
 msgid "Return to Book Folder"
 msgstr "Întoarce-te la dosarul cărții"
 
-#: sui_menu.lua:614 sui_menu.lua:974
+#: sui_menu.lua:622 sui_menu.lua:1036
 msgid "Right"
 msgstr "Dreapta"
 
@@ -1215,27 +1247,29 @@ msgstr "sîmbătă"
 msgid "Save"
 msgstr "Salvează"
 
-#: sui_menu.lua:1455 desktop_modules/module_clock.lua:433
+#: sui_menu.lua:1706 desktop_modules/module_clock.lua:433
 #: desktop_modules/module_clock.lua:435
-#: desktop_modules/module_collections.lua:434
-#: desktop_modules/module_collections.lua:436
-#: desktop_modules/module_currently.lua:649
-#: desktop_modules/module_currently.lua:651
-#: desktop_modules/module_new_books.lua:222
-#: desktop_modules/module_new_books.lua:224
-#: desktop_modules/module_quick_actions.lua:381
-#: desktop_modules/module_quick_actions.lua:383
-#: desktop_modules/module_quote.lua:1002 desktop_modules/module_quote.lua:1006
+#: desktop_modules/module_collections.lua:500
+#: desktop_modules/module_collections.lua:502
+#: desktop_modules/module_coverdeck.lua:698
+#: desktop_modules/module_coverdeck.lua:700
+#: desktop_modules/module_currently.lua:797
+#: desktop_modules/module_currently.lua:799
+#: desktop_modules/module_new_books.lua:246
+#: desktop_modules/module_new_books.lua:248
+#: desktop_modules/module_quick_actions.lua:380
+#: desktop_modules/module_quick_actions.lua:382
+#: desktop_modules/module_quote.lua:1004 desktop_modules/module_quote.lua:1008
 #: desktop_modules/module_reading_goals.lua:566
 #: desktop_modules/module_reading_goals.lua:568
-#: desktop_modules/module_reading_stats.lua:390
-#: desktop_modules/module_reading_stats.lua:392
+#: desktop_modules/module_reading_stats.lua:389
+#: desktop_modules/module_reading_stats.lua:391
 #: desktop_modules/module_recent.lua:242 desktop_modules/module_recent.lua:244
-#: desktop_modules/module_tbr.lua:230 desktop_modules/module_tbr.lua:232
+#: desktop_modules/module_tbr.lua:362 desktop_modules/module_tbr.lua:364
 msgid "Scale"
 msgstr "Scalare"
 
-#: desktop_modules/module_currently.lua:679
+#: desktop_modules/module_currently.lua:827
 msgid ""
 "Scale for all text elements (title, author, progress, time).\n"
 "100% is the default size."
@@ -1243,7 +1277,7 @@ msgstr ""
 "Scalare pentru toate elementele text (titlu, autor, progres, timp).\n"
 "Mărimea implicită este 100%."
 
-#: desktop_modules/module_quick_actions.lua:395
+#: desktop_modules/module_quick_actions.lua:394
 msgid ""
 "Scale for the button label text.\n"
 "100% is the default size."
@@ -1251,7 +1285,7 @@ msgstr ""
 "Scalare pentru eticheta butoanelor.\n"
 "Mărimea implicită este 100%."
 
-#: desktop_modules/module_collections.lua:450
+#: desktop_modules/module_collections.lua:516
 msgid ""
 "Scale for the collection name text.\n"
 "100% is the default size."
@@ -1259,7 +1293,7 @@ msgstr ""
 "Scalare pentru textul numelui colecției.\n"
 "Mărimea implicită este 100%."
 
-#: desktop_modules/module_collections.lua:570
+#: desktop_modules/module_collections.lua:654
 msgid ""
 "Scale for the collection thumbnails only.\n"
 "The label text follows the module scale.\n"
@@ -1269,7 +1303,7 @@ msgstr ""
 "Textul etichetei urmează scalarea modulului.\n"
 "Mărimea implicită este 100%."
 
-#: desktop_modules/module_currently.lua:666
+#: desktop_modules/module_currently.lua:814
 msgid ""
 "Scale for the cover thumbnail only.\n"
 "100% is the default size."
@@ -1277,7 +1311,15 @@ msgstr ""
 "Scalare doar pentru miniatura coperții.\n"
 "Mărimea implicită este 100%."
 
-#: desktop_modules/module_new_books.lua:239
+#: desktop_modules/module_coverdeck.lua:709
+msgid ""
+"Scale for the cover thumbnails only.\n"
+"100% is the default size."
+msgstr ""
+"Scalare doar pentru miniaturile coperților.\n"
+"Mărimea implicită este 100%."
+
+#: desktop_modules/module_new_books.lua:263
 #: desktop_modules/module_recent.lua:259
 msgid ""
 "Scale for the cover thumbnails only.\n"
@@ -1288,7 +1330,15 @@ msgstr ""
 "Textul și bara de progres folosesc aceeași scalare ca modulul\n"
 "Mărimea implicită este 100%."
 
-#: desktop_modules/module_new_books.lua:251
+#: sui_menu.lua:2111
+msgid ""
+"Scale for the folder name overlay text.\n"
+"100% is the default size."
+msgstr ""
+"Scalare pentru textul suprapus cu numele dosarului.\n"
+"Mărimea implicită este 100%."
+
+#: desktop_modules/module_new_books.lua:275
 msgid ""
 "Scale for the label text.\n"
 "100% is the default size."
@@ -1304,15 +1354,19 @@ msgstr ""
 "Scalare pentru textul de procentaj citit.\n"
 "Mărimea implicită este 100%."
 
+#: desktop_modules/module_coverdeck.lua:701
+msgid "Scale for this module."
+msgstr "Scalare pentru acest modul."
+
 #: desktop_modules/module_clock.lua:436
-#: desktop_modules/module_collections.lua:437
-#: desktop_modules/module_currently.lua:652
-#: desktop_modules/module_new_books.lua:225
-#: desktop_modules/module_quick_actions.lua:384
-#: desktop_modules/module_quote.lua:1008
+#: desktop_modules/module_collections.lua:503
+#: desktop_modules/module_currently.lua:800
+#: desktop_modules/module_new_books.lua:249
+#: desktop_modules/module_quick_actions.lua:383
+#: desktop_modules/module_quote.lua:1010
 #: desktop_modules/module_reading_goals.lua:569
-#: desktop_modules/module_reading_stats.lua:393
-#: desktop_modules/module_recent.lua:245 desktop_modules/module_tbr.lua:233
+#: desktop_modules/module_reading_stats.lua:392
+#: desktop_modules/module_recent.lua:245 desktop_modules/module_tbr.lua:365
 msgid ""
 "Scale for this module.\n"
 "100% is the default size."
@@ -1320,7 +1374,15 @@ msgstr ""
 "Scalare pentru acest modul.\n"
 "Mărimea implicită este 100%."
 
-#: sui_menu.lua:1478
+#: desktop_modules/module_coverdeck.lua:717
+msgid ""
+"Scale for title and statistics text.\n"
+"100% is the default size."
+msgstr ""
+"Scalare pentru textul titlului și statisticilor.\n"
+"Mărimea implicită este 100%."
+
+#: sui_menu.lua:1729
 msgid ""
 "Scales all modules and labels together.\n"
 "100% is the default size."
@@ -1328,7 +1390,7 @@ msgstr ""
 "Scalează toate modulele și etichetele împreună.\n"
 "Mărimea implicită este 100%."
 
-#: sui_menu.lua:1514
+#: sui_menu.lua:1765
 msgid ""
 "Scales the section label text above each module.\n"
 "100% is the default size."
@@ -1336,7 +1398,7 @@ msgstr ""
 "Scalează textul etichetei de secțiune de deasupra fiecărui modul.\n"
 "Mărimea implicită este 100%."
 
-#: sui_menu.lua:1924
+#: sui_menu.lua:2154
 msgid "Scan subfolders for cover"
 msgstr "Scanează subdosarele pentru copertă"
 
@@ -1344,7 +1406,7 @@ msgstr "Scanează subdosarele pentru copertă"
 msgid "Search"
 msgstr "Caută"
 
-#: desktop_modules/module_collections.lua:543
+#: desktop_modules/module_collections.lua:627
 msgid "Select at least 2 collections to arrange."
 msgstr "Selectează cel puțin 2 colecții pentru a le aranja."
 
@@ -1352,27 +1414,31 @@ msgstr "Selectează cel puțin 2 colecții pentru a le aranja."
 msgid "September"
 msgstr "septembrie"
 
-#: sui_menu.lua:1834
+#: sui_menu.lua:2052
 msgid "Series Index"
 msgstr "Index serie"
 
-#: sui_foldercovers.lua:542
+#: sui_foldercovers.lua:574
 msgid "Series cover"
 msgstr "Copertă serie"
 
-#: sui_foldercovers.lua:632
+#: sui_menu.lua:567
+msgid "Set"
+msgstr "Setează"
+
+#: sui_foldercovers.lua:664
 msgid "Set folder cover…"
 msgstr "Setează copertă dosar…"
 
-#: sui_foldercovers.lua:632
+#: sui_foldercovers.lua:664
 msgid "Set series cover…"
 msgstr "Setează copertă serie…"
 
-#: sui_menu.lua:1712
+#: sui_menu.lua:1929
 msgid "Settings"
 msgstr "Setări"
 
-#: sui_menu.lua:718 sui_menu.lua:888 sui_menu.lua:1605
+#: sui_menu.lua:780 sui_menu.lua:950 sui_menu.lua:1853
 msgid "Settings on Long Tap"
 msgstr "Setări la atingere lungă"
 
@@ -1388,7 +1454,7 @@ msgstr "Arată ceasul"
 msgid "Show Date"
 msgstr "Arată data"
 
-#: sui_config.lua:1682
+#: sui_config.lua:1748
 msgid "Show section label"
 msgstr "Arată eticheta secțiunii"
 
@@ -1414,41 +1480,23 @@ msgstr ""
 "Punctul paginii active este plin; celelalte sînt estompate.\n"
 "Mereu activ cînd Navpager este selectat."
 
-#: desktop_modules/module_currently.lua:778
+#: desktop_modules/module_currently.lua:926
 msgid "Simple"
 msgstr "Simplu"
 
-#: main.lua:491 main.lua:504 sui_menu.lua:1681 sui_menu.lua:1685
+#: main.lua:541 main.lua:554 sui_menu.lua:1898 sui_menu.lua:1902
 msgid "Simple UI"
 msgstr "Simple UI"
 
-#: sui_updater.lua:312
-msgid ""
-"Simple UI %s is available (you have %s).\n"
-"\n"
-"No automatic update file was found.\n"
-"\n"
-"Open the releases page on GitHub?"
-msgstr ""
-"Simple UI %s este disponibil (ai acum %s).\n"
-"\n"
-"Nu a fost găsit niciun fișier pentru actualizare automată.\n"
-"\n"
-"Deschizi pagina de release-uri pe GitHub?"
-
-#: sui_updater.lua:333
+#: sui_updater.lua:407
 msgid ""
 "Simple UI %s is available!\n"
-"Current version: %s\n"
-"\n"
-"Download and install now?"
+"You have %s."
 msgstr ""
 "Simple UI %s este disponibil!\n"
-"Versiunea curentă: %s\n"
-"\n"
-"Descarci și instalezi acum?"
+"Momentan folosești %s."
 
-#: sui_updater.lua:245
+#: sui_updater.lua:357
 msgid ""
 "Simple UI %s successfully installed.\n"
 "\n"
@@ -1458,11 +1506,11 @@ msgstr ""
 "\n"
 "Repornești KOReader pentru a aplica actualizarea?"
 
-#: sui_updater.lua:301
+#: sui_updater.lua:399
 msgid "Simple UI is up to date (%s)."
 msgstr "Simple UI este la zi (%s)."
 
-#: sui_menu.lua:1702
+#: sui_menu.lua:1919
 msgid ""
 "Simple UI will be %s after restart.\n"
 "\n"
@@ -1472,11 +1520,11 @@ msgstr ""
 "\n"
 "Repornești acum?"
 
-#: sui_menu.lua:453 sui_menu.lua:690 sui_menu.lua:760
+#: sui_menu.lua:453 sui_menu.lua:752 sui_menu.lua:822
 msgid "Size"
 msgstr "Mărime"
 
-#: sui_menu.lua:825
+#: sui_menu.lua:887
 msgid ""
 "Size of the tab icons.\n"
 "100% is the default size."
@@ -1484,7 +1532,7 @@ msgstr ""
 "Mărimea pictogramelor filelor.\n"
 "Mărimea implicită este 100%."
 
-#: sui_menu.lua:845
+#: sui_menu.lua:907
 msgid ""
 "Size of the tab label text.\n"
 "100% is the default size."
@@ -1492,7 +1540,7 @@ msgstr ""
 "Mărimea etichetelor filelor.\n"
 "Mărimea implicită este 100%."
 
-#: desktop_modules/module_reading_stats.lua:474
+#: desktop_modules/module_reading_stats.lua:473
 msgid ""
 "Size of the text inside the stat cards.\n"
 "Does not affect card size or padding.\n"
@@ -1510,23 +1558,24 @@ msgstr "Ațipire"
 msgid "Small"
 msgstr "Mic"
 
-#: desktop_modules/module_quote.lua:1034
+#: desktop_modules/module_coverdeck.lua:725
+#: desktop_modules/module_quote.lua:1036
 msgid "Source"
 msgstr "Sursă"
 
-#: sui_menu.lua:803
+#: sui_menu.lua:865
 msgid ""
 "Space below the bottom navigation bar.\n"
 "100% is the default spacing."
 msgstr ""
-"Spațiu de sub bara de navigare din subsol.\n"
+"Spațiu de sub bara de navigare de jos.\n"
 "Mărimea implicită este 100%."
 
-#: sui_patches.lua:538 sui_patches.lua:540
+#: sui_patches.lua:526 sui_patches.lua:528
 msgid "Start with"
 msgstr "Pornește cu"
 
-#: sui_menu.lua:1580
+#: sui_menu.lua:1831
 msgid "Start with Home Screen"
 msgstr "Pornește cu ecranul Acasă"
 
@@ -1538,19 +1587,19 @@ msgstr "Plugin-ul de statistici nu este disponibil."
 msgid "Stats"
 msgstr "Statistici"
 
-#: desktop_modules/module_currently.lua:803
+#: desktop_modules/module_currently.lua:951
 msgid "Stats layout"
 msgstr "Aspectul statisticilor"
 
-#: sui_menu.lua:1718
+#: sui_menu.lua:1935
 msgid "Status Bar"
 msgstr "Bara de stare"
 
-#: desktop_modules/module_reading_stats.lua:68
+#: desktop_modules/module_reading_stats.lua:67
 msgid "Streak"
 msgstr "Serie"
 
-#: sui_menu.lua:1114
+#: sui_menu.lua:1176
 msgid "Sub-pages Buttons"
 msgstr "Butoane pentru subpagini"
 
@@ -1570,68 +1619,89 @@ msgstr "Acțiuni de sistem"
 msgid "System action error: %s"
 msgstr "Eroare acțiune de sistem: %s"
 
-#: sui_menu.lua:883
+#: sui_menu.lua:945
 msgid "Tabs  (%d/%d — %d left)"
 msgstr "File  (%d/%d — %d rămase)"
 
-#: sui_menu.lua:881
+#: sui_menu.lua:943
 msgid "Tabs  (%d/%d — at limit)"
 msgstr "File  (%d/%d — la limită)"
 
-#: sui_menu.lua:102
+#: sui_menu.lua:103
 msgid "Text"
 msgstr "Text"
 
-#: desktop_modules/module_collections.lua:448
-#: desktop_modules/module_collections.lua:449
-#: desktop_modules/module_currently.lua:677
-#: desktop_modules/module_currently.lua:678
-#: desktop_modules/module_new_books.lua:249
-#: desktop_modules/module_new_books.lua:250
-#: desktop_modules/module_quick_actions.lua:391
-#: desktop_modules/module_quick_actions.lua:394
-#: desktop_modules/module_reading_stats.lua:470
-#: desktop_modules/module_reading_stats.lua:473
+#: desktop_modules/module_collections.lua:514
+#: desktop_modules/module_collections.lua:515
+#: desktop_modules/module_currently.lua:825
+#: desktop_modules/module_currently.lua:826
+#: desktop_modules/module_new_books.lua:273
+#: desktop_modules/module_new_books.lua:274
+#: desktop_modules/module_quick_actions.lua:390
+#: desktop_modules/module_quick_actions.lua:393
+#: desktop_modules/module_reading_stats.lua:469
+#: desktop_modules/module_reading_stats.lua:472
 #: desktop_modules/module_recent.lua:271 desktop_modules/module_recent.lua:272
 msgid "Text Size"
 msgstr "Mărime text"
 
-#: desktop_modules/module_reading_stats.lua:471
+#: desktop_modules/module_reading_stats.lua:470
 msgid "Text Size — %d%%"
 msgstr "Mărime text — %d%%"
 
-#: sui_menu.lua:104
+#: sui_menu.lua:105
 msgid "Text only"
 msgstr "Doar text"
+
+#: sui_menu.lua:2108 desktop_modules/module_coverdeck.lua:715
+#: desktop_modules/module_coverdeck.lua:716
+msgid "Text size"
+msgstr "Mărime text"
+
+#: sui_patches.lua:675
+msgid "The «To Be Read» collection cannot be renamed."
+msgstr "Colecția „De citit” nu poate fi redenumită."
 
 #: desktop_modules/module_clock.lua:51
 msgid "Thursday"
 msgstr "joi"
 
-#: desktop_modules/module_currently.lua:269
+#: desktop_modules/module_coverdeck.lua:77
+#: desktop_modules/module_currently.lua:270
 msgid "Time read"
 msgstr "Timp citit"
 
-#: desktop_modules/module_currently.lua:270
+#: desktop_modules/module_coverdeck.lua:78
+#: desktop_modules/module_currently.lua:271
 msgid "Time remaining"
 msgstr "Timp rămas"
 
-#: sui_titlebar.lua:57 desktop_modules/module_currently.lua:264
+#: sui_titlebar.lua:57 desktop_modules/module_currently.lua:265
 msgid "Title"
 msgstr "Titlu"
 
-#: sui_menu.lua:1719
+#: sui_menu.lua:1936
 msgid "Title Bar"
 msgstr "Bara de titlu"
 
-#: desktop_modules/module_tbr.lua:108 desktop_modules/module_tbr.lua:109
-#: desktop_modules/module_tbr.lua:148 desktop_modules/module_tbr.lua:266
+#: desktop_modules/module_coverdeck.lua:747
+msgid "Title Position"
+msgstr "Poziție titlu"
+
+#: desktop_modules/module_coverdeck.lua:736 desktop_modules/module_tbr.lua:229
+#: desktop_modules/module_tbr.lua:230 desktop_modules/module_tbr.lua:244
+#: desktop_modules/module_tbr.lua:280 desktop_modules/module_tbr.lua:398
 msgid "To Be Read"
 msgstr "De citit"
 
-#: desktop_modules/module_tbr.lua:307
+#: desktop_modules/module_tbr.lua:450
 msgid "To Be Read books"
 msgstr "Cărți de citit"
+
+#: sui_patches.lua:723 sui_patches.lua:762 sui_patches.lua:794
+#: sui_patches.lua:835
+msgid "To Be Read list is full (max. 5 books)."
+msgstr "Lista „De citit” este plină (max. 5 cărți)."
 
 #: desktop_modules/module_reading_goals.lua:509
 #: desktop_modules/module_reading_goals.lua:511
@@ -1640,45 +1710,45 @@ msgstr "Cărți de citit"
 msgid "Today"
 msgstr "Astăzi"
 
-#: desktop_modules/module_reading_stats.lua:63
+#: desktop_modules/module_reading_stats.lua:62
 msgid "Today — Pages"
 msgstr "Astăzi — Pagini"
 
-#: desktop_modules/module_reading_stats.lua:62
+#: desktop_modules/module_reading_stats.lua:61
 msgid "Today — Time"
 msgstr "Astăzi — Timp"
 
-#: sui_menu.lua:1716 sui_menu.lua:1810 sui_menu.lua:1864
+#: sui_menu.lua:1933 sui_menu.lua:2028 sui_menu.lua:2082
 msgid "Top"
-msgstr "Antet"
+msgstr "Zona superioară"
 
-#: sui_menu.lua:671 sui_topbar.lua:497
+#: sui_menu.lua:733 sui_topbar.lua:507
 msgid "Top Bar"
-msgstr "Bara din antet"
+msgstr "Bara de sus"
 
-#: sui_menu.lua:696
+#: sui_menu.lua:758
 msgid "Top Bar Size"
-msgstr "Mărimea barei din antet"
+msgstr "Mărimea barei de sus"
 
-#: sui_menu.lua:679
+#: sui_menu.lua:741
 msgid ""
 "Top Bar will be %s after restart.\n"
 "\n"
 "Restart now?"
 msgstr ""
-"Bara din antet va fi %s după o repornire.\n"
+"Bara de sus va fi %s după o repornire.\n"
 "\n"
 "Repornești acum?"
 
-#: sui_homescreen.lua:1587
+#: sui_homescreen.lua:1681
 msgid "Top Margin  (%d%%)"
 msgstr "Marginea de sus  (%d%%)"
 
-#: sui_menu.lua:859
+#: sui_menu.lua:921
 msgid "Top separator"
-msgstr "Separator antet"
+msgstr "Separator superior"
 
-#: sui_menu.lua:1853
+#: sui_menu.lua:2071
 msgid "Transparent"
 msgstr "Transparent"
 
@@ -1686,17 +1756,25 @@ msgstr "Transparent"
 msgid "Tuesday"
 msgstr "marți"
 
-#: sui_menu.lua:872 desktop_modules/module_quick_actions.lua:403
+#: sui_menu.lua:934 desktop_modules/module_quick_actions.lua:402
 #: desktop_modules/module_reading_goals.lua:584
-#: desktop_modules/module_reading_stats.lua:431
+#: desktop_modules/module_reading_stats.lua:430
 msgid "Type"
 msgstr "Stil"
 
-#: sui_menu.lua:1892
+#: sui_menu.lua:2122
 msgid "Uniformize Covers (2:3)"
 msgstr "Uniformizează coperțile (2:3)"
 
-#: sui_menu.lua:1970
+#: sui_updater.lua:377
+msgid "Update cancelled."
+msgstr "Actualizarea a fost anulată."
+
+#: sui_updater.lua:487
+msgid "Update check cancelled."
+msgstr "Verificarea pentru actualizări a fost anulată."
+
+#: sui_menu.lua:2200
 msgid "Updater module not found."
 msgstr "Modulul de actualizare nu a fost găsit."
 
@@ -1708,11 +1786,11 @@ msgstr ""
 "Folosește bara de paginare standard a KOReader pe ecranul Acasă.\n"
 "Nu este disponibilă cînd Navpager este activ."
 
-#: sui_menu.lua:1955
+#: sui_menu.lua:2185
 msgid "Version: %s"
 msgstr "Versiune: %s"
 
-#: sui_homescreen.lua:1590
+#: sui_homescreen.lua:1684
 msgid ""
 "Vertical space above this module.\n"
 "100% is the default spacing."
@@ -1720,7 +1798,7 @@ msgstr ""
 "Spațiu vertical deasupra acestui modul.\n"
 "Mărimea implicită este 100%."
 
-#: sui_menu.lua:859
+#: sui_menu.lua:921
 msgid "Visible"
 msgstr "Vizibil"
 
@@ -1728,7 +1806,11 @@ msgstr "Vizibil"
 msgid "Wednesday"
 msgstr "miercuri"
 
-#: sui_menu.lua:1606
+#: sui_updater.lua:412
+msgid "What's new:"
+msgstr "Ce este nou:"
+
+#: sui_menu.lua:1854
 msgid ""
 "When enabled, long-pressing a section opens its settings menu.\n"
 "Disable this to prevent the settings menu from appearing on long tap."
@@ -1738,31 +1820,32 @@ msgstr ""
 "Dezactivează asta pentru a preveni apariția meniului de setări la apăsarea "
 "lungă."
 
-#: sui_menu.lua:889
+#: sui_menu.lua:951
 msgid ""
 "When enabled, long-pressing the bottom bar opens its settings menu.\n"
 "Disable this to prevent the settings menu from appearing on long tap."
 msgstr ""
-"Cînd este activată, apăsarea lungă pe bara din subsol va deschide meniul de "
+"Cînd este activată, apăsarea lungă pe bara de jos va deschide meniul de "
 "setări al acesteia.\n"
 "Dezactivează asta pentru a preveni apariția meniului de setări la apăsarea "
 "lungă."
 
-#: sui_menu.lua:719
+#: sui_menu.lua:781
 msgid ""
 "When enabled, long-pressing the top bar opens its settings menu.\n"
 "Disable this to prevent the settings menu from appearing on long tap."
 msgstr ""
-"Cînd este activată, apăsarea lungă pe bara din antet va deschide meniul de "
+"Cînd este activată, apăsarea lungă pe bara de sus va deschide meniul de "
 "setări al acesteia.\n"
 "Dezactivează asta pentru a preveni apariția meniului de setări la apăsarea "
 "lungă."
 
-#: sui_menu.lua:1591
+#: sui_menu.lua:1842
 msgid ""
 "When enabled, opening the file browser after finishing or closing a book "
 "navigates to the folder the book is in, matching native KOReader behaviour.\n"
-"When disabled (default), SimpleUI always returns to the library root."
+"When disabled (default), SimpleUI always returns to the library root.\n"
+"This option works independently of \"Start with Home Screen\"."
 msgstr ""
 "Cînd este activată, deschiderea navigatorului de fișiere după terminarea sau "
 "închiderea unei cărți va naviga către dosarul în care se află cartea, exact "
@@ -1790,27 +1873,37 @@ msgstr "WiFi nu este disponibil pe acest dispozitiv."
 msgid "Wikipedia Lookup"
 msgstr "Căutare pe Wikipedia"
 
-#: desktop_modules/module_currently.lua:788
+#: desktop_modules/module_currently.lua:936
 msgid "With percentage"
 msgstr "Cu procentaj"
 
-#: desktop_modules/module_quote.lua:747
+#: desktop_modules/module_quote.lua:748
 msgid "Your highlights"
 msgstr "Evidențierile tale"
 
-#: desktop_modules/module_reading_stats.lua:67
+#: sui_updater.lua:410
+msgid ""
+"\n"
+"\n"
+"Download and install now?"
+msgstr ""
+"\n"
+"\n"
+"Descarci și instalezi acum?"
+
+#: desktop_modules/module_reading_stats.lua:66
 msgid "books finished"
 msgstr "cărți terminate"
 
-#: desktop_modules/module_reading_stats.lua:64
+#: desktop_modules/module_reading_stats.lua:63
 msgid "daily avg (7 days)"
 msgstr "media zilnică (7 zile)"
 
-#: desktop_modules/module_reading_stats.lua:69
+#: desktop_modules/module_reading_stats.lua:68
 msgid "day streak"
 msgstr "zi în serie"
 
-#: desktop_modules/module_reading_stats.lua:69
+#: desktop_modules/module_reading_stats.lua:68
 msgid "days streak"
 msgstr "zile în serie"
 
@@ -1818,7 +1911,7 @@ msgstr "zile în serie"
 msgid "default"
 msgstr "implicit"
 
-#: sui_menu.lua:679 sui_menu.lua:748 sui_menu.lua:1088 sui_menu.lua:1702
+#: sui_menu.lua:741 sui_menu.lua:810 sui_menu.lua:1150 sui_menu.lua:1919
 msgid "disabled"
 msgstr "dezactivat"
 
@@ -1838,7 +1931,7 @@ msgstr "ex: Sci-Fi…"
 msgid "e.g. Sleep, Refresh…"
 msgstr "ex: Ațipire, Reîmprospătare…"
 
-#: sui_menu.lua:679 sui_menu.lua:748 sui_menu.lua:1088 sui_menu.lua:1702
+#: sui_menu.lua:741 sui_menu.lua:810 sui_menu.lua:1150 sui_menu.lua:1919
 msgid "enabled"
 msgstr "activat"
 
@@ -1846,7 +1939,7 @@ msgstr "activat"
 msgid "hex code, e.g. E001"
 msgstr "cod hex, ex: E001"
 
-#: desktop_modules/module_reading_stats.lua:69
+#: desktop_modules/module_reading_stats.lua:68
 msgid "no streak"
 msgstr "nicio serie"
 
@@ -1854,21 +1947,31 @@ msgstr "nicio serie"
 msgid "not configured"
 msgstr "neconfigurat"
 
-#: desktop_modules/module_reading_stats.lua:62
+#: desktop_modules/module_reading_stats.lua:61
 msgid "of reading today"
 msgstr "de citit astăzi"
 
-#: desktop_modules/module_reading_stats.lua:66
+#: desktop_modules/module_reading_stats.lua:65
 msgid "of reading, all time"
 msgstr "de citit, din tot timpul"
 
-#: desktop_modules/module_reading_stats.lua:63
+#: desktop_modules/module_reading_stats.lua:62
 msgid "pages read today"
 msgstr "pagini citite astăzi"
 
-#: desktop_modules/module_reading_stats.lua:65
+#: desktop_modules/module_reading_stats.lua:64
 msgid "pages/day (7 days)"
 msgstr "pagini/zi (7 zile)"
+
+#: sui_menu.lua:238 sui_menu.lua:1336
+#: desktop_modules/module_collections.lua:689
+#: desktop_modules/module_quick_actions.lua:319
+#: desktop_modules/module_reading_stats.lua:507
+msgid "  (%d left)"
+msgid_plural "  (%d left)"
+msgstr[0] "  (%s rămasă)"
+msgstr[1] "  (%s rămase)"
+msgstr[2] "  (%s rămase)"
 
 #: desktop_modules/module_reading_goals.lua:617
 msgid "  Set Goal  (%d book in %s)"
@@ -1884,8 +1987,9 @@ msgstr[0] "%d carte"
 msgstr[1] "%d cărți"
 msgstr[2] "%d de cărți"
 
-#: desktop_modules/module_currently.lua:446
-#: desktop_modules/module_currently.lua:513
+#: desktop_modules/module_coverdeck.lua:574
+#: desktop_modules/module_currently.lua:540
+#: desktop_modules/module_currently.lua:607
 msgid "%d day of reading"
 msgid_plural "%d days of reading"
 msgstr[0] "%d zi de citit"
@@ -1899,21 +2003,38 @@ msgstr[0] "%d/%d carte"
 msgstr[1] "%d/%d cărți"
 msgstr[2] "%d/%d de cărți"
 
-#: sui_menu.lua:1168
+#: sui_menu.lua:1230
 msgid "Digital: %d book in %s"
 msgid_plural "Digital: %d books in %s"
 msgstr[0] "Digital: %d carte în %s"
 msgstr[1] "Digital: %d cărți în %s"
 msgstr[2] "Digital: %d de cărți în %s"
 
-#: sui_menu.lua:1174
+#: sui_menu.lua:1236
 msgid "Physical: %d book in %s"
 msgid_plural "Physical: %d books in %s"
 msgstr[0] "Fizic: %d carte în %s"
 msgstr[1] "Fizic: %d cărți în %s"
 msgstr[2] "Fizic: %d de cărți în %s"
 
-#: sui_menu.lua:1238 desktop_modules/module_quick_actions.lua:262
+#: sui_menu.lua:556
+msgid ""
+"Text shown in the top bar.\n"
+"Maximum %d character."
+msgid_plural ""
+"Text shown in the top bar.\n"
+"Maximum %d characters."
+msgstr[0] ""
+"Textul afișat în bara superioară.\n"
+"Maxim %d caracter."
+msgstr[1] ""
+"Textul afișat în bara superioară.\n"
+"Maxim %d caractere."
+msgstr[2] ""
+"Textul afișat în bara superioară.\n"
+"Maxim %d de caractere."
+
+#: sui_menu.lua:1300 desktop_modules/module_quick_actions.lua:262
 msgid "The maximum of %d action per module has been reached. Remove one first."
 msgid_plural ""
 "The maximum of %d actions per module has been reached. Remove one first."
@@ -1935,7 +2056,7 @@ msgstr[1] ""
 msgstr[2] ""
 "Numărul maxim de %d de acțiuni rapide a fost atins. Șterge una mai întîi."
 
-#: desktop_modules/module_reading_stats.lua:420
+#: desktop_modules/module_reading_stats.lua:419
 msgid "The maximum of %d stat per row has been reached. Remove one first."
 msgid_plural ""
 "The maximum of %d stats per row has been reached. Remove one first."
@@ -1958,6 +2079,36 @@ msgstr[2] "Numărul maxim de %d de file a fost atins. Șterge una mai întîi."
 
 #~ msgid "1 day of reading"
 #~ msgstr "1 zi de citit"
+
+#~ msgid "Could not retrieve version information."
+#~ msgstr "Nu s-a putut prelua informația de versiune."
+
+#~ msgid "Enable at least 2 modules to arrange."
+#~ msgstr "Activează cel puțin 2 module pentru a le aranja."
+
+#~ msgid ""
+#~ "Maximum number of modules shown on each page.\n"
+#~ "Swipe left/right on the Home Screen to turn pages."
+#~ msgstr ""
+#~ "Numărul maxim de module afișat pe fiecare pagină.\n"
+#~ "Glisează stînga/dreapta pe ecranul Acasă pentru a întoarce paginile."
+
+#~ msgid "Modules per Page"
+#~ msgstr "Module per pagină"
+
+#~ msgid "Modules per Page  (%d)"
+#~ msgstr "Module per pagină  (%d)"
+
+#~ msgid ""
+#~ "Simple UI %s is available!\n"
+#~ "Current version: %s\n"
+#~ "\n"
+#~ "Download and install now?"
+#~ msgstr ""
+#~ "Simple UI %s este disponibil!\n"
+#~ "Versiunea curentă: %s\n"
+#~ "\n"
+#~ "Descarci și instalezi acum?"
 
 #~ msgid "Maximum %d stats per row. Remove one first."
 #~ msgstr ""
@@ -2020,9 +2171,6 @@ msgstr[2] "Numărul maxim de %d de file a fost atins. Șterge una mai întîi."
 
 #~ msgid "%s TO GO"
 #~ msgstr "%s DE PARCURS"
-
-#~ msgid "Custom Text"
-#~ msgstr "Text personalizat"
 
 #~ msgid "Date"
 #~ msgstr "Dată"

--- a/locale/simpleui.pot
+++ b/locale/simpleui.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: simpleui\n"
-"POT-Creation-Date: 2026-04-10 23:03\n"
+"POT-Creation-Date: 2026-04-11 15:45\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -52,11 +52,11 @@ msgstr ""
 msgid "%s remaining"
 msgstr ""
 
-#: sui_menu.lua:846
+#: sui_menu.lua:845
 msgid "A restart is required to apply the new bar size across all layouts.\n\nRestart now?"
 msgstr ""
 
-#: sui_menu.lua:2106
+#: sui_menu.lua:2174
 msgid "About"
 msgstr ""
 
@@ -64,7 +64,7 @@ msgstr ""
 msgid "Above"
 msgstr ""
 
-#: sui_menu.lua:1320
+#: sui_menu.lua:1319
 #: desktop_modules/module_quick_actions.lua:288
 msgid "Add at least 2 actions to arrange."
 msgstr ""
@@ -93,17 +93,17 @@ msgstr ""
 msgid "Annual Goal"
 msgstr ""
 
-#: sui_menu.lua:1230
+#: sui_menu.lua:1229
 #: desktop_modules/module_reading_goals.lua:353
 msgid "Annual Reading Goal"
 msgstr ""
 
 #: sui_config.lua:1626
 #: sui_config.lua:1707
-#: sui_menu.lua:766
-#: sui_menu.lua:836
-#: sui_menu.lua:1669
-#: sui_menu.lua:1704
+#: sui_menu.lua:765
+#: sui_menu.lua:835
+#: sui_menu.lua:1736
+#: sui_menu.lua:1771
 msgid "Apply"
 msgstr ""
 
@@ -115,32 +115,32 @@ msgstr ""
 msgid "Arrange"
 msgstr ""
 
-#: sui_menu.lua:1324
+#: sui_menu.lua:1323
 #: desktop_modules/module_quick_actions.lua:300
 msgid "Arrange %s"
 msgstr ""
 
-#: sui_menu.lua:1046
-#: sui_menu.lua:1097
-#: sui_menu.lua:1112
+#: sui_menu.lua:1045
+#: sui_menu.lua:1096
+#: sui_menu.lua:1111
 msgid "Arrange Buttons"
 msgstr ""
 
-#: desktop_modules/module_collections.lua:621
-#: desktop_modules/module_collections.lua:634
+#: desktop_modules/module_collections.lua:622
+#: desktop_modules/module_collections.lua:635
 msgid "Arrange Collections"
 msgstr ""
 
-#: sui_menu.lua:601
-#: sui_menu.lua:630
-#: sui_menu.lua:1314
+#: sui_menu.lua:600
+#: sui_menu.lua:629
+#: sui_menu.lua:1313
 #: desktop_modules/module_currently.lua:863
 #: desktop_modules/module_currently.lua:887
 #: desktop_modules/module_quick_actions.lua:279
 msgid "Arrange Items"
 msgstr ""
 
-#: sui_menu.lua:1511
+#: sui_menu.lua:1578
 msgid "Arrange Modules"
 msgstr ""
 
@@ -171,13 +171,13 @@ msgstr ""
 msgid "Author"
 msgstr ""
 
-#: sui_menu.lua:2122
+#: sui_menu.lua:2190
 msgid "Author: %s"
 msgstr ""
 
 #: sui_foldercovers.lua:540
 #: sui_foldercovers.lua:605
-#: desktop_modules/module_collections.lua:582
+#: desktop_modules/module_collections.lua:583
 msgid "Auto (first book)"
 msgstr ""
 
@@ -185,11 +185,11 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: desktop_modules/module_collections.lua:661
+#: desktop_modules/module_collections.lua:662
 msgid "Badge position: Bottom"
 msgstr ""
 
-#: desktop_modules/module_collections.lua:662
+#: desktop_modules/module_collections.lua:663
 msgid "Badge position: Top"
 msgstr ""
 
@@ -221,31 +221,31 @@ msgstr ""
 msgid "Books to read in %s:"
 msgstr ""
 
-#: sui_menu.lua:1874
-#: sui_menu.lua:1968
-#: sui_menu.lua:2030
+#: sui_menu.lua:1941
+#: sui_menu.lua:2036
+#: sui_menu.lua:2098
 msgid "Bottom"
 msgstr ""
 
 #: sui_bottombar.lua:843
-#: sui_menu.lua:803
+#: sui_menu.lua:802
 msgid "Bottom Bar"
 msgstr ""
 
-#: sui_menu.lua:829
+#: sui_menu.lua:828
 msgid "Bottom Bar Size"
 msgstr ""
 
-#: sui_menu.lua:811
+#: sui_menu.lua:810
 msgid "Bottom Bar will be %s after restart.\n\nRestart now?"
 msgstr ""
 
-#: sui_menu.lua:862
-#: sui_menu.lua:865
+#: sui_menu.lua:861
+#: sui_menu.lua:864
 msgid "Bottom Margin"
 msgstr ""
 
-#: sui_menu.lua:863
+#: sui_menu.lua:862
 msgid "Bottom Margin — %d%%"
 msgstr ""
 
@@ -254,7 +254,7 @@ msgstr ""
 msgid "Brightness"
 msgstr ""
 
-#: sui_menu.lua:1162
+#: sui_menu.lua:1161
 msgid "Button Size"
 msgstr ""
 
@@ -264,11 +264,11 @@ msgstr ""
 #: sui_config.lua:1708
 #: sui_foldercovers.lua:569
 #: sui_foldercovers.lua:636
-#: sui_menu.lua:563
-#: sui_menu.lua:767
-#: sui_menu.lua:837
-#: sui_menu.lua:1670
-#: sui_menu.lua:1705
+#: sui_menu.lua:562
+#: sui_menu.lua:766
+#: sui_menu.lua:836
+#: sui_menu.lua:1737
+#: sui_menu.lua:1772
 #: sui_quickactions.lua:358
 #: sui_quickactions.lua:444
 #: sui_quickactions.lua:552
@@ -281,8 +281,8 @@ msgstr ""
 #: sui_quickactions.lua:1153
 #: sui_updater.lua:421
 #: sui_updater.lua:438
-#: desktop_modules/module_collections.lua:608
-#: desktop_modules/module_quote.lua:952
+#: desktop_modules/module_collections.lua:609
+#: desktop_modules/module_quote.lua:959
 #: desktop_modules/module_reading_goals.lua:357
 #: desktop_modules/module_reading_goals.lua:373
 #: desktop_modules/module_reading_goals.lua:390
@@ -293,8 +293,8 @@ msgstr ""
 msgid "Cards"
 msgstr ""
 
-#: sui_menu.lua:617
-#: sui_menu.lua:2022
+#: sui_menu.lua:616
+#: sui_menu.lua:2090
 msgid "Center"
 msgstr ""
 
@@ -302,7 +302,7 @@ msgstr ""
 msgid "Change Icons"
 msgstr ""
 
-#: sui_menu.lua:2127
+#: sui_menu.lua:2195
 msgid "Check for Updates"
 msgstr ""
 
@@ -327,8 +327,8 @@ msgstr ""
 msgid "Collection"
 msgstr ""
 
-#: desktop_modules/module_collections.lua:569
-#: desktop_modules/module_collections.lua:575
+#: desktop_modules/module_collections.lua:570
+#: desktop_modules/module_collections.lua:576
 msgid "Collection is empty."
 msgstr ""
 
@@ -342,11 +342,11 @@ msgstr ""
 #: desktop_modules/module_collections.lua:298
 #: desktop_modules/module_collections.lua:299
 #: desktop_modules/module_collections.lua:318
-#: desktop_modules/module_collections.lua:619
+#: desktop_modules/module_collections.lua:620
 msgid "Collections"
 msgstr ""
 
-#: sui_patches.lua:900
+#: sui_patches.lua:906
 msgid "Collections (%1)"
 msgstr ""
 
@@ -354,7 +354,7 @@ msgstr ""
 msgid "Collections not available."
 msgstr ""
 
-#: sui_menu.lua:1166
+#: sui_menu.lua:1165
 #: desktop_modules/module_currently.lua:964
 #: desktop_modules/module_reading_goals.lua:594
 msgid "Compact"
@@ -372,12 +372,12 @@ msgstr ""
 msgid "Cover Deck"
 msgstr ""
 
-#: desktop_modules/module_collections.lua:612
+#: desktop_modules/module_collections.lua:613
 msgid "Cover for \"%s\""
 msgstr ""
 
-#: desktop_modules/module_collections.lua:650
-#: desktop_modules/module_collections.lua:652
+#: desktop_modules/module_collections.lua:651
+#: desktop_modules/module_collections.lua:653
 #: desktop_modules/module_coverdeck.lua:707
 #: desktop_modules/module_coverdeck.lua:708
 #: desktop_modules/module_currently.lua:811
@@ -396,7 +396,7 @@ msgstr ""
 #: sui_config.lua:1735
 #: desktop_modules/module_currently.lua:296
 #: desktop_modules/module_currently.lua:297
-#: desktop_modules/module_currently.lua:401
+#: desktop_modules/module_currently.lua:402
 #: desktop_modules/module_currently.lua:981
 msgid "Currently Reading"
 msgstr ""
@@ -406,15 +406,15 @@ msgid "Custom"
 msgstr ""
 
 #: sui_config.lua:165
-#: sui_menu.lua:555
+#: sui_menu.lua:554
 msgid "Custom Text"
 msgstr ""
 
-#: sui_menu.lua:1139
+#: sui_menu.lua:1138
 msgid "Custom Title Bar"
 msgstr ""
 
-#: sui_menu.lua:1150
+#: sui_menu.lua:1149
 msgid "Custom Title Bar will be %s after restart.\n\nRestart now?"
 msgstr ""
 
@@ -443,13 +443,13 @@ msgstr ""
 msgid "December"
 msgstr ""
 
-#: sui_menu.lua:353
-#: sui_menu.lua:482
-#: sui_menu.lua:1167
+#: sui_menu.lua:352
+#: sui_menu.lua:481
+#: sui_menu.lua:1166
 #: sui_quickactions.lua:512
 #: desktop_modules/module_currently.lua:954
-#: desktop_modules/module_quick_actions.lua:402
-#: desktop_modules/module_quick_actions.lua:407
+#: desktop_modules/module_quick_actions.lua:401
+#: desktop_modules/module_quick_actions.lua:406
 #: desktop_modules/module_reading_goals.lua:586
 msgid "Default"
 msgstr ""
@@ -467,7 +467,7 @@ msgstr ""
 msgid "Default (System)"
 msgstr ""
 
-#: desktop_modules/module_quote.lua:1040
+#: desktop_modules/module_quote.lua:1042
 msgid "Default Quotes"
 msgstr ""
 
@@ -484,11 +484,11 @@ msgstr ""
 msgid "Dictionary Lookup"
 msgstr ""
 
-#: sui_menu.lua:1231
+#: sui_menu.lua:1230
 msgid "Digital Goal  (%s)"
 msgstr ""
 
-#: sui_menu.lua:1689
+#: sui_menu.lua:1756
 msgid "Disable \"Lock Scale\" first to set a custom label scale."
 msgstr ""
 
@@ -504,7 +504,7 @@ msgstr ""
 msgid "Dispatcher not available."
 msgstr ""
 
-#: sui_menu.lua:390
+#: sui_menu.lua:389
 msgid "Dot Pager"
 msgstr ""
 
@@ -524,8 +524,8 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: sui_menu.lua:547
-#: sui_menu.lua:549
+#: sui_menu.lua:546
+#: sui_menu.lua:548
 msgid "Edit Custom Text"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Error checking for updates: "
 msgstr ""
 
-#: sui_menu.lua:458
+#: sui_menu.lua:457
 msgid "Extra Small"
 msgstr ""
 
@@ -574,8 +574,8 @@ msgstr ""
 msgid "File Search"
 msgstr ""
 
-#: desktop_modules/module_quick_actions.lua:402
-#: desktop_modules/module_quick_actions.lua:416
+#: desktop_modules/module_quick_actions.lua:401
+#: desktop_modules/module_quick_actions.lua:415
 #: desktop_modules/module_reading_stats.lua:443
 msgid "Flat"
 msgstr ""
@@ -584,15 +584,15 @@ msgstr ""
 msgid "Folder"
 msgstr ""
 
-#: sui_menu.lua:1912
+#: sui_menu.lua:1979
 msgid "Folder Covers"
 msgstr ""
 
-#: sui_menu.lua:1990
+#: sui_menu.lua:2058
 msgid "Folder Name"
 msgstr ""
 
-#: sui_menu.lua:2042
+#: sui_menu.lua:2110
 msgid "Folder Name Text Size"
 msgstr ""
 
@@ -612,48 +612,48 @@ msgstr ""
 msgid "Frontlight not available on this device."
 msgstr ""
 
-#: sui_menu.lua:350
+#: sui_menu.lua:349
 msgid "General"
 msgstr ""
 
-#: sui_menu.lua:1663
+#: sui_menu.lua:1730
 msgid "Global scale for all modules.\nIndividual overrides in Module Settings take precedence.\n100% is the default size."
 msgstr ""
 
-#: sui_menu.lua:1932
+#: sui_menu.lua:1999
 msgid "Group Books by Series"
 msgstr ""
 
-#: sui_menu.lua:830
+#: sui_menu.lua:829
 msgid "Height of the bottom navigation bar.\n100% is the default size."
 msgstr ""
 
-#: sui_menu.lua:760
+#: sui_menu.lua:759
 msgid "Height of the top status bar.\n100% is the default size."
 msgstr ""
 
-#: sui_menu.lua:374
-#: sui_menu.lua:433
-#: sui_menu.lua:922
-#: sui_menu.lua:1949
-#: sui_menu.lua:1993
+#: sui_menu.lua:373
+#: sui_menu.lua:432
+#: sui_menu.lua:921
+#: sui_menu.lua:2017
+#: sui_menu.lua:2061
 msgid "Hidden"
 msgstr ""
 
-#: sui_menu.lua:1348
-#: desktop_modules/module_quick_actions.lua:330
+#: sui_menu.lua:1346
+#: desktop_modules/module_quick_actions.lua:329
 msgid "Hide Text"
 msgstr ""
 
-#: sui_menu.lua:529
+#: sui_menu.lua:528
 msgid "Hide Wi-Fi icon when off"
 msgstr ""
 
-#: sui_menu.lua:2064
+#: sui_menu.lua:2132
 msgid "Hide selection underline"
 msgstr ""
 
-#: sui_menu.lua:441
+#: sui_menu.lua:440
 msgid "Hides the pagination bar on the homescreen.\nNot available when Navpager is active."
 msgstr ""
 
@@ -671,11 +671,11 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: sui_menu.lua:387
-#: sui_menu.lua:1754
-#: sui_menu.lua:1872
-#: sui_patches.lua:497
-#: sui_patches.lua:520
+#: sui_menu.lua:386
+#: sui_menu.lua:1821
+#: sui_menu.lua:1939
+#: sui_patches.lua:503
+#: sui_patches.lua:526
 msgid "Home Screen"
 msgstr ""
 
@@ -700,12 +700,12 @@ msgstr ""
 msgid "Icon"
 msgstr ""
 
-#: sui_menu.lua:884
-#: sui_menu.lua:887
+#: sui_menu.lua:883
+#: sui_menu.lua:886
 msgid "Icon Size"
 msgstr ""
 
-#: sui_menu.lua:885
+#: sui_menu.lua:884
 msgid "Icon Size — %d%%"
 msgstr ""
 
@@ -721,11 +721,11 @@ msgstr ""
 msgid "Icons only"
 msgstr ""
 
-#: sui_menu.lua:1059
+#: sui_menu.lua:1058
 msgid "Invalid arrangement.\nKeep items between the Left and Right separators."
 msgstr ""
 
-#: sui_menu.lua:644
+#: sui_menu.lua:643
 msgid "Invalid arrangement.\nKeep the Left, Center and Right separators in order."
 msgstr ""
 
@@ -733,11 +733,11 @@ msgstr ""
 msgid "Invalid input. Please enter 1–6 hexadecimal digits (0–9, A–F)."
 msgstr ""
 
-#: sui_menu.lua:779
-#: sui_menu.lua:1358
+#: sui_menu.lua:778
+#: sui_menu.lua:1356
 #: desktop_modules/module_coverdeck.lua:769
 #: desktop_modules/module_currently.lua:983
-#: desktop_modules/module_quick_actions.lua:340
+#: desktop_modules/module_quick_actions.lua:339
 msgid "Items"
 msgstr ""
 
@@ -753,54 +753,54 @@ msgstr ""
 msgid "June"
 msgstr ""
 
-#: sui_menu.lua:411
+#: sui_menu.lua:410
 msgid "KOReader"
 msgstr ""
 
-#: sui_menu.lua:1697
+#: sui_menu.lua:1764
 msgid "Label Scale"
 msgstr ""
 
-#: sui_menu.lua:904
-#: sui_menu.lua:907
+#: sui_menu.lua:903
+#: sui_menu.lua:906
 msgid "Label Size"
 msgstr ""
 
-#: sui_menu.lua:905
+#: sui_menu.lua:904
 msgid "Label Size — %d%%"
 msgstr ""
 
-#: sui_menu.lua:1682
+#: sui_menu.lua:1749
 msgid "Labels"
 msgstr ""
 
-#: sui_menu.lua:1168
+#: sui_menu.lua:1167
 msgid "Large"
 msgstr ""
 
-#: sui_menu.lua:338
-#: sui_menu.lua:743
-#: sui_menu.lua:812
-#: sui_menu.lua:848
-#: sui_menu.lua:1154
-#: sui_menu.lua:1853
+#: sui_menu.lua:337
+#: sui_menu.lua:742
+#: sui_menu.lua:811
+#: sui_menu.lua:847
+#: sui_menu.lua:1153
+#: sui_menu.lua:1920
 #: sui_updater.lua:361
 msgid "Later"
 msgstr ""
 
-#: sui_menu.lua:611
-#: sui_menu.lua:1029
+#: sui_menu.lua:610
+#: sui_menu.lua:1028
 msgid "Left"
 msgstr ""
 
 #: sui_config.lua:131
 #: sui_config.lua:403
-#: sui_menu.lua:1893
-#: sui_titlebar.lua:675
+#: sui_menu.lua:1960
+#: sui_titlebar.lua:720
 msgid "Library"
 msgstr ""
 
-#: sui_menu.lua:1172
+#: sui_menu.lua:1171
 msgid "Library Buttons"
 msgstr ""
 
@@ -808,7 +808,7 @@ msgstr ""
 msgid "List"
 msgstr ""
 
-#: sui_menu.lua:1643
+#: sui_menu.lua:1710
 msgid "Lock Scale"
 msgstr ""
 
@@ -829,11 +829,11 @@ msgstr ""
 msgid "Menu"
 msgstr ""
 
-#: sui_menu.lua:262
+#: sui_menu.lua:261
 msgid "Minimum 1 tab required in navpager mode."
 msgstr ""
 
-#: sui_menu.lua:263
+#: sui_menu.lua:262
 msgid "Minimum 2 tabs required. Select another tab first."
 msgstr ""
 
@@ -841,19 +841,19 @@ msgstr ""
 msgid "Minutes per day:"
 msgstr ""
 
-#: sui_menu.lua:1660
+#: sui_menu.lua:1727
 msgid "Module Scale"
 msgstr ""
 
-#: sui_menu.lua:1635
+#: sui_menu.lua:1702
 msgid "Module Settings"
 msgstr ""
 
-#: sui_menu.lua:1654
+#: sui_menu.lua:1721
 msgid "Modules"
 msgstr ""
 
-#: sui_menu.lua:1475
+#: sui_menu.lua:1473
 msgid "Modules  (%d)"
 msgstr ""
 
@@ -861,7 +861,7 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
-#: desktop_modules/module_quote.lua:1060
+#: desktop_modules/module_quote.lua:1062
 msgid "My Highlights"
 msgstr ""
 
@@ -872,15 +872,15 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: sui_menu.lua:1876
+#: sui_menu.lua:1943
 msgid "Navigation Bar"
 msgstr ""
 
-#: sui_menu.lua:363
+#: sui_menu.lua:362
 msgid "Navpager"
 msgstr ""
 
-#: sui_menu.lua:370
+#: sui_menu.lua:369
 msgid "Navpager enabled.\n\nRestart now?"
 msgstr ""
 
@@ -943,7 +943,7 @@ msgstr ""
 msgid "No books opened yet"
 msgstr ""
 
-#: desktop_modules/module_collections.lua:672
+#: desktop_modules/module_collections.lua:673
 msgid "No collections found."
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "No folder, collection or plugin configured.\nGo to Simple UI \xe2\x86\x92 Settings \xe2\x86\x92 Quick Actions to set one."
 msgstr ""
 
-#: desktop_modules/module_quote.lua:745
+#: desktop_modules/module_quote.lua:746
 msgid "No highlights found. Open a book and highlight some passages."
 msgstr ""
 
@@ -967,7 +967,7 @@ msgstr ""
 msgid "No plugins found."
 msgstr ""
 
-#: desktop_modules/module_quote.lua:711
+#: desktop_modules/module_quote.lua:712
 msgid "No quotes found."
 msgstr ""
 
@@ -983,16 +983,16 @@ msgstr ""
 msgid "November"
 msgstr ""
 
-#: sui_menu.lua:1946
+#: sui_menu.lua:2014
 msgid "Number of Books in Folder"
 msgstr ""
 
-#: sui_menu.lua:1480
-#: sui_menu.lua:1978
+#: sui_menu.lua:1478
+#: sui_menu.lua:2046
 msgid "Number of Pages"
 msgstr ""
 
-#: sui_menu.lua:497
+#: sui_menu.lua:496
 msgid "Number of Pages in Title Bar Always"
 msgstr ""
 
@@ -1004,26 +1004,26 @@ msgstr ""
 msgid "October"
 msgstr ""
 
-#: sui_menu.lua:734
-#: sui_menu.lua:803
-#: sui_menu.lua:993
-#: sui_menu.lua:1139
-#: sui_menu.lua:1754
-#: sui_menu.lua:1835
+#: sui_menu.lua:733
+#: sui_menu.lua:802
+#: sui_menu.lua:992
+#: sui_menu.lua:1138
+#: sui_menu.lua:1821
+#: sui_menu.lua:1902
 msgid "Off"
 msgstr ""
 
-#: sui_menu.lua:734
-#: sui_menu.lua:803
-#: sui_menu.lua:993
-#: sui_menu.lua:1139
-#: sui_menu.lua:1754
-#: sui_menu.lua:1835
+#: sui_menu.lua:733
+#: sui_menu.lua:802
+#: sui_menu.lua:992
+#: sui_menu.lua:1138
+#: sui_menu.lua:1821
+#: sui_menu.lua:1902
 msgid "On"
 msgstr ""
 
 #: sui_homescreen.lua:420
-#: desktop_modules/module_quote.lua:951
+#: desktop_modules/module_quote.lua:958
 msgid "Open"
 msgstr ""
 
@@ -1036,34 +1036,34 @@ msgid "Open in browser"
 msgstr ""
 
 #: sui_homescreen.lua:419
-#: desktop_modules/module_quote.lua:950
+#: desktop_modules/module_quote.lua:957
 msgid "Open this file?"
 msgstr ""
 
-#: sui_menu.lua:1942
+#: sui_menu.lua:2010
 msgid "Overlays"
 msgstr ""
 
 #: sui_homescreen.lua:1611
-#: sui_patches.lua:1561
+#: sui_patches.lua:1567
 msgid "Page %1 of %2"
 msgstr ""
 
-#: sui_menu.lua:1877
+#: sui_menu.lua:1944
 msgid "Pagination Bar"
 msgstr ""
 
-#: sui_menu.lua:380
+#: sui_menu.lua:379
 msgid "Pagination bar hidden.\n\nRestart now?"
 msgstr ""
 
-#: sui_menu.lua:359
+#: sui_menu.lua:358
 msgid "Pagination bar set to Default.\n\nRestart now?"
 msgstr ""
 
-#: sui_menu.lua:466
-#: sui_menu.lua:478
-#: sui_menu.lua:490
+#: sui_menu.lua:465
+#: sui_menu.lua:477
+#: sui_menu.lua:489
 msgid "Pagination bar size will change after restart.\n\nRestart now?"
 msgstr ""
 
@@ -1093,7 +1093,7 @@ msgstr ""
 msgid "Physical books read this year:"
 msgstr ""
 
-#: sui_menu.lua:2071
+#: sui_menu.lua:2139
 msgid "Placeholder cover for bookless folders"
 msgstr ""
 
@@ -1126,20 +1126,20 @@ msgstr ""
 msgid "Progress bar style"
 msgstr ""
 
-#: sui_menu.lua:1453
-#: sui_menu.lua:1884
+#: sui_menu.lua:1451
+#: sui_menu.lua:1951
 msgid "Quick Actions"
 msgstr ""
 
-#: sui_menu.lua:1888
+#: sui_menu.lua:1955
 msgid "Quick Actions  (%d/%d — %d left)"
 msgstr ""
 
-#: sui_menu.lua:1886
+#: sui_menu.lua:1953
 msgid "Quick Actions  (%d/%d — at limit)"
 msgstr ""
 
-#: sui_menu.lua:1290
+#: sui_menu.lua:1289
 #: desktop_modules/module_quick_actions.lua:198
 #: desktop_modules/module_quick_actions.lua:244
 msgid "Quick Actions %d"
@@ -1149,11 +1149,11 @@ msgstr ""
 msgid "Quit"
 msgstr ""
 
-#: desktop_modules/module_quote.lua:821
+#: desktop_modules/module_quote.lua:822
 msgid "Quote of the Day"
 msgstr ""
 
-#: desktop_modules/module_quote.lua:1082
+#: desktop_modules/module_quote.lua:1084
 msgid "Quotes + My Highlights"
 msgstr ""
 
@@ -1189,40 +1189,40 @@ msgstr ""
 msgid "Rename"
 msgstr ""
 
-#: sui_menu.lua:366
+#: sui_menu.lua:365
 msgid "Replaces the pagination bar with Prev/Next arrows at the edges of the bottom bar.\nThe arrows dim when there is no previous or next page.\nWith navpager active, as few as 1 tab and at most 4 tabs can be configured."
 msgstr ""
 
-#: sui_menu.lua:1725
+#: sui_menu.lua:1792
 #: sui_quickactions.lua:1015
 msgid "Reset"
 msgstr ""
 
-#: sui_menu.lua:1724
+#: sui_menu.lua:1791
 msgid "Reset all scales to default (100%)? This cannot be undone."
 msgstr ""
 
-#: sui_menu.lua:1719
+#: sui_menu.lua:1786
 msgid "Reset to Default Scale"
 msgstr ""
 
 #: sui_bottombar.lua:1715
-#: sui_menu.lua:338
-#: sui_menu.lua:743
-#: sui_menu.lua:812
-#: sui_menu.lua:847
-#: sui_menu.lua:1153
-#: sui_menu.lua:1853
+#: sui_menu.lua:337
+#: sui_menu.lua:742
+#: sui_menu.lua:811
+#: sui_menu.lua:846
+#: sui_menu.lua:1152
+#: sui_menu.lua:1920
 #: sui_updater.lua:360
 msgid "Restart"
 msgstr ""
 
-#: sui_menu.lua:1774
+#: sui_menu.lua:1841
 msgid "Return to Book Folder"
 msgstr ""
 
-#: sui_menu.lua:623
-#: sui_menu.lua:1037
+#: sui_menu.lua:622
+#: sui_menu.lua:1036
 msgid "Right"
 msgstr ""
 
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: sui_menu.lua:1639
+#: sui_menu.lua:1706
 #: desktop_modules/module_clock.lua:433
 #: desktop_modules/module_clock.lua:435
 #: desktop_modules/module_collections.lua:500
@@ -1249,10 +1249,10 @@ msgstr ""
 #: desktop_modules/module_currently.lua:799
 #: desktop_modules/module_new_books.lua:246
 #: desktop_modules/module_new_books.lua:248
-#: desktop_modules/module_quick_actions.lua:381
-#: desktop_modules/module_quick_actions.lua:383
-#: desktop_modules/module_quote.lua:1002
-#: desktop_modules/module_quote.lua:1006
+#: desktop_modules/module_quick_actions.lua:380
+#: desktop_modules/module_quick_actions.lua:382
+#: desktop_modules/module_quote.lua:1004
+#: desktop_modules/module_quote.lua:1008
 #: desktop_modules/module_reading_goals.lua:566
 #: desktop_modules/module_reading_goals.lua:568
 #: desktop_modules/module_reading_stats.lua:389
@@ -1268,7 +1268,7 @@ msgstr ""
 msgid "Scale for all text elements (title, author, progress, time).\n100% is the default size."
 msgstr ""
 
-#: desktop_modules/module_quick_actions.lua:395
+#: desktop_modules/module_quick_actions.lua:394
 msgid "Scale for the button label text.\n100% is the default size."
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Scale for the collection name text.\n100% is the default size."
 msgstr ""
 
-#: desktop_modules/module_collections.lua:653
+#: desktop_modules/module_collections.lua:654
 msgid "Scale for the collection thumbnails only.\nThe label text follows the module scale.\n100% is the default size."
 msgstr ""
 
@@ -1293,7 +1293,7 @@ msgstr ""
 msgid "Scale for the cover thumbnails only.\nText and progress bar follow the module scale.\n100% is the default size."
 msgstr ""
 
-#: sui_menu.lua:2043
+#: sui_menu.lua:2111
 msgid "Scale for the folder name overlay text.\n100% is the default size."
 msgstr ""
 
@@ -1313,8 +1313,8 @@ msgstr ""
 #: desktop_modules/module_collections.lua:503
 #: desktop_modules/module_currently.lua:800
 #: desktop_modules/module_new_books.lua:249
-#: desktop_modules/module_quick_actions.lua:384
-#: desktop_modules/module_quote.lua:1008
+#: desktop_modules/module_quick_actions.lua:383
+#: desktop_modules/module_quote.lua:1010
 #: desktop_modules/module_reading_goals.lua:569
 #: desktop_modules/module_reading_stats.lua:392
 #: desktop_modules/module_recent.lua:245
@@ -1326,15 +1326,15 @@ msgstr ""
 msgid "Scale for title and statistics text.\n100% is the default size."
 msgstr ""
 
-#: sui_menu.lua:1662
+#: sui_menu.lua:1729
 msgid "Scales all modules and labels together.\n100% is the default size."
 msgstr ""
 
-#: sui_menu.lua:1698
+#: sui_menu.lua:1765
 msgid "Scales the section label text above each module.\n100% is the default size."
 msgstr ""
 
-#: sui_menu.lua:2086
+#: sui_menu.lua:2154
 msgid "Scan subfolders for cover"
 msgstr ""
 
@@ -1342,7 +1342,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: desktop_modules/module_collections.lua:626
+#: desktop_modules/module_collections.lua:627
 msgid "Select at least 2 collections to arrange."
 msgstr ""
 
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "September"
 msgstr ""
 
-#: sui_menu.lua:1984
+#: sui_menu.lua:2052
 msgid "Series Index"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Series cover"
 msgstr ""
 
-#: sui_menu.lua:568
+#: sui_menu.lua:567
 msgid "Set"
 msgstr ""
 
@@ -1370,13 +1370,13 @@ msgstr ""
 msgid "Set series cover…"
 msgstr ""
 
-#: sui_menu.lua:1862
+#: sui_menu.lua:1929
 msgid "Settings"
 msgstr ""
 
-#: sui_menu.lua:781
-#: sui_menu.lua:951
-#: sui_menu.lua:1786
+#: sui_menu.lua:780
+#: sui_menu.lua:950
+#: sui_menu.lua:1853
 msgid "Settings on Long Tap"
 msgstr ""
 
@@ -1396,11 +1396,11 @@ msgstr ""
 msgid "Show section label"
 msgstr ""
 
-#: sui_menu.lua:501
+#: sui_menu.lua:500
 msgid "Shows \"Page X of Y\" in the title bar subtitle when browsing the library, history or collections.\nNavpager enables this automatically.\nNot available when Navpager is active."
 msgstr ""
 
-#: sui_menu.lua:398
+#: sui_menu.lua:397
 msgid "Shows a row of dots at the bottom of the homescreen.\nThe active page dot is filled; the others are dimmed.\nAlways active when Navpager is selected."
 msgstr ""
 
@@ -1410,8 +1410,8 @@ msgstr ""
 
 #: main.lua:541
 #: main.lua:554
-#: sui_menu.lua:1831
-#: sui_menu.lua:1835
+#: sui_menu.lua:1898
+#: sui_menu.lua:1902
 msgid "Simple UI"
 msgstr ""
 
@@ -1427,21 +1427,21 @@ msgstr ""
 msgid "Simple UI is up to date (%s)."
 msgstr ""
 
-#: sui_menu.lua:1852
+#: sui_menu.lua:1919
 msgid "Simple UI will be %s after restart.\n\nRestart now?"
 msgstr ""
 
-#: sui_menu.lua:454
-#: sui_menu.lua:753
-#: sui_menu.lua:823
+#: sui_menu.lua:453
+#: sui_menu.lua:752
+#: sui_menu.lua:822
 msgid "Size"
 msgstr ""
 
-#: sui_menu.lua:888
+#: sui_menu.lua:887
 msgid "Size of the tab icons.\n100% is the default size."
 msgstr ""
 
-#: sui_menu.lua:908
+#: sui_menu.lua:907
 msgid "Size of the tab label text.\n100% is the default size."
 msgstr ""
 
@@ -1453,25 +1453,25 @@ msgstr ""
 msgid "Sleep"
 msgstr ""
 
-#: sui_menu.lua:470
+#: sui_menu.lua:469
 msgid "Small"
 msgstr ""
 
 #: desktop_modules/module_coverdeck.lua:725
-#: desktop_modules/module_quote.lua:1034
+#: desktop_modules/module_quote.lua:1036
 msgid "Source"
 msgstr ""
 
-#: sui_menu.lua:866
+#: sui_menu.lua:865
 msgid "Space below the bottom navigation bar.\n100% is the default spacing."
 msgstr ""
 
-#: sui_patches.lua:520
-#: sui_patches.lua:522
+#: sui_patches.lua:526
+#: sui_patches.lua:528
 msgid "Start with"
 msgstr ""
 
-#: sui_menu.lua:1764
+#: sui_menu.lua:1831
 msgid "Start with Home Screen"
 msgstr ""
 
@@ -1488,7 +1488,7 @@ msgstr ""
 msgid "Stats layout"
 msgstr ""
 
-#: sui_menu.lua:1868
+#: sui_menu.lua:1935
 msgid "Status Bar"
 msgstr ""
 
@@ -1496,7 +1496,7 @@ msgstr ""
 msgid "Streak"
 msgstr ""
 
-#: sui_menu.lua:1177
+#: sui_menu.lua:1176
 msgid "Sub-pages Buttons"
 msgstr ""
 
@@ -1504,7 +1504,7 @@ msgstr ""
 msgid "Sunday"
 msgstr ""
 
-#: sui_menu.lua:519
+#: sui_menu.lua:518
 msgid "Swipe Indicator"
 msgstr ""
 
@@ -1516,11 +1516,11 @@ msgstr ""
 msgid "System action error: %s"
 msgstr ""
 
-#: sui_menu.lua:946
+#: sui_menu.lua:945
 msgid "Tabs  (%d/%d — %d left)"
 msgstr ""
 
-#: sui_menu.lua:944
+#: sui_menu.lua:943
 msgid "Tabs  (%d/%d — at limit)"
 msgstr ""
 
@@ -1534,8 +1534,8 @@ msgstr ""
 #: desktop_modules/module_currently.lua:826
 #: desktop_modules/module_new_books.lua:273
 #: desktop_modules/module_new_books.lua:274
-#: desktop_modules/module_quick_actions.lua:391
-#: desktop_modules/module_quick_actions.lua:394
+#: desktop_modules/module_quick_actions.lua:390
+#: desktop_modules/module_quick_actions.lua:393
 #: desktop_modules/module_reading_stats.lua:469
 #: desktop_modules/module_reading_stats.lua:472
 #: desktop_modules/module_recent.lua:271
@@ -1551,17 +1551,13 @@ msgstr ""
 msgid "Text only"
 msgstr ""
 
-#: sui_menu.lua:558
-msgid "Text shown in the top bar.\nMaximum %d characters."
-msgstr ""
-
-#: sui_menu.lua:2040
+#: sui_menu.lua:2108
 #: desktop_modules/module_coverdeck.lua:715
 #: desktop_modules/module_coverdeck.lua:716
 msgid "Text size"
 msgstr ""
 
-#: sui_patches.lua:669
+#: sui_patches.lua:675
 msgid "The «To Be Read» collection cannot be renamed."
 msgstr ""
 
@@ -1584,7 +1580,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: sui_menu.lua:1869
+#: sui_menu.lua:1936
 msgid "Title Bar"
 msgstr ""
 
@@ -1605,10 +1601,10 @@ msgstr ""
 msgid "To Be Read books"
 msgstr ""
 
-#: sui_patches.lua:717
-#: sui_patches.lua:756
-#: sui_patches.lua:788
-#: sui_patches.lua:829
+#: sui_patches.lua:723
+#: sui_patches.lua:762
+#: sui_patches.lua:794
+#: sui_patches.lua:835
 msgid "To Be Read list is full (max. 5 books)."
 msgstr ""
 
@@ -1627,22 +1623,22 @@ msgstr ""
 msgid "Today — Time"
 msgstr ""
 
-#: sui_menu.lua:1866
-#: sui_menu.lua:1960
-#: sui_menu.lua:2014
+#: sui_menu.lua:1933
+#: sui_menu.lua:2028
+#: sui_menu.lua:2082
 msgid "Top"
 msgstr ""
 
-#: sui_menu.lua:734
+#: sui_menu.lua:733
 #: sui_topbar.lua:507
 msgid "Top Bar"
 msgstr ""
 
-#: sui_menu.lua:759
+#: sui_menu.lua:758
 msgid "Top Bar Size"
 msgstr ""
 
-#: sui_menu.lua:742
+#: sui_menu.lua:741
 msgid "Top Bar will be %s after restart.\n\nRestart now?"
 msgstr ""
 
@@ -1650,11 +1646,11 @@ msgstr ""
 msgid "Top Margin  (%d%%)"
 msgstr ""
 
-#: sui_menu.lua:922
+#: sui_menu.lua:921
 msgid "Top separator"
 msgstr ""
 
-#: sui_menu.lua:2003
+#: sui_menu.lua:2071
 msgid "Transparent"
 msgstr ""
 
@@ -1662,14 +1658,14 @@ msgstr ""
 msgid "Tuesday"
 msgstr ""
 
-#: sui_menu.lua:935
-#: desktop_modules/module_quick_actions.lua:403
+#: sui_menu.lua:934
+#: desktop_modules/module_quick_actions.lua:402
 #: desktop_modules/module_reading_goals.lua:584
 #: desktop_modules/module_reading_stats.lua:430
 msgid "Type"
 msgstr ""
 
-#: sui_menu.lua:2054
+#: sui_menu.lua:2122
 msgid "Uniformize Covers (2:3)"
 msgstr ""
 
@@ -1681,15 +1677,15 @@ msgstr ""
 msgid "Update check cancelled."
 msgstr ""
 
-#: sui_menu.lua:2132
+#: sui_menu.lua:2200
 msgid "Updater module not found."
 msgstr ""
 
-#: sui_menu.lua:420
+#: sui_menu.lua:419
 msgid "Uses the standard KOReader pagination bar on the homescreen.\nNot available when Navpager is active."
 msgstr ""
 
-#: sui_menu.lua:2117
+#: sui_menu.lua:2185
 msgid "Version: %s"
 msgstr ""
 
@@ -1697,7 +1693,7 @@ msgstr ""
 msgid "Vertical space above this module.\n100% is the default spacing."
 msgstr ""
 
-#: sui_menu.lua:922
+#: sui_menu.lua:921
 msgid "Visible"
 msgstr ""
 
@@ -1709,19 +1705,19 @@ msgstr ""
 msgid "What's new:"
 msgstr ""
 
-#: sui_menu.lua:1787
+#: sui_menu.lua:1854
 msgid "When enabled, long-pressing a section opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
 msgstr ""
 
-#: sui_menu.lua:952
+#: sui_menu.lua:951
 msgid "When enabled, long-pressing the bottom bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
 msgstr ""
 
-#: sui_menu.lua:782
+#: sui_menu.lua:781
 msgid "When enabled, long-pressing the top bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
 msgstr ""
 
-#: sui_menu.lua:1775
+#: sui_menu.lua:1842
 msgid "When enabled, opening the file browser after finishing or closing a book navigates to the folder the book is in, matching native KOReader behaviour.\nWhen disabled (default), SimpleUI always returns to the library root.\nThis option works independently of \"Start with Home Screen\"."
 msgstr ""
 
@@ -1749,7 +1745,7 @@ msgstr ""
 msgid "With percentage"
 msgstr ""
 
-#: desktop_modules/module_quote.lua:747
+#: desktop_modules/module_quote.lua:748
 msgid "Your highlights"
 msgstr ""
 
@@ -1777,10 +1773,10 @@ msgstr ""
 msgid "default"
 msgstr ""
 
-#: sui_menu.lua:742
-#: sui_menu.lua:811
-#: sui_menu.lua:1151
-#: sui_menu.lua:1852
+#: sui_menu.lua:741
+#: sui_menu.lua:810
+#: sui_menu.lua:1150
+#: sui_menu.lua:1919
 msgid "disabled"
 msgstr ""
 
@@ -1800,10 +1796,10 @@ msgstr ""
 msgid "e.g. Sleep, Refresh…"
 msgstr ""
 
-#: sui_menu.lua:742
-#: sui_menu.lua:811
-#: sui_menu.lua:1151
-#: sui_menu.lua:1852
+#: sui_menu.lua:741
+#: sui_menu.lua:810
+#: sui_menu.lua:1150
+#: sui_menu.lua:1919
 msgid "enabled"
 msgstr ""
 
@@ -1836,6 +1832,16 @@ msgstr ""
 msgid "pages/day (7 days)"
 msgstr ""
 
+#: sui_menu.lua:238
+#: sui_menu.lua:1336
+#: desktop_modules/module_collections.lua:689
+#: desktop_modules/module_quick_actions.lua:319
+#: desktop_modules/module_reading_stats.lua:507
+msgid "  (%d left)"
+msgid_plural "  (%d left)"
+msgstr[0] ""
+msgstr[1] ""
+
 #: desktop_modules/module_reading_goals.lua:617
 msgid "  Set Goal  (%d book in %s)"
 msgid_plural "  Set Goal  (%d books in %s)"
@@ -1862,19 +1868,25 @@ msgid_plural "%d/%d books"
 msgstr[0] ""
 msgstr[1] ""
 
-#: sui_menu.lua:1231
+#: sui_menu.lua:1230
 msgid "Digital: %d book in %s"
 msgid_plural "Digital: %d books in %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: sui_menu.lua:1237
+#: sui_menu.lua:1236
 msgid "Physical: %d book in %s"
 msgid_plural "Physical: %d books in %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: sui_menu.lua:1301
+#: sui_menu.lua:556
+msgid "Text shown in the top bar.\nMaximum %d character."
+msgid_plural "Text shown in the top bar.\nMaximum %d characters."
+msgstr[0] ""
+msgstr[1] ""
+
+#: sui_menu.lua:1300
 #: desktop_modules/module_quick_actions.lua:262
 msgid "The maximum of %d action per module has been reached. Remove one first."
 msgid_plural "The maximum of %d actions per module has been reached. Remove one first."
@@ -1893,7 +1905,7 @@ msgid_plural "The maximum of %d stats per row has been reached. Remove one first
 msgstr[0] ""
 msgstr[1] ""
 
-#: sui_menu.lua:272
+#: sui_menu.lua:271
 msgid "The maximum of %d tab has been reached. Remove one first."
 msgid_plural "The maximum of %d tabs has been reached. Remove one first."
 msgstr[0] ""

--- a/sui_menu.lua
+++ b/sui_menu.lua
@@ -235,8 +235,7 @@ SimpleUIPlugin.addToMainMenu = function(self, menu_items)
                         if tid == _aid then return _base_label end
                     end
                     local rem = limit - #loadTabConfig()
-                    if rem <= 0 then return _base_label .. "  (0 left)" end
-                    if rem <= 2 then return _base_label .. "  (" .. rem .. " left)" end
+                    if rem <= 2 then return _base_label .. string.format(N_("  (%d left)", "  (%d left)", rem), rem) end
                     return _base_label
                 end,
                 checked_func = function()
@@ -554,9 +553,9 @@ SimpleUIPlugin.addToMainMenu = function(self, menu_items)
                     dlg = InputDialog():new{
                         title       = _("Custom Text"),
                         input       = Config.getTopbarCustomText(),
-                        description = string.format(
-                            _("Text shown in the top bar.\nMaximum %d characters."),
-                            Config.TOPBAR_CUSTOM_TEXT_MAX),
+                        description = string.format(N_("Text shown in the top bar.\nMaximum %d character.",
+                                      "Text shown in the top bar.\nMaximum %d characters.", Config.TOPBAR_CUSTOM_TEXT_MAX),
+                                      Config.TOPBAR_CUSTOM_TEXT_MAX),
                         input_type  = "text",
                         buttons     = {{
                             {
@@ -1334,8 +1333,7 @@ SimpleUIPlugin.addToMainMenu = function(self, menu_items)
                 text_func = function()
                     if isSelected(aid) then return _lbl end
                     local rem = MAX_QA_ITEMS - #getItems()
-                    if rem <= 0 then return _lbl .. "  (0 left)" end
-                    if rem <= 2 then return _lbl .. "  (" .. rem .. " left)" end
+                    if rem <= 2 then return _lbl .. string.format(N_("  (%d left)", "  (%d left)", rem), rem) end
                     return _lbl
                 end,
                 checked_func   = function() return isSelected(aid) end,


### PR DESCRIPTION
`(0 left)` is untranslatable.

- Provide translatable string with plural forms.
- Update pot template
- Update ro translations