### PR TITLE
Author/Series Nav Tabs

### DIFF
--- a/icons/authors.svg
+++ b/icons/authors.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" id="Multiple-Neutral-2--Streamline-Ultimate" height="24" width="24">
+  <desc>
+    Multiple Neutral 2 Streamline Icon: https://streamlinehq.com
+  </desc>
+  <path d="M3.25 7.75a4.25 4.25 0 1 0 8.5 0 4.25 4.25 0 1 0 -8.5 0" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+  <path d="M0.5 20.5a7 7 0 0 1 14 0Z" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+  <path d="M16.5 20.5h7a5.5 5.5 0 0 0 -8.027 -4.885" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+  <path d="M14.694 10.25a3.25 3.25 0 1 0 6.5 0 3.25 3.25 0 1 0 -6.5 0" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+</svg>

--- a/icons/series.svg
+++ b/icons/series.svg
@@ -1,0 +1,17 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" id="Archive-Books--Streamline-Ultimate" height="24" width="24">
+  <desc>
+    Archive Books Streamline Icon: https://streamlinehq.com
+  </desc>
+  <path d="M8 22.5a1 1 0 0 1 -1 1H1.5a1 1 0 0 1 -1 -1v-21a1 1 0 0 1 1 -1H7a1 1 0 0 1 1 1Z" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+  <path d="M5.5 14a0.5 0.5 0 0 1 -0.5 0.5H3a0.5 0.5 0 0 1 -0.5 -0.5V3a0.5 0.5 0 0 1 0.5 -0.5h2a0.5 0.5 0 0 1 0.5 0.5Z" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+  <path d="m2.5 5.5 3 0" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+  <path d="M16 22.5a1 1 0 0 1 -1 1H9a1 1 0 0 1 -1 -1v-21a1 1 0 0 1 1 -1h6a1 1 0 0 1 1 1Z" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+  <path d="M13.5 14a0.5 0.5 0 0 1 -0.5 0.5h-2a0.5 0.5 0 0 1 -0.5 -0.5V3a0.5 0.5 0 0 1 0.5 -0.5h2a0.5 0.5 0 0 1 0.5 0.5Z" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+  <path d="m10.5 5.5 3 0" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+  <path d="M23.5 22.5a1 1 0 0 1 -1 1H17a1 1 0 0 1 -1 -1v-21a1 1 0 0 1 1 -1h5.5a1 1 0 0 1 1 1Z" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+  <path d="M21.5 14a0.5 0.5 0 0 1 -0.5 0.5h-2a0.5 0.5 0 0 1 -0.5 -0.5V3a0.5 0.5 0 0 1 0.5 -0.5h2a0.5 0.5 0 0 1 0.5 0.5Z" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+  <path d="m18.5 5.5 3 0" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+  <path d="M2.5 19a1.5 1.5 0 1 0 3 0 1.5 1.5 0 1 0 -3 0" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+  <path d="M10.5 19a1.5 1.5 0 1 0 3 0 1.5 1.5 0 1 0 -3 0" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+  <path d="M18.5 19a1.5 1.5 0 1 0 3 0 1.5 1.5 0 1 0 -3 0" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"></path>
+</svg>

--- a/main.lua
+++ b/main.lua
@@ -214,7 +214,7 @@ end
 local _PLUGIN_MODULES = {
     "sui_i18n", "sui_config", "sui_core", "sui_bottombar", "sui_topbar",
     "sui_patches", "sui_menu", "sui_titlebar", "sui_quickactions",
-    "sui_homescreen", "sui_foldercovers", "sui_updater",
+    "sui_homescreen", "sui_foldercovers", "sui_updater", "sui_metabrowser",
     "desktop_modules/moduleregistry",
     "desktop_modules/module_books_shared",
     "desktop_modules/module_clock",

--- a/sui_bottombar.lua
+++ b/sui_bottombar.lua
@@ -1310,6 +1310,16 @@ function M.navigate(plugin, action_id, fm_self, tabs, force)
         if fm.collections then fm.collections:onShowCollList()
         else showUnavailable(_("Collections not available.")) end
 
+    elseif action_id == "authors" or action_id == "series" then
+        local ok_mb, MB = pcall(require, "sui_metabrowser")
+        if ok_mb and MB and type(MB.show) == "function" then
+            MB.show(fm, action_id)
+        else
+            showUnavailable(action_id == "authors"
+                and _("Authors not available.")
+                or _("Series not available."))
+        end
+
     elseif action_id == "history" then
         local ok = pcall(function() fm.history:onShowHist() end)
         if not ok then showUnavailable(_("History not available.")) end

--- a/sui_config.lua
+++ b/sui_config.lua
@@ -77,6 +77,8 @@ M.ICON = {
     -- Plugin icons
     library        = _P .. "library.svg",
     collections    = _P .. "collections.svg",
+    authors        = _P .. "authors.svg",
+    series         = _P .. "series.svg",
     history        = _P .. "history.svg",
     continue_      = _P .. "continue.svg",       -- trailing _ avoids clash with Lua keyword
     frontlight     = _P .. "frontlight.svg",
@@ -130,6 +132,8 @@ end
 M.ALL_ACTIONS = {
     { id = "home",             label = _("Library"),          icon = M.ICON.library     },
     { id = "homescreen",       label = _("Home"),             icon = M.ICON.ko_home     },
+    { id = "authors",          label = _("Authors"),          icon = M.ICON.authors     },
+    { id = "series",           label = _("Series"),           icon = M.ICON.series      },
     { id = "collections",      label = _("Collections"),      icon = M.ICON.collections },
     { id = "history",          label = _("History"),          icon = M.ICON.history     },
     { id = "continue",         label = _("Continue"),         icon = M.ICON.continue_   },

--- a/sui_foldercovers.lua
+++ b/sui_foldercovers.lua
@@ -1296,8 +1296,8 @@ function M.install()
         local dir_path = self.entry and self.entry.path
         if not dir_path then return end
 
-        -- ── Series group cover: use first available book cover from the group ──
-        if self.entry.is_series_group then
+        -- ── Virtual metadata group cover: use first available book cover ──
+        if self.entry.is_series_group or self.entry.is_meta_group then
             if self._foldercover_processed then return end
 
             -- Check for a user-chosen cover override first.
@@ -1323,6 +1323,7 @@ function M.install()
 
             -- No override: use first available book cover from the group.
             local items = self.entry.series_items
+                or self.entry.meta_items
                 or _sg_items_cache[dir_path]
             if items then
                 for _, book_entry in ipairs(items) do

--- a/sui_metabrowser.lua
+++ b/sui_metabrowser.lua
@@ -16,6 +16,9 @@ local T                = ffiUtil.template
 
 local M = {}
 
+-- We intentionally extend FileChooser so the browser participates in the same
+-- coverbrowser/mosaic pipeline as the library, instead of behaving like a
+-- standalone BookList.
 local MetaChooser = FileChooser:extend{
     name = "simpleui_metabrowser",
     covers_fullscreen = true,
@@ -71,6 +74,8 @@ local function _seriesSortKey(entry)
 end
 
 local function _virtualPath(kind, group)
+    -- Virtual groups are not real directories on disk; they only need a stable
+    -- synthetic path so FileChooser/CoverBrowser can treat them like folders.
     return "::simpleui_meta::" .. kind .. "::" .. group.value
 end
 
@@ -79,6 +84,7 @@ local function _groupMandatory(group)
 end
 
 local function _buildRootItems(kind, groups)
+    -- Root view: one virtual directory per author/series value.
     local items = {}
     for _, group in ipairs(groups) do
         items[#items + 1] = {
@@ -98,6 +104,8 @@ local function _buildRootItems(kind, groups)
 end
 
 local function _buildBookItems(kind, group)
+    -- Group view: real file entries, so opening/holding a book reuses the same
+    -- FileChooser actions as the library.
     local items = {}
     for _, entry in ipairs(group.items) do
         local mandatory
@@ -145,6 +153,9 @@ local function _collectGroups(ui, kind)
     local home = _resolveHomeDir()
     if not home then return nil, _("Home folder not available.") end
 
+    -- The browser is metadata-driven: folder names do not matter here.
+    -- We scan every supported book below home_dir and group by embedded
+    -- author/series metadata.
     local grouped = {}
     util.findFiles(home, function(file)
         if not DocumentRegistry:hasProvider(file) then return end
@@ -192,6 +203,7 @@ end
 
 function MetaChooser:init()
     FileChooser.init(self)
+    -- Preserve the titlebar's original left-button position
     if self.title_bar and self.title_bar.left_button then
         local btn = self.title_bar.left_button
         self._meta_back_offset = btn.overlap_offset and { btn.overlap_offset[1], btn.overlap_offset[2] } or nil
@@ -210,13 +222,17 @@ function MetaChooser:_updateBackButton()
     end
 
     if self._meta_group then
+        -- Inside a group: go back to the root author/series list.
         btn.callback = function() self:onFolderUp() end
     else
+        -- At root: keep the button visible to match the surrounding titlebar,
+        -- but make it inert so it does not close the browser unexpectedly.
         btn.callback = function() end
     end
 end
 
 function MetaChooser:_showRoot()
+    -- Root = virtual folders (authors or series).
     self._meta_group = nil
     self.title = T("%1 (%2)", _labelFor(self._meta_kind), #self._meta_groups)
     self.onReturn = nil
@@ -227,6 +243,7 @@ function MetaChooser:_showRoot()
 end
 
 function MetaChooser:_showGroup(group)
+    -- Group = concrete book files for one selected author/series.
     self._meta_group = group
     self.onReturn = function()
         self:_showRoot()
@@ -239,6 +256,8 @@ function MetaChooser:_showGroup(group)
 end
 
 function MetaChooser:refreshPath()
+    -- FileChooser expects refreshPath() to rebuild the current view. Since this
+    -- browser is virtual, we re-render whichever level is currently active.
     if self._meta_group then
         self:_showGroup(self._meta_group)
     else
@@ -248,6 +267,7 @@ end
 
 function MetaChooser:onMenuSelect(item)
     if item and item.is_meta_group then
+        -- Enter the virtual folder instead of changing to a real filesystem path.
         self:_showGroup(self._meta_groups_by_value[item.meta_value])
         return true
     end
@@ -282,6 +302,7 @@ function MetaChooser:onLeftButtonTap()
 end
 
 function MetaChooser:onFileSelect(item)
+    -- Open the selected book through the same helper the library uses.
     filemanagerutil.openFile(self.ui, item.path, self.close_callback)
     return true
 end
@@ -293,6 +314,8 @@ end
 function M.show(ui, kind)
     if kind ~= "authors" and kind ~= "series" then return end
 
+    -- The scan can touch many books, so show a short transient message and do
+    -- the actual collection work on the next tick to keep the UI responsive.
     local info = InfoMessage:new{
         text = _scanLabel(kind),
         timeout = 0.1,

--- a/sui_metabrowser.lua
+++ b/sui_metabrowser.lua
@@ -22,6 +22,7 @@ local MetaChooser = FileChooser:extend{
     is_borderless = true,
     is_popout = false,
     title_bar_fm_style = true,
+    title_bar_left_icon = "chevron.left",
     return_arrow_propagation = true,
 }
 
@@ -191,6 +192,28 @@ end
 
 function MetaChooser:init()
     FileChooser.init(self)
+    if self.title_bar and self.title_bar.left_button then
+        local btn = self.title_bar.left_button
+        self._meta_back_offset = btn.overlap_offset and { btn.overlap_offset[1], btn.overlap_offset[2] } or nil
+    end
+    self:_updateBackButton()
+end
+
+function MetaChooser:_updateBackButton()
+    local tb = self.title_bar
+    local btn = tb and tb.left_button
+    if not btn then return end
+
+    if self._meta_back_offset then
+        btn.overlap_align = nil
+        btn.overlap_offset = { self._meta_back_offset[1], self._meta_back_offset[2] }
+    end
+
+    if self._meta_group then
+        btn.callback = function() self:onFolderUp() end
+    else
+        btn.callback = function() end
+    end
 end
 
 function MetaChooser:_showRoot()
@@ -200,6 +223,7 @@ function MetaChooser:_showRoot()
     self.paths = {}
     self:switchItemTable(self.title, _buildRootItems(self._meta_kind, self._meta_groups), 1, nil,
         BD.directory(filemanagerutil.abbreviate(self._meta_home)))
+    self:_updateBackButton()
 end
 
 function MetaChooser:_showGroup(group)
@@ -208,8 +232,10 @@ function MetaChooser:_showGroup(group)
         self:_showRoot()
     end
     self.paths = { true }
-    self:switchItemTable(T("%1 (%2)", group.value, #group.items), _buildBookItems(self._meta_kind, group), 1, nil,
+    local items = _buildBookItems(self._meta_kind, group)
+    self:switchItemTable(T("%1 (%2)", group.value, #items), items, 1, nil,
         group.value)
+    self:_updateBackButton()
 end
 
 function MetaChooser:refreshPath()
@@ -249,6 +275,10 @@ function MetaChooser:onFolderUp()
         self.close_callback()
         return true
     end
+end
+
+function MetaChooser:onLeftButtonTap()
+    return self:onFolderUp()
 end
 
 function MetaChooser:onFileSelect(item)

--- a/sui_metabrowser.lua
+++ b/sui_metabrowser.lua
@@ -1,0 +1,312 @@
+-- sui_metabrowser.lua — Simple UI
+-- Virtual FileChooser-based metadata browsers for Authors and Series.
+
+local BD               = require("ui/bidi")
+local Device           = require("device")
+local DocumentRegistry = require("document/documentregistry")
+local FileChooser      = require("ui/widget/filechooser")
+local InfoMessage      = require("ui/widget/infomessage")
+local UIManager        = require("ui/uimanager")
+local ffiUtil          = require("ffi/util")
+local filemanagerutil  = require("apps/filemanager/filemanagerutil")
+local lfs              = require("libs/libkoreader-lfs")
+local util             = require("util")
+local _                = require("gettext")
+local T                = ffiUtil.template
+
+local M = {}
+
+local MetaChooser = FileChooser:extend{
+    name = "simpleui_metabrowser",
+    covers_fullscreen = true,
+    is_borderless = true,
+    is_popout = false,
+    title_bar_fm_style = true,
+    return_arrow_propagation = true,
+}
+
+local function _labelFor(kind)
+    return kind == "authors" and _("Authors") or _("Series")
+end
+
+local function _scanLabel(kind)
+    return kind == "authors" and _("Scanning authors…") or _("Scanning series…")
+end
+
+local function _emptyLabel(kind)
+    return kind == "authors" and _("No authors found.") or _("No series found.")
+end
+
+local function _trim(s)
+    if type(s) ~= "string" then return nil end
+    s = s:match("^%s*(.-)%s*$")
+    if s == "" then return nil end
+    return s
+end
+
+local function _resolveHomeDir()
+    local home = G_reader_settings:readSetting("home_dir")
+    if not home or lfs.attributes(home, "mode") ~= "directory" then
+        home = Device.home_dir
+    end
+    if home and lfs.attributes(home, "mode") == "directory" then
+        return home
+    end
+end
+
+local function _splitAuthors(authors)
+    if type(authors) ~= "string" or authors == "" then return {} end
+    local out = {}
+    for _, author in ipairs(util.splitToArray(authors, "\n")) do
+        author = _trim(author)
+        if author then out[#out + 1] = author end
+    end
+    return out
+end
+
+local function _seriesSortKey(entry)
+    local idx = tonumber(entry.series_index)
+    return idx or math.huge
+end
+
+local function _virtualPath(kind, group)
+    return "::simpleui_meta::" .. kind .. "::" .. group.value
+end
+
+local function _groupMandatory(group)
+    return tostring(#group.items) .. " \u{F016}"
+end
+
+local function _buildRootItems(kind, groups)
+    local items = {}
+    for _, group in ipairs(groups) do
+        items[#items + 1] = {
+            text = group.value .. "/",
+            path = _virtualPath(kind, group),
+            attr = { mode = "directory" },
+            is_directory = true,
+            bidi_wrap_func = BD.directory,
+            mandatory = _groupMandatory(group),
+            is_meta_group = true,
+            meta_kind = kind,
+            meta_items = group.items,
+            meta_value = group.value,
+        }
+    end
+    return items
+end
+
+local function _buildBookItems(kind, group)
+    local items = {}
+    for _, entry in ipairs(group.items) do
+        local mandatory
+        if kind == "authors" then
+            if entry.series and entry.series ~= "" then
+                mandatory = entry.series
+                if entry.series_index then
+                    mandatory = mandatory .. " #" .. tostring(entry.series_index)
+                end
+            else
+                mandatory = filemanagerutil.abbreviate(entry.file)
+            end
+        else
+            mandatory = entry.authors and entry.authors:gsub("\n.*", " et al.")
+                or filemanagerutil.abbreviate(entry.file)
+        end
+        items[#items + 1] = {
+            text = entry.title,
+            path = entry.file,
+            attr = lfs.attributes(entry.file) or { mode = "file" },
+            is_file = true,
+            mandatory = mandatory,
+            bidi_wrap_func = BD.filename,
+            doc_props = {
+                display_title = entry.title,
+                authors = entry.authors,
+                series = entry.series,
+                series_index = entry.series_index,
+            },
+        }
+    end
+    table.sort(items, function(a, b)
+        local ea = group.by_file[a.path]
+        local eb = group.by_file[b.path]
+        if kind == "series" then
+            local ia, ib = _seriesSortKey(ea), _seriesSortKey(eb)
+            if ia ~= ib then return ia < ib end
+        end
+        return ffiUtil.strcoll(a.text, b.text)
+    end)
+    return items
+end
+
+local function _collectGroups(ui, kind)
+    local home = _resolveHomeDir()
+    if not home then return nil, _("Home folder not available.") end
+
+    local grouped = {}
+    util.findFiles(home, function(file)
+        if not DocumentRegistry:hasProvider(file) then return end
+        local props = ui.bookinfo and ui.bookinfo:getDocProps(file, nil, true) or nil
+        if not props then return end
+
+        local values
+        if kind == "authors" then
+            values = _splitAuthors(props.authors)
+        else
+            local series = _trim(props.series)
+            values = series and { series } or {}
+        end
+        if #values == 0 then return end
+
+        local title = _trim(props.display_title) or file:match("([^/]+)$") or file
+        local entry = {
+            file = file,
+            path = file,
+            title = title,
+            authors = _trim(props.authors),
+            series = _trim(props.series),
+            series_index = props.series_index,
+        }
+        for _, value in ipairs(values) do
+            local group = grouped[value]
+            if not group then
+                group = { value = value, items = {}, by_file = {} }
+                grouped[value] = group
+            end
+            if not group.by_file[file] then
+                group.items[#group.items + 1] = entry
+                group.by_file[file] = entry
+            end
+        end
+    end, true)
+
+    local groups = {}
+    for _, group in pairs(grouped) do
+        groups[#groups + 1] = group
+    end
+    table.sort(groups, function(a, b) return ffiUtil.strcoll(a.value, b.value) end)
+    return groups, home
+end
+
+function MetaChooser:init()
+    FileChooser.init(self)
+end
+
+function MetaChooser:_showRoot()
+    self._meta_group = nil
+    self.title = T("%1 (%2)", _labelFor(self._meta_kind), #self._meta_groups)
+    self.onReturn = nil
+    self.paths = {}
+    self:switchItemTable(self.title, _buildRootItems(self._meta_kind, self._meta_groups), 1, nil,
+        BD.directory(filemanagerutil.abbreviate(self._meta_home)))
+end
+
+function MetaChooser:_showGroup(group)
+    self._meta_group = group
+    self.onReturn = function()
+        self:_showRoot()
+    end
+    self.paths = { true }
+    self:switchItemTable(T("%1 (%2)", group.value, #group.items), _buildBookItems(self._meta_kind, group), 1, nil,
+        group.value)
+end
+
+function MetaChooser:refreshPath()
+    if self._meta_group then
+        self:_showGroup(self._meta_group)
+    else
+        self:_showRoot()
+    end
+end
+
+function MetaChooser:onMenuSelect(item)
+    if item and item.is_meta_group then
+        self:_showGroup(self._meta_groups_by_value[item.meta_value])
+        return true
+    end
+    return FileChooser.onMenuSelect(self, item)
+end
+
+function MetaChooser:onMenuHold(item)
+    if item and item.is_meta_group then
+        return true
+    end
+    local fm_fc = self.ui and self.ui.file_chooser
+    if fm_fc and type(fm_fc.showFileDialog) == "function" then
+        fm_fc:showFileDialog(item)
+        return true
+    end
+    return true
+end
+
+function MetaChooser:onFolderUp()
+    if self._meta_group then
+        self:_showRoot()
+        return true
+    end
+    if self.close_callback then
+        self.close_callback()
+        return true
+    end
+end
+
+function MetaChooser:onFileSelect(item)
+    filemanagerutil.openFile(self.ui, item.path, self.close_callback)
+    return true
+end
+
+function MetaChooser:onFileHold(item)
+    return self:onMenuHold(item)
+end
+
+function M.show(ui, kind)
+    if kind ~= "authors" and kind ~= "series" then return end
+
+    local info = InfoMessage:new{
+        text = _scanLabel(kind),
+        timeout = 0.1,
+        _navbar_closing_intentionally = true,
+    }
+    UIManager:show(info)
+    UIManager:nextTick(function()
+        local ok, groups_or_err, home = pcall(function()
+            local groups, resolved_home = _collectGroups(ui, kind)
+            return groups, resolved_home
+        end)
+        UIManager:close(info)
+        if not ok then
+            UIManager:show(InfoMessage:new{ text = tostring(groups_or_err), timeout = 2 })
+            return
+        end
+        if not groups_or_err then
+            UIManager:show(InfoMessage:new{ text = _("Home folder not available."), timeout = 2 })
+            return
+        end
+        if #groups_or_err == 0 then
+            UIManager:show(InfoMessage:new{ text = _emptyLabel(kind), timeout = 2 })
+            return
+        end
+
+        local by_value = {}
+        for _, group in ipairs(groups_or_err) do
+            by_value[group.value] = group
+        end
+
+        local chooser
+        chooser = MetaChooser:new{
+            ui = ui,
+            path = home,
+            _meta_kind = kind,
+            _meta_home = home,
+            _meta_groups = groups_or_err,
+            _meta_groups_by_value = by_value,
+            close_callback = function()
+                UIManager:close(chooser)
+            end,
+        }
+        UIManager:show(chooser)
+    end)
+end
+
+return M


### PR DESCRIPTION
Hey, so yesterday I posted on [Reddit](https://www.reddit.com/r/koreader/comments/1sjtbz3/ok_now_i_can_finally_get_to_reading_again/) about my setup and people was interested on having the same Authors/Series nav bar, I also think it is pretty handy and gives similar vibes to the Kobo experience.

What we are doing here is basically:
- scan the home_dir recursively
- group books by embedded metadata, not folder names
- open as fullscreen SimpleUI browsers
- support CoverBrowser mosaic/list rendering
- show virtual group covers using the first available book cover in each group

Similar to what we have on Library view.


<img width="1264" height="1680" alt="FileManager_2026-04-13_145939" src="https://github.com/user-attachments/assets/322bb85b-98b9-4f8b-80a1-f17a4c8329f5" />
<img width="1264" height="1680" alt="FileManager_2026-04-13_145948" src="https://github.com/user-attachments/assets/4195c6c0-ef92-4e3c-bea0-7b928436e8e0" />
<img width="1264" height="1680" alt="FileManager_2026-04-13_145955" src="https://github.com/user-attachments/assets/34117116-770d-4656-b110-c9749b4394a8" />
<img width="1264" height="1680" alt="FileManager_2026-04-13_145902" src="https://github.com/user-attachments/assets/05b08b28-6c45-4322-85de-345dab0e2d21" />
<img width="1264" height="1680" alt="FileManager_2026-04-13_145908" src="https://github.com/user-attachments/assets/99ddc524-e5f4-4280-b746-bc8076b0c57b" />
<img width="1264" height="1680" alt="FileManager_2026-04-13_145919" src="https://github.com/user-attachments/assets/f73603c8-2bf1-4c85-8d16-801593d2e51d" />
