### PR TITLE
Add quick action and menu option to open a random document

### DIFF
--- a/sui_bottombar.lua
+++ b/sui_bottombar.lua
@@ -1362,9 +1362,13 @@ function M.navigate(plugin, action_id, fm_self, tabs, force)
             showUnavailable(_("Homescreen not available."))
         end
 
-    elseif action_id == "favorites" then
-        if fm.collections then fm.collections:onShowColl()
-        else showUnavailable(_("Favorites not available.")) end
+	elseif action_id == "random_document" then
+    	local fm = plugin.ui
+    	if fm then
+        	fm:openRandomFile(fm.file_chooser and fm.file_chooser.path or "/", false)
+    	else
+        	showUnavailable(_("File Manager not available."))
+    	end
 
     elseif action_id == "bookmark_browser" then
         -- Show the source-selection ButtonDialog floating on top of whatever

--- a/sui_config.lua
+++ b/sui_config.lua
@@ -145,6 +145,7 @@ M.ALL_ACTIONS = {
       browsemeta_mode = "author" },
     { id = "browse_series",    label = _("Series"),           icon = M.ICON.series,
       browsemeta_mode = "series" },
+    { id = "random_document", label = _("Random Document"), icon = M.ICON.library },
 }
 
 -- Fast lookup map keyed by action ID.


### PR DESCRIPTION
This commit adds the possibility to add the "Open Random Document" action to one of the quick action modules.

## This is where the menu is in KOReader:
<img width="540" height="1206" alt="image" src="https://github.com/user-attachments/assets/e85d65e9-1ef1-47d8-979c-ef71f8872683" />

## It would look like this in the quick actions menu:
<img width="632" height="840" alt="image" src="https://github.com/user-attachments/assets/42e8e22d-e201-4d18-8a66-0e0467145b43" />

**Disclaimer: I've changed the label to "Random" in my Kobo because I felt that "Random Document" was too long**