### PR TITLE
feat: add menu action recording, icon browser, and enhance quick actions

### DIFF
--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -4402,3 +4402,49 @@ msgstr "书籍统计"
 #~ "当前版本：%s\n"
 #~ "\n"
 #~ "是否立即下载并安装？"
+
+#: sui_quickactions.lua
+msgid "Menu Action"
+msgstr "菜单操作"
+
+msgid "Finish recording & save as shortcut"
+msgstr "完成录制并保存为快捷方式"
+
+msgid "Tap any menu item to record it as a shortcut."
+msgstr "点击任意菜单项，将其录制为快捷方式。"
+
+msgid "Recorded menu navigation path"
+msgstr "录制的菜单导航路径"
+
+msgid "This shortcut only works in the reader. Please open a book first."
+msgstr "此快捷方式仅在阅读器中有效。请先打开一本书。"
+
+msgid "This shortcut only works in the file browser."
+msgstr "此快捷方式仅在文件浏览器中有效。"
+
+msgid "Failed to replay menu action. Menu structure may have changed."
+msgstr "无法回放菜单操作。菜单结构可能已更改。"
+
+msgid "Could not open menu."
+msgstr "无法打开菜单。"
+
+msgid "Open a book or go to file browser first."
+msgstr "请先打开一本书或进入文件浏览器。"
+
+msgid "Failed to load menu picker module."
+msgstr "无法加载菜单选择器模块。"
+
+msgid "Browse files…"
+msgstr "浏览文件…"
+
+msgid "Choose icon"
+msgstr "选择图标"
+
+msgid "Filter by name…"
+msgstr "按名称筛选…"
+
+msgid "No icons found in:"
+msgstr "未在以下位置找到图标："
+
+msgid "No options available for this action."
+msgstr "此操作没有可用选项。"

--- a/sui_config.lua
+++ b/sui_config.lua
@@ -94,11 +94,11 @@ M.CUSTOM_DISPATCHER_ICON = M.ICON.ko_settings
 -- ===========================================================================
 
 M.DEFAULT_NUM_TABS       = 5
-M.MAX_TABS               = 6
-M.MAX_TABS_NAVPAGER      = 4
-M.MAX_LABEL_LEN          = 20
+M.MAX_TABS               = 10
+M.MAX_TABS_NAVPAGER      = 6
+M.MAX_LABEL_LEN          = 40
 M.MAX_CUSTOM_QA          = 24
-M.NAVPAGER_CENTER_TABS   = 4
+M.NAVPAGER_CENTER_TABS   = 6
 
 M.DEFAULT_TABS = { "home", "sui_settings", "homescreen", "history", "power" }
 
@@ -138,7 +138,7 @@ local function _QA_lazy() return package.loaded["sui_quickactions"] or require("
 function M.getCustomQAList()         return _QA_lazy().getCustomQAList()                                                              end
 function M.saveCustomQAList(list)    return _QA_lazy().saveCustomQAList(list)                                                         end
 function M.getCustomQAConfig(id)     return _QA_lazy().getCustomQAConfig(id)                                                          end
-function M.saveCustomQAConfig(id, label, path, coll, icon, pk, pm, da) return _QA_lazy().saveCustomQAConfig(id, label, path, coll, icon, pk, pm, da) end
+function M.saveCustomQAConfig(id, label, path, coll, icon, pk, pm, da, dv, mp) return _QA_lazy().saveCustomQAConfig(id, label, path, coll, icon, pk, pm, da, dv, mp) end
 function M.deleteCustomQA(id)        return _QA_lazy().deleteCustomQA(id)                                                             end
 function M.purgeQACollection(coll)   return _QA_lazy().purgeQACollection(coll)                                                        end
 function M.renameQACollection(o, n)  return _QA_lazy().renameQACollection(o, n)                                                       end

--- a/sui_icon_browser.lua
+++ b/sui_icon_browser.lua
@@ -1,0 +1,266 @@
+-- sui_icon_browser.lua
+-- Simple UI Icon Browser - browse filesystem for SVG/PNG icons
+
+local BD = require("ui/bidi")
+local Device = require("device")
+local filemanagerutil = require("apps/filemanager/filemanagerutil")
+local Font = require("ui/font")
+local FrameContainer = require("ui/widget/container/framecontainer")
+local Geom = require("ui/geometry")
+local ImageWidget = require("ui/widget/imagewidget")
+local InputText = require("ui/widget/inputtext")
+local Menu = require("ui/widget/menu")
+local PathChooser = require("ui/widget/pathchooser")
+local Size = require("ui/size")
+local UIManager = require("ui/uimanager")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local ffiUtil = require("ffi/util")
+local util = require("util")
+local _ = require("sui_i18n").translate
+local Screen = Device.screen
+local DataStorage = require("datastorage")
+
+local THUMB_SIZE = Screen:scaleBySize(32)
+local THUMB_GAP = Screen:scaleBySize(6)
+
+-- ---------------------------------------------------------------------------
+-- Inner PathChooser subclass with thumbnail preview
+-- ---------------------------------------------------------------------------
+local _InnerChooser = PathChooser:extend{
+    select_directory = false,
+    select_file = true,
+    state_w = THUMB_SIZE + THUMB_GAP,
+    path = DataStorage:getDataDir() .. "/icons/",
+    onConfirm = nil,
+    _filter_text = "",
+    _all_items = nil,
+    stop_events_propagation = true,
+}
+
+function _InnerChooser:init()
+    self.title = _('Choose icon')
+    
+    -- Only show SVG and PNG files
+    self.file_filter = function(filename)
+        local ext = filename:lower()
+        return ext:match('%.svg$') ~= nil or ext:match('%.png$') ~= nil
+    end
+    
+    self.state_w = THUMB_SIZE + THUMB_GAP
+    self._recalculateDimen = _InnerChooser._recalculateDimen
+    PathChooser.init(self)
+    if not self._all_items then
+        self:refreshPath()
+    end
+end
+
+function _InnerChooser:_recalculateDimen(no_recalculate_dimen)
+    Menu._recalculateDimen(self, no_recalculate_dimen)
+    if not self.item_dimen then return end
+    
+    if self._filter_bar_height and self._filter_bar_height > 0 and not no_recalculate_dimen then
+        self.available_height = self.available_height - self._filter_bar_height
+        self.item_dimen.h = math.floor(self.available_height / self.perpage)
+    end
+    
+    local content_w = math.max(0, self.item_dimen.w - 2 * Size.padding.fullscreen)
+    local max_state_w = math.max(1, math.floor(content_w / 4))
+    local ts = THUMB_SIZE
+    local tg = THUMB_GAP
+    self.state_w = math.min(ts + tg, max_state_w)
+    self._thumb_size = math.max(0, math.min(ts, self.state_w - tg))
+end
+
+function _InnerChooser:getCollate()
+    return self.collates.strcoll, "strcoll"
+end
+
+function _InnerChooser:refreshPath()
+    local _, folder_name = util.splitFilePathName(self.path)
+    Screen:setWindowTitle(folder_name)
+    self._all_items = self:genItemTableFromPath(self.path)
+    self:_applyCurrentFilter()
+end
+
+function _InnerChooser:_applyCurrentFilter()
+    local filter_text = self._filter_text or ""
+    local items
+    
+    if filter_text == "" then
+        items = self._all_items
+    else
+        items = {}
+        local pattern = filter_text:lower()
+        for _, item in ipairs(self._all_items) do
+            if item.is_go_up or (item.text and item.text:lower():find(pattern, 1, true)) then
+                table.insert(items, item)
+            end
+        end
+    end
+    
+    local itemmatch
+    if self.focused_path then
+        itemmatch = {path = self.focused_path}
+        self.focused_path = nil
+    end
+    
+    local subtitle = BD.directory(filemanagerutil.abbreviate(self.path))
+    self:switchItemTable(nil, items, filter_text == "" and self.path_items[self.path] or 1, itemmatch, subtitle)
+end
+
+function _InnerChooser:applyFilter(text)
+    self._filter_text = text or ""
+    if self._all_items then
+        self:_applyCurrentFilter()
+    end
+end
+
+function _InnerChooser:updateItems(select_number, no_recalculate_dimen)
+    Menu.updateItems(self, select_number, no_recalculate_dimen)
+    self.path_items[self.path] = (self.page - 1) * self.perpage + (select_number or 1)
+
+    local eff_thumb = self._thumb_size or 0
+    if eff_thumb <= 0 then return end
+
+    local item_h = self.item_dimen and self.item_dimen.h or eff_thumb
+    local center_y = math.max(0, math.floor((item_h - eff_thumb) / 2))
+
+    for _, item_widget in ipairs(self.item_group) do
+        local entry = item_widget.entry
+        if not entry then goto continue end
+        local filepath = entry.path or ""
+        
+        local ext = filepath:lower()
+        if not (ext:match("%.svg$") or ext:match("%.png$")) then goto continue end
+
+        local uc = item_widget._underline_container
+        if not uc then goto continue end
+        local hg = uc[1]
+        if not hg then goto continue end
+        local og = hg[1]
+        if not og then goto continue end
+
+        table.insert(og, 1, ImageWidget:new{
+            file = filepath,
+            width = eff_thumb,
+            height = eff_thumb,
+            alpha = true,
+            overlap_offset = { 0, center_y },
+        })
+        og._size = nil
+
+        ::continue::
+    end
+end
+
+-- Tap to select (no confirmation dialog)
+function _InnerChooser:onMenuSelect(item)
+    local path = item.path or ""
+    local ext = path:lower()
+    
+    if ext:match("%.svg$") or ext:match("%.png$") then
+        local real_path = ffiUtil.realpath(path) or path
+        if self.show_parent then
+            self.show_parent:onClose()
+        else
+            UIManager:close(self)
+        end
+        if self.onConfirm then
+            self.onConfirm(real_path)
+        end
+        return true
+    end
+    return PathChooser.onMenuSelect(self, item)
+end
+
+function _InnerChooser:onMenuHold(item)
+    local path = item.path or ""
+    local ext = path:lower()
+    if ext:match("%.svg$") or ext:match("%.png$") then
+        return true
+    end
+    return PathChooser.onMenuHold(self, item)
+end
+
+-- ---------------------------------------------------------------------------
+-- Outer wrapper with filter bar
+-- ---------------------------------------------------------------------------
+local IconBrowser = WidgetContainer:extend{
+    path = DataStorage:getDataDir() .. "/icons/",
+    onConfirm = nil,
+    is_always_active = true,
+}
+
+function IconBrowser:init()
+    self.dimen = Geom:new{x = 0, y = 0, w = Screen:getWidth(), h = Screen:getHeight()}
+
+    -- Filter input
+    self._filter_input = InputText:new{
+        text = "",
+        hint = _("Filter by name…"),
+        width = self.dimen.w - 4 * Size.padding.default,
+        height = nil,
+        face = Font:getFace("smallinfofont"),
+        padding = Size.padding.small,
+        margin = 0,
+        bordersize = Size.border.inputtext,
+        parent = self,
+        scroll = false,
+        focused = false,
+        edit_callback = function()
+            self:_applyFilter()
+        end,
+    }
+    
+    -- Intercept Enter key
+    self._filter_input.addChars = function(inp, chars)
+        if chars == "\n" then
+            inp:onCloseKeyboard()
+            return
+        end
+        InputText.addChars(inp, chars)
+    end
+    
+    self._filter_bar = FrameContainer:new{
+        padding = Size.padding.default,
+        padding_top = Size.padding.small,
+        padding_bottom = Size.padding.small,
+        bordersize = 0,
+        self._filter_input,
+    }
+    
+    local filter_h = self._filter_bar:getSize().h
+
+    self._chooser = _InnerChooser:new{
+        show_parent = self,
+        path = self.path,
+        onConfirm = self.onConfirm,
+        height = self.dimen.h,
+        close_callback = function() self:onClose() end,
+    }
+    
+    table.insert(self._chooser.content_group, 2, self._filter_bar)
+    self._chooser._filter_bar_height = filter_h
+    self._chooser:refreshPath()
+
+    self[1] = self._chooser
+end
+
+function IconBrowser:_applyFilter()
+    if not self._chooser then return end
+    local text = self._filter_input and self._filter_input:getText() or ""
+    self._chooser:applyFilter(text)
+end
+
+function IconBrowser:getFocusableWidgetXY()
+    return nil, nil
+end
+
+function IconBrowser:onClose()
+    if self._filter_input then
+        self._filter_input:onCloseKeyboard()
+    end
+    UIManager:close(self)
+end
+
+return IconBrowser

--- a/sui_menu_picker.lua
+++ b/sui_menu_picker.lua
@@ -1,0 +1,483 @@
+-- sui_menu_picker.lua
+-- Record and replay menu navigation paths
+
+local Blitbuffer   = require("ffi/blitbuffer")
+local Button       = require("ui/widget/button")
+local InfoMessage  = require("ui/widget/infomessage")
+local Size         = require("ui/size")
+local TouchMenu    = require("ui/widget/touchmenu")
+local UIManager    = require("ui/uimanager")
+local VerticalSpan = require("ui/widget/verticalspan")
+local VerticalGroup   = require("ui/widget/verticalgroup")
+local logger       = require("logger")
+local _            = require("sui_i18n").translate
+
+local M = {}
+
+-- ==========================================================================
+-- Module-level picking state
+-- ==========================================================================
+
+local _state = {
+    active          = false,
+    menu            = nil,
+    on_done         = nil,
+    on_cancel       = nil,
+    tab_index       = nil,
+    nav_path        = nil,      -- stores { index = n, text = s } for each level
+    view            = nil,
+    action_bar      = nil,
+    bars_span       = nil,
+}
+
+-- Originals saved before patching
+local _orig_onMenuSelect    = nil
+local _orig_backToUpperMenu = nil
+local _orig_switchMenuTab   = nil
+local _orig_closeMenu       = nil
+local _orig_updateItems     = nil
+
+-- ==========================================================================
+-- Helpers
+-- ==========================================================================
+
+local function itemText(item)
+    local t = item.text
+    if type(t) == "function" then t = t() end
+    if not t and item.text_func then t = item.text_func() end
+    return type(t) == "string" and t or ""
+end
+
+local function snapshotMenuState(menu)
+    local item_table_stack = {}
+    for i, item_table in ipairs(menu.item_table_stack or {}) do
+        item_table_stack[i] = item_table
+    end
+    return {
+        cur_tab = menu.cur_tab,
+        item_table = menu.item_table,
+        item_table_stack = item_table_stack,
+        page = menu.page,
+    }
+end
+
+local function restoreMenuState(menu, state)
+    if not menu or not state then return end
+    menu.cur_tab = state.cur_tab
+    menu.item_table = state.item_table
+    menu.item_table_stack = {}
+    for i, tbl in ipairs(state.item_table_stack or {}) do
+        menu.item_table_stack[i] = tbl
+    end
+    menu.parent_id = nil
+    menu.page = state.page or 1
+    menu:updateItems(menu.page)
+end
+
+-- ==========================================================================
+-- Patch management
+-- ==========================================================================
+
+local function _stopPicking()
+    print("[sui_menu_picker] _stopPicking called")
+    local menu = _state.menu
+    local action_bar = _state.action_bar
+    local bars_span = _state.bars_span
+
+    _state.action_bar = nil
+    _state.bars_span = nil
+    _state.active = false
+    _state.menu = nil
+    _state.on_done = nil
+    _state.on_cancel = nil
+    _state.tab_index = nil
+    _state.nav_path = nil
+    _state.view = nil
+
+    if menu and action_bar then
+        local ig = menu.item_group
+        for i = #ig, 1, -1 do
+            if ig[i] == action_bar or ig[i] == bars_span then
+                table.remove(ig, i)
+            end
+        end
+        ig:resetLayout()
+        menu.dimen.h = ig:getSize().h + menu.bordersize * 2 + menu.padding
+        UIManager:setDirty(menu.show_parent, function()
+            return "ui", menu.dimen
+        end)
+    end
+
+    UIManager:setDirty("all", "flashui")
+
+    local TouchMenu = require("ui/widget/touchmenu")
+    if _orig_onMenuSelect then
+        print("[sui_menu_picker] Restoring original TouchMenu methods")
+        TouchMenu.onMenuSelect    = _orig_onMenuSelect
+        TouchMenu.backToUpperMenu = _orig_backToUpperMenu
+        TouchMenu.switchMenuTab   = _orig_switchMenuTab
+        TouchMenu.closeMenu       = _orig_closeMenu
+        TouchMenu.updateItems     = _orig_updateItems
+        _orig_onMenuSelect    = nil
+        _orig_backToUpperMenu = nil
+        _orig_switchMenuTab   = nil
+        _orig_closeMenu       = nil
+        _orig_updateItems     = nil
+    end
+end
+
+local function makeActionBar(menu)
+    local buttons = {}
+    
+    -- Add "Finish recording" button
+    table.insert(buttons, Button:new{
+        text           = _("Finish recording & save as shortcut"),
+        width          = menu.item_width,
+        text_font_bold = true,
+        bordersize     = Size.border.thin,
+        background     = Blitbuffer.COLOR_LIGHT_GRAY,
+        show_parent    = menu.show_parent,
+        callback       = function()
+            if _state.active then
+                -- Build index path from current navigation state
+                local index_path = {}
+                for _, step in ipairs(_state.nav_path) do
+                    table.insert(index_path, step.index)
+                end
+                local path_record = {
+                    tab_index     = _state.tab_index,
+                    display_label = _state.nav_path[#_state.nav_path] and _state.nav_path[#_state.nav_path].text or _("Menu Action"),
+                    index_path    = index_path,
+                    view          = _state.view,
+                    is_leaf       = false, 
+                }
+                local cb = _state.on_done
+                _stopPicking()
+                if cb then cb(path_record) end
+            end
+        end,
+    })
+    
+    -- Add cancel button
+    table.insert(buttons, Button:new{
+        text           = _("Cancel"),
+        width          = menu.item_width,
+        text_font_bold = true,
+        bordersize     = Size.border.thin,
+        background     = Blitbuffer.COLOR_LIGHT_GRAY,
+        show_parent    = menu.show_parent,
+        callback       = function()
+            if _state.active then
+                local cb = _state.on_cancel
+                _stopPicking()
+                if cb then cb() end
+            end
+        end,
+    })
+    
+    -- Return VerticalGroup containing both buttons
+    local vg = VerticalGroup:new{ align = "center" }
+    for _, btn in ipairs(buttons) do
+        table.insert(vg, btn)
+        table.insert(vg, VerticalSpan:new{ width = Size.padding.small })
+    end
+    return vg
+end
+
+local function _installPatches()
+    print("[sui_menu_picker] _installPatches called")
+    local TouchMenu = require("ui/widget/touchmenu")
+    
+    if _orig_onMenuSelect then
+        print("[sui_menu_picker] Already patched, skipping")
+        return
+    end
+
+    _orig_onMenuSelect    = TouchMenu.onMenuSelect
+    _orig_backToUpperMenu = TouchMenu.backToUpperMenu
+    _orig_switchMenuTab   = TouchMenu.switchMenuTab
+    _orig_closeMenu       = TouchMenu.closeMenu
+    _orig_updateItems     = TouchMenu.updateItems
+    
+    print("[sui_menu_picker] Saved original methods")
+
+    TouchMenu.updateItems = function(self, ...)
+        local result = _orig_updateItems(self, ...)
+        if _state.active and self == _state.menu then
+            if not _state.action_bar then
+                _state.action_bar = makeActionBar(self)
+            end
+            if not _state.bars_span then
+                _state.bars_span = VerticalSpan:new{ width = Size.padding.default }
+            end
+            table.insert(self.item_group, _state.bars_span)
+            table.insert(self.item_group, _state.action_bar)
+            self.item_group:resetLayout()
+            self.dimen.h = self.item_group:getSize().h + self.bordersize * 2 + self.padding
+            UIManager:setDirty(self.show_parent, function()
+                return "ui", self.dimen
+            end)
+        end
+        return result
+    end
+
+    TouchMenu.closeMenu = function(self, ...)
+        local orig = _orig_closeMenu
+        if _state.active and self == _state.menu then
+            print("[sui_menu_picker] Menu closed unexpectedly, cancelling pick")
+            local cb = _state.on_cancel
+            _stopPicking()
+            if cb then cb() end
+        end
+        return orig(self, ...)
+    end
+
+    -- Intercept item selection during picking
+    TouchMenu.onMenuSelect = function(self, item, tap_on_checkmark)
+        if not _state.active then
+            return _orig_onMenuSelect(self, item, tap_on_checkmark)
+        end
+
+        print("[sui_menu_picker] onMenuSelect intercepted, active=true")
+        
+        local sub = (item.sub_item_table_func and item.sub_item_table_func())
+                 or item.sub_item_table
+
+        local item_index
+        for i, it in ipairs(self.item_table or {}) do
+            if it == item then item_index = i; break end
+        end
+
+        if sub then
+            -- Record navigation step (store both index and text)
+            print("[sui_menu_picker] Entering sub-menu, recording step")
+            table.insert(_state.nav_path, {
+                index = item_index,
+                text  = itemText(item),
+            })
+            return _orig_onMenuSelect(self, item, tap_on_checkmark)
+        end
+
+        -- Leaf item tapped - capture it with index path
+        local label = itemText(item)
+        print("[sui_menu_picker] Leaf item tapped, capturing:", label)
+        
+        -- Build index path from nav_path
+        local index_path = {}
+        for _, step in ipairs(_state.nav_path) do
+            table.insert(index_path, step.index)
+        end
+        table.insert(index_path, item_index)
+        
+        print("[sui_menu_picker] Index path:", table.concat(index_path, " -> "))
+        
+        local path_record = {
+            tab_index     = _state.tab_index,
+            display_label = label,
+            index_path    = index_path,
+            view          = _state.view,
+            is_leaf       = true,  
+        }
+        
+        print("[sui_menu_picker] Path record created, calling on_done")
+        local cb = _state.on_done
+        _stopPicking()
+        if cb then 
+            cb(path_record) 
+        end
+        return true
+    end
+
+    TouchMenu.backToUpperMenu = function(self, no_close)
+        local orig = _orig_backToUpperMenu
+        if _state.active and self == _state.menu then
+            if #self.item_table_stack ~= 0 then
+                if #_state.nav_path > 0 then
+                    print("[sui_menu_picker] Back navigation, popping nav_path")
+                    table.remove(_state.nav_path)
+                end
+            else
+                print("[sui_menu_picker] Back to root, cancelling pick")
+                local cb = _state.on_cancel
+                _stopPicking()
+                if cb then cb() end
+            end
+        end
+        return orig(self, no_close)
+    end
+
+    TouchMenu.switchMenuTab = function(self, tab_num)
+        local orig = _orig_switchMenuTab
+        if _state.active and self == _state.menu then
+            print("[sui_menu_picker] Switched to tab:", tab_num)
+            _state.tab_index = tab_num
+            _state.nav_path  = {}
+        end
+        return orig(self, tab_num)
+    end
+    
+    print("[sui_menu_picker] Patches installed successfully")
+end
+
+-- ==========================================================================
+-- Public API
+-- ==========================================================================
+
+function M.startPicking(menu, on_done, on_cancel, view)
+    print("[sui_menu_picker] startPicking called")
+    
+    if _state.active then 
+        print("[sui_menu_picker] Already active, stopping previous pick")
+        _stopPicking() 
+    end
+
+    _state.active    = true
+    _state.menu      = menu
+    _state.tab_index = 1
+    _state.nav_path  = {}
+    _state.view      = view or "reader"
+    _state.on_done   = on_done
+    _state.on_cancel = on_cancel
+
+    _installPatches()
+
+    menu.cur_tab = nil
+    if menu.bar and menu.bar.switchToTab then
+        menu.bar:switchToTab(1)
+    end
+
+    UIManager:show(InfoMessage:new{
+        text    = _("Tap any menu item to record it as a shortcut."),
+        timeout = 3,
+    })
+    print("[sui_menu_picker] startPicking completed")
+end
+
+function M.cancelPicking()
+    print("[sui_menu_picker] cancelPicking called")
+    if _state.active then
+        local cb = _state.on_cancel
+        _stopPicking()
+        if cb then cb() end
+    end
+end
+
+function M.replay(menu, path_record)
+    print("[sui_menu_picker] ========== replay START ==========")
+    
+    print("index_path length:", #path_record.index_path)
+    for i, idx in ipairs(path_record.index_path) do
+        print("  level", i, ":", idx)
+    end
+    print("tab_index:", path_record.tab_index)
+    print("view:", path_record.view)
+    print("is_leaf:", path_record.is_leaf)
+
+    if not path_record then 
+        print("[sui_menu_picker] ERROR: path_record is nil")
+        return false 
+    end
+    
+    local index_path = path_record.index_path
+    if not index_path or #index_path == 0 then
+        print("[sui_menu_picker] ERROR: no index_path")
+        print("  path_record keys:")
+        for k, v in pairs(path_record) do
+            print("    ", k, "=", type(v) == "table" and "table" or v)
+        end
+        return false
+    end
+    
+    print("  index_path:", table.concat(index_path, " -> "))
+    print("  tab_index:", path_record.tab_index)
+    print("  view:", path_record.view)
+    
+    local saved_state = snapshotMenuState(menu)
+    print("  snapshotMenuState done")
+    
+    -- Switch to the recorded tab
+    if path_record.tab_index then
+        print("[sui_menu_picker] Switching to tab:", path_record.tab_index)
+        -- Ensure menu has updateItems method
+        if not menu.updateItems then
+            menu.updateItems = function() end
+        end
+        local switch = _orig_switchMenuTab or TouchMenu.switchMenuTab
+        switch(menu, path_record.tab_index)
+    end
+    
+    local current_menu = menu
+    local current_item = nil
+    
+    -- Helper function to switch to the correct page for a given index
+    local function ensurePageForIndex(target_idx)
+        if not current_menu.perpage then return end
+        local target_page = math.ceil(target_idx / current_menu.perpage)
+        if target_page > 1 and target_page ~= current_menu.page then
+            print("[sui_menu_picker] Switching to page", target_page, "for index", target_idx)
+            if current_menu.onGotoPage then
+                current_menu:onGotoPage(target_page)
+            end
+        end
+    end
+
+    for i, idx in ipairs(index_path) do
+        print("[sui_menu_picker] Looking for index", idx)
+        
+        -- Ensure we are on the correct page before looking up the index
+        ensurePageForIndex(idx)
+
+        if not current_menu.item_table or not current_menu.item_table[idx] then
+            print("[sui_menu_picker] Index", idx, "not found in current menu")
+            if current_menu.item_table then
+                print("[sui_menu_picker] Current menu has items 1..", #current_menu.item_table)
+            end
+            restoreMenuState(menu, saved_state)
+            return false
+        end
+        
+        current_item = current_menu.item_table[idx]
+        print("[sui_menu_picker] Found item at index", idx, ":", itemText(current_item))
+        
+        -- Determine whether to enter submenu:
+        -- 1. There is a next level (i < #index_path)
+        -- 2. Or this is the last level but is_leaf = false (intermediate node, need to open menu)
+        local should_enter_submenu = (i < #index_path) or (i == #index_path and not path_record.is_leaf)
+        
+        if should_enter_submenu then
+            local sub = (current_item.sub_item_table_func and current_item.sub_item_table_func())
+                     or current_item.sub_item_table
+            if not sub or #sub == 0 then
+                print("[sui_menu_picker] No submenu at index", idx)
+                restoreMenuState(menu, saved_state)
+                return false
+            end
+            table.insert(current_menu.item_table_stack, current_menu.item_table)
+            current_menu.item_table = sub
+            current_menu.page = 1
+            current_menu:updateItems(1)  -- Refresh menu display
+            print("[sui_menu_picker] Entered submenu at index", idx)
+        end
+    end
+    
+    -- Execute the leaf item callback based on is_leaf flag
+    if path_record.is_leaf then
+        print("[sui_menu_picker] Leaf node, executing callback and closing menu")
+        local callback = (current_item.callback_func and current_item.callback_func()) or current_item.callback
+        if callback then
+            local ok, err = pcall(callback, current_menu)
+            if not ok then
+                print("[sui_menu_picker] Callback error:", err)
+            end
+        end
+        restoreMenuState(menu, saved_state)
+        menu:closeMenu()
+    else
+        print("[sui_menu_picker] Intermediate node, navigating only (keeping menu open)")
+        -- Only navigate to the target menu, keep it open, do not execute callback
+    end
+    print("[sui_menu_picker] ========== replay END (success) ==========")
+    return true 
+end
+
+return M

--- a/sui_patches.lua
+++ b/sui_patches.lua
@@ -1215,6 +1215,7 @@ function M.patchUIManagerShow(plugin)
         -- Wire the native "File browser" menu tab to use our flash-free
         -- close path every time a ReaderUI is shown (guard inside the fn).
         if widget.name == "ReaderUI" then
+            widget._simpleui_plugin = plugin
             pcall(M.wireReaderMenuFMTab,    plugin, widget)
             pcall(M.patchReloadDocument,    plugin, widget)
         end

--- a/sui_quickactions.lua
+++ b/sui_quickactions.lua
@@ -42,9 +42,9 @@ local N_ = require("sui_i18n").ngettext
 
 local Config      = require("sui_config")
 local SUISettings = require("sui_store")
+local ButtonDialog = require("ui/widget/buttondialog")
 
 local QA = {}
-
 -- ---------------------------------------------------------------------------
 -- Icon path guard — picker-time validation
 -- ---------------------------------------------------------------------------
@@ -603,11 +603,13 @@ function QA.getCustomQAConfig(qa_id)
         plugin_key        = cfg.plugin_key,
         plugin_method     = cfg.plugin_method,
         dispatcher_action = cfg.dispatcher_action,
+        dispatcher_value  = cfg.dispatcher_value,
+        menu_path         = cfg.menu_path,
         icon              = cfg.icon,
     }
 end
 
-function QA.saveCustomQAConfig(qa_id, label, path, collection, icon, plugin_key, plugin_method, dispatcher_action)
+function QA.saveCustomQAConfig(qa_id, label, path, collection, icon, plugin_key, plugin_method, dispatcher_action, dispatcher_value, menu_path)
     SUISettings:set(getQASettingsKey(qa_id), {
         label             = label,
         path              = path,
@@ -615,6 +617,8 @@ function QA.saveCustomQAConfig(qa_id, label, path, collection, icon, plugin_key,
         plugin_key        = plugin_key,
         plugin_method     = plugin_method,
         dispatcher_action = dispatcher_action,
+        dispatcher_value  = dispatcher_value,
+        menu_path         = menu_path,
         icon              = icon,
     })
 end
@@ -848,6 +852,8 @@ function QA.sui_show_qa_list(plugin, ctx_menu, ctx)
                 desc = "⬡ " .. c.plugin_key .. ":" .. (c.plugin_method or "?")
             elseif c.collection and c.collection ~= "" then
                 desc = "⊞ " .. c.collection
+            elseif c.menu_path and type(c.menu_path) == "table" then
+                desc = "⊚ " .. (c.menu_path.display_label or "Menu Action")
             else
                 desc = c.path or ctx_menu._("not configured")
                 if #desc > 34 then desc = "…" .. desc:sub(-31) end
@@ -1367,6 +1373,25 @@ function QA.showIconPicker(current_icon, on_select, default_label, _picker_handl
             end,
         }}
     end
+
+    -- ==========================================================================
+    -- Browse files button — opens sui_icon_browser to pick icons from filesystem
+    -- ==========================================================================
+    buttons[#buttons + 1] = {{
+        text = _("Browse files…"),
+        callback = function()
+            UIManager:close(_picker_handle[picker_key])
+            local IconBrowser = require("sui_icon_browser")
+            local DataStorage = require("datastorage")
+            UIManager:show(IconBrowser:new{
+                path = DataStorage:getDataDir() .. "/icons/",
+                onConfirm = function(file_path)
+                    on_select(file_path)
+                end,
+            })
+        end,
+    }}
+
     if #icons == 0 then
         buttons[#buttons + 1] = {{
             text    = _("No icons found in:") .. "\n" .. QA.ICONS_DIR,
@@ -1554,6 +1579,10 @@ function QA.showQuickActionDialog(plugin, qa_id, on_done)
         current_action_type = "path"
         current_action_val1 = cfg.path
         current_action_title = cfg.path:match("([^/]+)$") or cfg.path
+    elseif cfg.menu_path and type(cfg.menu_path) == "table" then
+        current_action_type = "menu"
+        current_action_val1 = cfg.menu_path
+        current_action_title = cfg.menu_path.display_label or "Menu Action"
     end
 
     local function iconButtonLabel(default_lbl)
@@ -1568,7 +1597,7 @@ function QA.showQuickActionDialog(plugin, qa_id, on_done)
         return _("Icon") .. ": " .. stem
     end
 
-    local function commitQA(final_label, path, coll, default_icon, fm_key, fm_method, dispatcher_action)
+    local function commitQA(final_label, path, coll, default_icon, fm_key, fm_method, dispatcher_action, dispatcher_value, menu_path)
         local final_id = qa_id or Config.nextCustomQAId()
         if not qa_id then
             local list = Config.getCustomQAList()
@@ -1576,7 +1605,7 @@ function QA.showQuickActionDialog(plugin, qa_id, on_done)
             Config.saveCustomQAList(list)
         end
         Config.saveCustomQAConfig(final_id, final_label, path, coll,
-            chosen_icon or default_icon, fm_key, fm_method, dispatcher_action)
+            chosen_icon or default_icon, fm_key, fm_method, dispatcher_action, dispatcher_value, menu_path)
         QA.invalidateCustomQACache()
         plugin:_rebuildAllNavbars()
         if on_done then on_done() end
@@ -1589,7 +1618,15 @@ function QA.showQuickActionDialog(plugin, qa_id, on_done)
         if not current_action_type and not qa_id then
             if on_done then on_done() end
         else
-            _buildSaveDialog(false)
+          if active_dialog then
+             UIManager:close(active_dialog)
+             active_dialog = nil
+           end
+           if _buildSaveDialog then
+               _buildSaveDialog(false)
+           elseif on_done then
+               on_done()
+           end
         end
     end
 
@@ -1630,6 +1667,9 @@ function QA.showQuickActionDialog(plugin, qa_id, on_done)
         elseif current_action_type == "dispatcher" then
             action_label = action_label .. (current_action_title or "")
             icon_default = Config.CUSTOM_DISPATCHER_ICON
+        elseif current_action_type == "menu" then
+            action_label = action_label .. (current_action_title or "")
+            icon_default = Config.CUSTOM_ICON
         else
             action_label = action_label .. _("None")
         end
@@ -1666,14 +1706,15 @@ function QA.showQuickActionDialog(plugin, qa_id, on_done)
                         
                         UIManager:close(active_dialog); active_dialog = nil
                         
-                        local p_path, p_coll, p_pk, p_pm, p_da
+                        local p_path, p_coll, p_pk, p_pm, p_da, p_dv, p_mp
                         if current_action_type == "path" then p_path = current_action_val1
                         elseif current_action_type == "collection" then p_coll = current_action_val1
                         elseif current_action_type == "plugin" then p_pk = current_action_val1; p_pm = current_action_val2
-                        elseif current_action_type == "dispatcher" then p_da = current_action_val1
+                        elseif current_action_type == "dispatcher" then p_da = current_action_val1; p_dv = current_action_val2
+                        elseif current_action_type == "menu" then p_mp = current_action_val1
                         end
                         
-                        commitQA(final_label, p_path, p_coll, chosen_icon or icon_default, p_pk, p_pm, p_da)
+                        commitQA(final_label, p_path, p_coll, chosen_icon or icon_default, p_pk, p_pm, p_da, p_dv, p_mp)
                     end } },
             },
         }
@@ -1756,30 +1797,278 @@ function QA.showQuickActionDialog(plugin, qa_id, on_done)
     end
 
     local function openDispatcherPicker()
-        local actions = _scanDispatcherActions()
-        if #actions == 0 then
+        local Dispatcher = require("dispatcher")
+        Dispatcher:init()
+        
+        -- Get settingsList upvalue
+        local settingsList, dispatcher_menu_order
+        local fn_idx = 1
+        while true do
+            local name, val = debug.getupvalue(Dispatcher.registerAction, fn_idx)
+            if not name then break end
+            if name == "settingsList" then settingsList = val end
+            if name == "dispatcher_menu_order" then dispatcher_menu_order = val end
+            fn_idx = fn_idx + 1
+        end
+        
+        if type(settingsList) ~= "table" then
             UIManager:show(InfoMessage:new{ text = _("No system actions found."), timeout = 3 })
             cancelActionPicker()
             return
         end
-        local buttons = {}
-        table.sort(actions, function(a, b) return a.title:lower() < b.title:lower() end)
-        for _i, a in ipairs(actions) do
-            local _a = a
-            buttons[#buttons + 1] = {{ text = _a.title, callback = function()
-                UIManager:close(plugin._qa_dispatcher_picker)
-                current_action_type = "dispatcher"
-                current_action_val1 = _a.id
-                current_action_title = _a.title
-                _buildSaveDialog(true)
-            end }}
+        local order = (type(dispatcher_menu_order) == "table" and dispatcher_menu_order)
+            or (function()
+                local keys = {}
+                for key in pairs(settingsList) do keys[#keys + 1] = key end
+                table.sort(keys)
+                return keys
+            end)()
+        
+        -- Define categories for grouping
+        local sections = {
+            { key = "general",     title = _("General") },
+            { key = "device",      title = _("Device") },
+            { key = "screen",      title = _("Screen and lights") },
+            { key = "filemanager", title = _("File browser") },
+            { key = "reader",      title = _("Reader") },
+            { key = "rolling",     title = _("Reflowable documents (epub, fb2, txt…)") },
+            { key = "paging",      title = _("Fixed layout documents (pdf, djvu, pics…)") },
+        }
+        
+        -- Collect actions by category
+        local sections_map = {}
+        for _, sec in ipairs(sections) do
+            sections_map[sec.key] = { title = sec.title, items = {} }
         end
-        buttons[#buttons + 1] = {{ text = _("Cancel"),
-            callback = function() UIManager:close(plugin._qa_dispatcher_picker); cancelActionPicker() end }}
-        plugin._qa_dispatcher_picker = ButtonDialog:new{ title = _("System Actions"), title_align = "center", buttons = buttons }
-        UIManager:show(plugin._qa_dispatcher_picker)
+        
+        for _, action_id in ipairs(order) do
+            local def = settingsList[action_id]
+            if type(def) == "table" and def.title and def.category
+                    and (def.condition == nil or def.condition == true) then
+                -- Determine section
+                local section_key = "general"
+                for _, sec in ipairs(sections) do
+                    if def[sec.key] == true then
+                        section_key = sec.key
+                        break
+                    end
+                end
+                table.insert(sections_map[section_key].items, {
+                    id = action_id,
+                    title = tostring(def.title),
+                    category = def.category,
+                    def = def,
+                })
+            end
+        end
+        
+        -- Handle action selection based on category
+        local function handleAction(action)
+            local category = action.category
+            local action_id = action.id
+            local action_title = action.title
+            local def = action.def
+            
+            if category == "none" or category == "arg" then
+                -- Direct action with no arguments or simple argument
+                current_action_type = "dispatcher"
+                current_action_val1 = action_id
+                current_action_val2 = true
+                current_action_title = action_title
+                _buildSaveDialog(true)
+             elseif category == "absolutenumber" or category == "incrementalnumber" then
+                -- Numeric action: show SpinWidget to select value
+                local SpinWidget = require("ui/widget/spinwidget")
+                local spin = SpinWidget:new{
+                    title_text = action_title,
+                    value = def.default or def.min or 0,
+                    value_min = def.min or 0,
+                    value_max = def.max or 100,
+                    value_step = def.step or 1,
+                    unit = def.unit,
+                    callback = function(spin)
+                        local value = spin.value
+                        current_action_type = "dispatcher"
+                        current_action_val1 = action_id
+                        current_action_val2 = value
+                        current_action_title = action_title .. ": " .. tostring(value)
+                        _buildSaveDialog(true)
+                    end,
+                }
+                UIManager:show(spin)
+            elseif category == "string" or category == "configurable" then
+                -- Parameterized action: show submenu with available options
+                local sub_items = {}
+                local args = def.args
+                local toggle = def.toggle
+                if def.args_func then
+                    local ok, a, t = pcall(def.args_func)
+                    if ok then
+                        args = a
+                        toggle = t
+                    end
+                end
+                
+                if args and #args > 0 then
+                    for i, value in ipairs(args) do
+                        local display = toggle and toggle[i] or tostring(value)
+                        table.insert(sub_items, {{
+                            text = display,
+                            callback = function()
+                                current_action_type = "dispatcher"
+                                current_action_val1 = action_id
+                                current_action_val2 = value
+                                current_action_title = display
+                                _buildSaveDialog(true)
+                            end,
+                        }})
+                    end
+                end
+                
+                if #sub_items > 0 then
+                    local sub_dialog = ButtonDialog:new{
+                        title = action_title,
+                        title_align = "center",
+                        buttons = sub_items,
+                        width = math.floor(Screen:getWidth() * 0.7),
+                    }
+                    UIManager:show(sub_dialog)
+                else
+                    UIManager:show(InfoMessage:new{
+                        text = _("No options available for this action."),
+                        timeout = 2,
+                    })
+                end
+            end
+        end
+        -- Build category buttons
+        local buttons = {}
+        for _, sec in ipairs(sections) do
+            local items = sections_map[sec.key].items
+            if #items > 0 then
+                table.sort(items, function(a, b) return a.title:lower() < b.title:lower() end)
+                local sub_buttons = {}
+                for _, action in ipairs(items) do
+                    sub_buttons[#sub_buttons + 1] = {{
+                        text = action.title,
+                        callback = function()
+                            handleAction(action)
+                        end,
+                    }}
+                end
+                buttons[#buttons + 1] = {{
+                    text = sec.title,
+                    callback = function()
+                        local sub_dialog = ButtonDialog:new{
+                            title = sec.title,
+                            title_align = "center",
+                            buttons = sub_buttons,
+                            width = math.floor(Screen:getWidth() * 0.7),
+                        }
+                        UIManager:show(sub_dialog)
+                    end,
+                }}
+            end
+        end
+        
+        if #buttons == 0 then
+            UIManager:show(InfoMessage:new{ text = _("No system actions found."), timeout = 3 })
+            cancelActionPicker()
+            return
+        end
+        
+        local picker = ButtonDialog:new{
+            title = _("System Actions"),
+            title_align = "center",
+            buttons = buttons,
+            width = math.floor(Screen:getWidth() * 0.7),
+        }
+        UIManager:show(picker)
+    end
+    -- ==========================================================================
+    -- openMenuPicker — record a menu navigation path
+    -- ==========================================================================
+    local function openMenuPicker()
+        local FM = package.loaded["apps/filemanager/filemanager"]
+        local fm = FM and FM.instance
+        local RUI = package.loaded["apps/reader/readerui"]
+        
+        local target_menu = nil
+        local view = "reader"
+        
+        -- Try to get ReaderUI menu first
+        if RUI and RUI.instance and RUI.instance.menu then
+            if not RUI.instance.menu.menu_container or not RUI.instance.menu.menu_container[1] then
+                RUI.instance.menu:onShowMenu()
+            end
+            target_menu = RUI.instance.menu.menu_container and RUI.instance.menu.menu_container[1]
+            view = "reader"
+        elseif fm and fm.menu then
+            -- Fall back to FileManager menu
+            if not fm.menu.menu_container or not fm.menu.menu_container[1] then
+                fm.menu:onShowMenu()
+            end
+            target_menu = fm.menu.menu_container and fm.menu.menu_container[1]
+            view = "fb"
+        else
+            UIManager:show(InfoMessage:new{
+                text = _("Open a book or go to file browser first."),
+                timeout = 3,
+            })
+            cancelActionPicker()
+            return
+        end
+        
+        if not target_menu then
+            UIManager:show(InfoMessage:new{
+                text = _("Could not open menu."),
+                timeout = 3,
+            })
+            cancelActionPicker()
+            return
+        end
+        
+        local ok, MenuPicker = pcall(require, "sui_menu_picker")
+        if not ok then
+            UIManager:show(InfoMessage:new{
+                text = _("Failed to load menu picker module."),
+                timeout = 3,
+            })
+            cancelActionPicker()
+            return
+        end
+        
+        MenuPicker.startPicking(
+            target_menu,
+            function(path_record)
+                -- Create a clean copy with only serializable data
+                local function cleanString(s)
+                    if not s then return "" end
+                    return s:gsub("[\n\r]", ""):match("^%s*(.-)%s*$") or ""
+                end
+                local clean_record = {
+                    tab_index = path_record.tab_index,
+                    display_label = cleanString(path_record.display_label),
+                    index_path = path_record.index_path,
+                    view = view,
+                    is_leaf = path_record.is_leaf,
+                }
+                
+                current_action_type = "menu"
+                current_action_val1 = clean_record
+                current_action_title = clean_record.display_label
+                _buildSaveDialog(true)
+            end,
+            function()
+                cancelActionPicker()
+            end,
+            view
+        )
     end
 
+    -- ==========================================================================
+    -- openActionPicker — main action type selection dialog
+    -- ==========================================================================
     openActionPicker = function()
         if active_dialog then UIManager:close(active_dialog); active_dialog = nil end
         local choice_dialog
@@ -1792,6 +2081,15 @@ function QA.showQuickActionDialog(plugin, qa_id, on_done)
                callback = function() UIManager:close(choice_dialog); openPluginPicker() end }},
             {{ text = _("System Actions"),
                callback = function() UIManager:close(choice_dialog); openDispatcherPicker() end }},
+            {{ text = _("Menu Action"),
+               callback = function()
+                   UIManager:close(choice_dialog)
+                   local SUIWindow = require("sui_window")
+                   for _, inst in ipairs(SUIWindow._open_instances or {}) do
+                       inst:close()
+                   end
+                   openMenuPicker()
+               end }},
             {{ text = _("Cancel"),
                callback = function() UIManager:close(choice_dialog); cancelActionPicker() end }},
         }}
@@ -2016,6 +2314,8 @@ function QA.makeMenuItems(plugin, ctx_menu)
                     desc = "⬡ " .. c.plugin_key .. ":" .. (c.plugin_method or "?")
                 elseif c.collection and c.collection ~= "" then
                     desc = "⊞ " .. c.collection
+                elseif c.menu_path and type(c.menu_path) == "table" then
+                    desc = "⊚ " .. (c.menu_path.display_label or "Menu Action")
                 else
                     desc = c.path or _("not configured")
                     if #desc > 34 then desc = "…" .. desc:sub(-31) end
@@ -2032,6 +2332,8 @@ function QA.makeMenuItems(plugin, ctx_menu)
                             desc = "⬡ " .. c.plugin_key .. ":" .. (c.plugin_method or "?")
                         elseif c.collection and c.collection ~= "" then
                             desc = "⊞ " .. c.collection
+                        elseif c.menu_path and type(c.menu_path) == "table" then
+                            desc = "⊚ " .. (c.menu_path.display_label or "Menu Action")
                         else
                             desc = c.path or _("not configured")
                             if #desc > 38 then desc = "…" .. desc:sub(-35) end
@@ -2096,8 +2398,9 @@ function QA.executeCustomQA(action_id, fm, show_unavailable_fn)
     if cfg.dispatcher_action and cfg.dispatcher_action ~= "" then
         local ok_disp, Dispatcher = pcall(require, "dispatcher")
         if ok_disp and Dispatcher then
+            local action_value = cfg.dispatcher_value or true
             local ok, err = pcall(function()
-                Dispatcher:execute({ [cfg.dispatcher_action] = true })
+                Dispatcher:execute({ [cfg.dispatcher_action] = action_value })
             end)
             if not ok then
                 logger.warn("simpleui: dispatcher_action failed:", cfg.dispatcher_action, tostring(err))
@@ -2141,6 +2444,69 @@ function QA.executeCustomQA(action_id, fm, show_unavailable_fn)
 
     elseif cfg.path and cfg.path ~= "" then
         if fm and fm.file_chooser then fm.file_chooser:changeToPath(cfg.path) end
+
+    -- Menu action (recorded menu navigation path)
+    elseif cfg.menu_path and type(cfg.menu_path) == "table" then
+        local MenuPicker = require("sui_menu_picker")
+        local target_menu = nil
+        
+        local recorded_view = cfg.menu_path.view or "reader"
+        local RUI = package.loaded["apps/reader/readerui"]
+        local FM_mod = package.loaded["apps/filemanager/filemanager"]
+        local fm_inst = FM_mod and FM_mod.instance
+        local rui_inst = RUI and RUI.instance
+        
+        -- Check if current view matches the recorded view
+        local current_view = nil
+        if rui_inst and rui_inst.menu then
+            current_view = "reader"
+        elseif fm_inst and fm_inst.menu then
+            current_view = "fb"
+        end
+        
+        if recorded_view ~= current_view then
+            local msg = (recorded_view == "reader") 
+                and _("This shortcut only works in the reader. Please open a book first.")
+                or _("This shortcut only works in the file browser.")
+            _unavail(msg)
+            return
+        end
+        
+        -- Get the target menu widget
+        if recorded_view == "reader" then
+            if rui_inst and rui_inst.menu then
+                if not rui_inst.menu.show_parent then
+                    rui_inst.menu:onShowMenu()
+                end
+                local mc = rui_inst.menu.menu_container
+                if mc and mc[1] then
+                    target_menu = mc[1]
+                else
+                    target_menu = rui_inst.menu
+                end
+            end
+        else  -- "fb"
+            if fm_inst and fm_inst.menu then
+                fm_inst.menu:onShowMenu(cfg.menu_path.tab_index or 1)
+                local mc = fm_inst.menu.menu_container
+                if mc and mc[1] then
+                    target_menu = mc[1]
+                else
+                    target_menu = fm_inst.menu
+                end
+            end
+        end
+        
+        if not target_menu then
+            _unavail(_("Menu not available."))
+            return
+        end
+        
+        local ok, err = pcall(MenuPicker.replay, target_menu, cfg.menu_path)
+        if not ok then
+            logger.warn("simpleui: menu replay failed for", action_id, tostring(err))
+            _unavail(_("Failed to replay menu action. Menu structure may have changed."))
+        end
 
     else
         _unavail(_("No folder, collection or plugin configured.\nGo to Simple UI → Settings → Quick Actions to set one."))

--- a/sui_quicksettings_bar.lua
+++ b/sui_quicksettings_bar.lua
@@ -68,7 +68,7 @@ local FRONTLIGHT_KEY = "simpleui_qs_bar_frontlight"
 local WARMTH_KEY     = "simpleui_qs_bar_warmth"
 local LABELS_KEY     = "simpleui_qs_bar_labels"
 local LABEL_SCALE_KEY= "simpleui_qs_bar_label_scale_pct"
-local MAX_SLOTS      = 6
+local MAX_SLOTS      = 24
 
 local function getSlots()
     local raw = SUISettings:readSetting(SLOTS_KEY)
@@ -127,7 +127,79 @@ end
 -- ---------------------------------------------------------------------------
 
 local function buildPanel(touch_menu)
-    local slots    = getSlots()
+    local original_slots = getSlots()
+
+    -- Detect current view: "reader" (inside a book) or "fb" (file browser)
+    local current_view = nil
+    local RUI = package.loaded["apps/reader/readerui"]
+    if RUI and RUI.instance and not RUI.instance.tearing_down then
+        current_view = "reader"
+    else
+        current_view = "fb"
+    end
+
+    -- Determine which context an action belongs to
+    -- Returns: "fb", "reader", or "common" (both)
+    local function getActionCategory(action_id)
+        local cfg = SUISettings:get("simpleui_qa_" .. action_id) or {}
+
+        -- Folder or collection: file browser only
+        if cfg.path or cfg.collection then
+            return "fb"
+        end
+
+        -- Plugin action: works everywhere
+        if cfg.plugin_key then
+            return "common"
+        end
+
+        -- Action with explicit menu_path.view setting
+        if cfg.menu_path and type(cfg.menu_path) == "table" then
+            return cfg.menu_path.view
+        end
+
+        -- Dispatcher action: inspect its category
+        if cfg.dispatcher_action then
+            local Dispatcher = require("dispatcher")
+            local settingsList
+            local fn_idx = 1
+            while true do
+                local name, val = debug.getupvalue(Dispatcher.registerAction, fn_idx)
+                if not name then break end
+                if name == "settingsList" then settingsList = val end
+                fn_idx = fn_idx + 1
+            end
+            local def = settingsList and settingsList[cfg.dispatcher_action]
+            if def then
+                if def.filemanager then return "fb" end
+                if def.reader or def.rolling or def.paging then return "reader" end
+            end
+            return "common"
+        end
+
+        -- Built-in file browser actions
+        local fb_actions = {
+            "home", "collections", "history", "favorites",
+            "browse_authors", "browse_series", "browse_tags"
+        }
+        for _, id in ipairs(fb_actions) do
+            if action_id == id then return "fb" end
+        end
+
+        -- Default: available in both contexts
+        return "common"
+    end
+
+    -- Filter slots: only show actions valid in current view
+    local slots = {}
+    for _, action_id in ipairs(original_slots) do
+        local category = getActionCategory(action_id)
+        if category == "common" or category == current_view then
+            table.insert(slots, action_id)
+        end
+    end
+
+    local n = #slots
     local panel_w  = touch_menu.item_width
     local padding  = Screen:scaleBySize(28)
     local inner_w  = panel_w - padding * 2
@@ -240,15 +312,35 @@ local function buildPanel(touch_menu)
         return vg, btn_frame
     end
 
-    local btn_row = HorizontalGroup:new{ align = "center" }
-    local n = #slots
+local n = #slots
+-- Calculate max buttons per row based on available width
+local fixed_gap = Screen:scaleBySize(8)
+local max_per_row = math.floor((inner_w + fixed_gap) / (btn_size + fixed_gap))
+if max_per_row < 1 then max_per_row = 1 end
 
-    if n > 0 then
-        local gap = (n > 1)
-            and math.max(0, math.floor((inner_w - n * btn_size) / (n - 1)))
+-- Split into multiple rows
+local rows = {}
+for i = 1, n, max_per_row do
+    local row_slots = {}
+    for j = i, math.min(i + max_per_row - 1, n) do
+        table.insert(row_slots, slots[j])
+    end
+    table.insert(rows, row_slots)
+end
+
+-- Build all rows vertically
+local rows_vg = VerticalGroup:new{ align = "center" }
+local row_gap = Screen:scaleBySize(8)
+
+if n > 0 then
+    for ri, row_slots in ipairs(rows) do
+        local row_n = #row_slots
+        local gap = (row_n > 1)
+            and math.max(0, math.floor((inner_w - row_n * btn_size) / (row_n - 1)))
             or 0
-
-        for i, action_id in ipairs(slots) do
+        
+        local hg = HorizontalGroup:new{ align = "center" }
+        for i, action_id in ipairs(row_slots) do
             local vg, btn_frame = makeButton(action_id)
             local _aid = action_id
             table.insert(refs.buttons, {
@@ -345,18 +437,27 @@ local function buildPanel(touch_menu)
                     return stay_open
                 end,
             })
-            table.insert(btn_row, vg)
-            if i < n then
-                table.insert(btn_row, HorizontalSpan:new{ width = gap })
+            table.insert(hg, vg)
+            if i < row_n then
+                table.insert(hg, HorizontalSpan:new{ width = gap })
             end
         end
-    else
-        table.insert(btn_row, TextWidget:new{
-            text    = _("No actions configured.\nGo to Bars → Quick Settings Bar."),
-            face    = Font:getFace("cfont"),
-            fgcolor = Blitbuffer.COLOR_DARK_GRAY,
-        })
+        
+        table.insert(rows_vg, hg)
+        if ri < #rows then
+            table.insert(rows_vg, VerticalSpan:new{ width = row_gap })
+        end
     end
+else
+    -- No actions configured, show a hint message
+    table.insert(rows_vg, TextWidget:new{
+        text    = _("No actions configured.\nGo to Bars → Quick Settings Bar."),
+        face    = Font:getFace("cfont"),
+        fgcolor = Blitbuffer.COLOR_DARK_GRAY,
+    })
+end
+
+local btn_row = rows_vg
 
     -- ── Slider helpers ───────────────────────────────────────────────────────
     local Button         = require("ui/widget/button")
@@ -949,6 +1050,45 @@ function QSBar.install()
     -- 1. Patch TouchMenu methods.
     patchTouchMenu()
 
+    -- Reset FileManagerMenu tab index to 1 when closing
+    -- This ensures Quick Settings panel is active when menu reopens
+    local function patchFileManagerMenuClose()
+        local ok, FileManagerMenu = pcall(require, "apps/filemanager/filemanagermenu")
+        if not ok or not FileManagerMenu then return end
+        if FileManagerMenu._sui_qs_fm_patched then return end
+        FileManagerMenu._sui_qs_fm_patched = true
+
+        local orig_onCloseFileManagerMenu = FileManagerMenu.onCloseFileManagerMenu
+        FileManagerMenu.onCloseFileManagerMenu = function(self)
+            if self.menu_container and self.menu_container[1] then
+                self.menu_container[1].last_index = 1
+            end
+            return orig_onCloseFileManagerMenu(self)
+        end
+    end
+
+    patchFileManagerMenuClose()
+
+    -- Reset ReaderMenu tab index to 1 when closing
+    -- This ensures Quick Settings panel is active when menu reopens
+    local function patchReaderMenuClose()
+        local ok, ReaderMenu = pcall(require, "apps/reader/modules/readermenu")
+        if not ok or not ReaderMenu then return end
+        if ReaderMenu._sui_qs_reader_patched then return end
+        ReaderMenu._sui_qs_reader_patched = true
+
+        local orig_onCloseReaderMenu = ReaderMenu.onCloseReaderMenu
+        ReaderMenu.onCloseReaderMenu = function(self)
+            if self.menu_container and self.menu_container[1] then
+                self.menu_container[1].last_index = 1
+                self.last_tab_index = 1
+            end
+            return orig_onCloseReaderMenu(self)
+        end
+    end
+
+    patchReaderMenuClose()
+
     -- 2. Patch FileManagerMenu:setUpdateItemTable to inject the panel tab.
     local ok_fm, FMMenu = pcall(require, "apps/filemanager/filemanagermenu")
     if not ok_fm or not FMMenu then return end
@@ -978,6 +1118,18 @@ function QSBar.install()
             -- tab_item_table is built (or already cached) at this point;
             -- inject our panel tab before the TouchMenu is created.
             if m_self.tab_item_table then
+                -- Move "File manager" tab to the end of the list
+                -- This gives priority to reader-specific tabs
+                local tabs = m_self.tab_item_table
+                for i, tab in ipairs(tabs) do
+                    if tab.id == "filemanager" or (tab.text and tab.text == _("File manager")) then
+                        if i < #tabs then
+                            table.remove(tabs, i)
+                            table.insert(tabs, tab)
+                        end
+                        break
+                    end
+                end 
                 injectPanelTab(m_self)
             end
             return orig_show_menu(m_self, ...)

--- a/sui_quicksettings_bar.lua
+++ b/sui_quicksettings_bar.lua
@@ -798,6 +798,14 @@ local function patchTouchMenu()
         self.page_info_left_chev:showHide(false)
         self.page_info_right_chev:showHide(false)
 
+        -- Disable long-press on pagination buttons to prevent crashes
+        if self.page_info_left_chev then
+            self.page_info_left_chev.hold_callback = nil
+        end
+        if self.page_info_right_chev then
+            self.page_info_right_chev.hold_callback = nil
+        end
+
         -- Update clock/battery in footer
         local time_txt = datetime.secondsToHour(
             os.time(), G_reader_settings:isTrue("twelve_hour_clock"))


### PR DESCRIPTION
## Summary

This PR adds several enhancements to SimpleUI, including menu action recording, icon browser, dispatcher parameter support, UI limit increases, and various user experience improvements.

---

## New Features

### 1. Menu Action Recording（inspired by [shortcutstoolbar.koplugin](https://github.com/hqwo/shortcutstoolbar.koplugin)）
- Record KOReader menu navigation paths and save as quick actions
- New module: `sui_menu_picker.lua`
- Supports both Reader and File Browser menus
- Replay recorded paths on demand

### 2. Icon Browser（inspired by [shortcutstoolbar.koplugin](https://github.com/hqwo/shortcutstoolbar.koplugin)）
- Browse filesystem for custom SVG/PNG icons with thumbnail preview
- New module: `sui_icon_browser.lua`
- Integrated into icon picker as "Browse files…" button

### 3. Dispatcher Parameter Support
- System actions now support parameters (numeric values, string options)
- Actions grouped by category: General, Device, Screen, File browser, Reader, etc.
- Shows SpinWidget for numeric actions, submenu for configurable actions

---

## Improvements

### Tab & Slot Limits

| Item | Before | After |
|------|--------|-------|
| Max bottom bar tabs | 6 | 10 |
| Max navpager tabs | 4 | 6 |
| Max label length | 20 | 40 |
| Max quick settings slots | 6 | 24 |

### Quick Settings Bar
- Multi-row layout (auto-wraps when exceeding max per row)
- **Context-aware action filtering**: automatically hides actions that are invalid in current view (Reader vs File Browser), reducing visual clutter
- Menu close patch to reset tab index (Quick Settings panel shows first)
- Crash prevention for footer long-press

### Reader Menu
- Move "File manager" tab to the end of the list
- Quick Settings panel injected and prioritized

### ReaderUI Integration
- Register `_simpleui_plugin` reference on ReaderUI for direct access

### Code Quality
- Fix nil-check in `cancelActionPicker` to prevent runtime error

---

## Localization

- Add Chinese translations for all new UI strings

---

## Files Changed

| File | Type | Description |
|------|------|-------------|
| `sui_config.lua` | Modified | Increase tab limits; extend saveCustomQAConfig signature |
| `sui_patches.lua` | Modified | Register plugin reference on ReaderUI |
| `sui_quicksettings_bar.lua` | Modified | MAX_SLOTS 6→24; multi-row layout; context-aware action filtering; crash prevention; menu close patch |
| `sui_quickactions.lua` | Modified | Menu Action type; dispatcher params; icon browser integration|
| `sui_menu_picker.lua` | **New** | Menu navigation recorder and replay |
| `sui_icon_browser.lua` | **New** | Filesystem icon browser with preview |
| `zh_CN.po` | Modified | Chinese translations |


<img width="1072" height="1448" alt="action type" src="https://github.com/user-attachments/assets/c75ebf0f-1c1f-4a27-8183-da729e688796" />
<img width="1072" height="1448" alt="system action" src="https://github.com/user-attachments/assets/988a8ac2-ae88-4849-832c-5a4bf8b6feba" />
<img width="1072" height="1448" alt="menu action" src="https://github.com/user-attachments/assets/458f59e6-d6a4-4c58-ab3f-8b456f3d8997" />
<img width="1072" height="1448" alt="icons-browse file" src="https://github.com/user-attachments/assets/ea8b0c74-9ae5-4512-82a4-ffa2825ed8c7" />
<img width="1072" height="1448" alt="icons picker" src="https://github.com/user-attachments/assets/92f00dca-cd99-45d4-918d-4348a9fd0582" />