### PR TITLE
Fix hardware back key not working

### DIFF
--- a/sui_homescreen.lua
+++ b/sui_homescreen.lua
@@ -839,7 +839,7 @@ function HomescreenWidget:init()
     end
     if Device:hasKeys() then
         self.key_events.HSOpenMenu   = { { "Menu"  } }
-        self.key_events.PrevPage     = { { Device.input.group.PgBwd } }
+        self.key_events.PrevPage     = { { Device.input.group.PgBack } }
         self.key_events.NextPage     = { { Device.input.group.PgFwd } }
     end
 


### PR DESCRIPTION
Fixes #186

Wrong key name was given for the back key.