### PR TITLE
fix: reading goals yearly stats now doesn't count reopen

### DIFF
--- a/desktop_modules/module_books_shared.lua
+++ b/desktop_modules/module_books_shared.lua
@@ -499,6 +499,10 @@ end
 -- without creating a circular dependency or reaching into internals.
 -- These are considered semi-internal (prefix _) but are stable across versions.
 SH._cacheGet = _cacheGet
+SH._cacheGetRaw = function(fp)
+    local e = _sidecar_cache[fp]
+    return e and e.data
+end
 SH._cachePut = _cachePut
 
 

--- a/desktop_modules/module_stats_provider.lua
+++ b/desktop_modules/module_stats_provider.lua
@@ -323,32 +323,54 @@ end
 
 -- ---------------------------------------------------------------------------
 -- Sidecar scan: one pass → books_year + books_total simultaneously.
--- books_year counts books *completed* this year, based on summary.modified
--- (the sidecar's completion timestamp) only. We deliberately do NOT use the
--- statistics DB's last_open here — it updates on every session close, not
--- just on completion, so using it as a "read this year" signal inflates the
--- count whenever an already-finished book from a previous year is reopened.
+-- books_year counts books *completed* this year, based on summary.date_finished
+-- or, as a fallback, summary.modified — but ONLY when modified is a string.
+--
+-- Why the string-only restriction on modified:
+--   • When the user taps a status button in KOReader's library,
+--     filemanagerutil.saveSummary writes modified as a formatted date string
+--     (e.g. "2024-01-15 10:30:00"). That string is a reliable completion date.
+--   • On every normal reader session close, KOReader writes modified as a
+--     NUMBER (os.time() unix timestamp). This timestamp is refreshed on every
+--     close — even for books whose status has not changed. Using a numeric
+--     modified as a "completed this year" signal would inflate books_year
+--     whenever an old finished book from a previous year is merely reopened,
+--     because the timestamp would now reflect the current year.
+--   • SimpleUI writes date_finished as a YYYY-MM-DD string (preferred).
+--
+-- We deliberately do NOT use the statistics DB's last_open — same reason: it
+-- updates on every session close, not just on completion.
 -- Replaces two separate countMarkedRead() calls (previously O(2N) sidecar I/O).
 -- Uses the same _sidecar_cache from module_books_shared for cache hits.
 -- ---------------------------------------------------------------------------
 local _MAX_HIST = 200   -- hard cap: avoids unbounded scan on huge histories
 
--- modifiedInYear: KOReader always writes `modified` as an ISO-8601 string
--- ("YYYY-MM-DD ..."), a unix timestamp (number), or an os.date("*t") table.
+-- _modifiedInYear: returns true when the book's completion date falls in year_str.
+--
+-- Priority order:
+--   1. summary.date_finished  — SimpleUI-written "YYYY-MM-DD" string (most reliable).
+--   2. summary.modified       — only when it is a STRING (filemanagerutil date string).
+--      Numeric modified (KOReader unix timestamp, rewritten on every session close)
+--      is intentionally ignored: it cannot reliably indicate completion year.
 local function _modifiedInYear(summary, year_str)
-    local mod = summary and summary.modified
+    local mod
+    if summary then
+        if summary.date_finished ~= nil then
+            mod = summary.date_finished
+        elseif type(summary.modified) == "string" then
+            -- Only trust modified when it is a string (filemanagerutil date or
+            -- SimpleUI-written).  A numeric modified is a volatile KOReader
+            -- session timestamp — not a valid completion date.
+            mod = summary.modified
+        end
+        -- type(summary.modified) == "number"  →  mod stays nil → return false below.
+        -- type(summary.modified) == "table"   →  also ignored (os.date("*t") struct
+        --   produced by older KOReader builds; same volatility concern as numbers).
+    end
     if mod == nil then return false end
-    if type(mod) == "number" then
-        -- Unix timestamp: compare year component directly without os.date.
-        local mod_t = os.date("*t", mod)
-        return mod_t and tostring(mod_t.year) == year_str
-    end
     if type(mod) == "string" then
-        -- ISO-8601 "YYYY-MM-DD..." — prefix check is sufficient and free.
+        -- ISO-8601 "YYYY-MM-DD..." or "YYYY-MM-DD HH:MM:SS" — prefix check.
         return #mod >= 4 and mod:sub(1, 4) == year_str
-    end
-    if type(mod) == "table" and mod.year then
-        return tostring(mod.year) == year_str
     end
     return false
 end
@@ -419,21 +441,16 @@ local function countMarkedReadBoth(year_str)
                 end
             end
 
-            if type(summary) == "table" and summary.status == "complete" then
+            if type(summary) == "table" and summary.status == "complete" and not summary.exclude_from_goals then
                 books_total = books_total + 1
-                -- books_year counts books *completed* this year, based solely
-                -- on summary.modified (the sidecar's completion timestamp).
-                --
-                -- We used to also accept DB last_open >= year_start as an
-                -- alternative signal, on the theory that pre-SimpleUI-2.0
-                -- books could have a stale summary.modified that predates
-                -- their real completion date. In practice this made the
-                -- yearly count go up whenever an already-finished book from
-                -- a previous year was merely reopened (e.g. to re-read a
-                -- page) — last_open updates on every session close, not just
-                -- on completion, so it isn't a valid "completed this year"
-                -- signal. See GitHub issue: yearly count inflated by
-                -- reopening old finished books.
+                -- books_year counts books whose sidecar completion date falls in
+                -- year_str. The check uses _modifiedInYear which accepts only
+                -- summary.date_finished (SimpleUI-written) or a string-typed
+                -- summary.modified (set by filemanagerutil.saveSummary when the
+                -- user taps a status button in KOReader's library). Numeric
+                -- modified values (KOReader session-close timestamps) are ignored
+                -- because they are refreshed on every close and do not represent
+                -- the completion date.
                 if _modifiedInYear(summary, year_str) then
                     books_year = books_year + 1
                 end

--- a/main.lua
+++ b/main.lua
@@ -1633,6 +1633,38 @@ function SimpleUIPlugin:onResume()
     end
 end
 
+function SimpleUIPlugin:onReaderReady()
+    -- Warm the sidecar cache for the opened book as soon as it is opened,
+    -- so that onCloseDocument has access to its pre-session summary state
+    -- even if the file browser didn't scan it recently (e.g. direct boot to book).
+    local RUI = package.loaded["apps/reader/readerui"]
+    local fp = RUI and RUI.instance and RUI.instance.document and RUI.instance.document.file
+    if fp then
+        local SH = package.loaded["desktop_modules/module_books_shared"]
+        if SH and SH._cachePut then
+            local ok_ds, DocSettings = pcall(require, "docsettings")
+            if ok_ds and DocSettings then
+                local ok_open, ds = pcall(function() return DocSettings:open(fp) end)
+                if ok_open and ds then
+                    local summary = ds:readSetting("summary")
+                    local doc_props = ds:readSetting("doc_props")
+                    local title = doc_props and doc_props.title
+                    local authors = doc_props and doc_props.authors
+                    SH._cachePut(fp, ds.source_candidate, {
+                        percent              = ds:readSetting("percent_finished") or 0,
+                        title                = title,
+                        authors              = authors,
+                        doc_pages            = ds:readSetting("doc_pages"),
+                        partial_md5_checksum = ds:readSetting("partial_md5_checksum"),
+                        summary              = summary,
+                    })
+                    pcall(function() ds:close() end)
+                end
+            end
+        end
+    end
+end
+
 function SimpleUIPlugin:onCloseDocument()
     -- Consume _closing_via_gesture unconditionally before any early return,
     -- so the flag never leaks to a subsequent close if this handler bails out
@@ -1815,11 +1847,21 @@ function SimpleUIPlugin:onCloseDocument()
                 -- Pre-session status: read from sidecar cache (no I/O).
                 -- The cache entry is still valid here — SH.invalidateSidecarCache
                 -- for closed_fp runs later in this function, after this block.
+                --
+                -- cache_hit: true only when _cacheGetRaw found a real entry.
+                -- A miss (book outside the prefetch window) means we cannot
+                -- determine the pre-session status from the cache, so we must
+                -- not assume the book just became complete — it may have been
+                -- complete for years.
                 local pre_status
-                if SH and SH._cacheGet then
-                    local cached = SH._cacheGet(closed_fp)
-                    local s = cached and cached.summary
-                    pre_status = type(s) == "table" and s.status or nil
+                local cache_hit = false
+                if SH and (SH._cacheGetRaw or SH._cacheGet) then
+                    local cached = (SH._cacheGetRaw or SH._cacheGet)(closed_fp)
+                    if cached then
+                        cache_hit = true
+                        local s = cached.summary
+                        pre_status = type(s) == "table" and s.status or nil
+                    end
                 end
                 -- Post-session status: read from the in-memory doc_settings.
                 -- ReaderUI:onClose() calls saveSettings() (flush) before firing
@@ -1833,11 +1875,77 @@ function SimpleUIPlugin:onCloseDocument()
                     local s = RUI.instance.doc_settings:readSetting("summary")
                     post_status = type(s) == "table" and s.status or nil
                 end
-                -- Status changed only when a "complete" boundary was crossed.
-                -- Both nil/non-complete pre and post → counts are unaffected.
                 local pre_complete  = pre_status  == "complete"
                 local post_complete = post_status == "complete"
-                status_changed = pre_complete ~= post_complete
+                -- status_changed: a genuine complete/not-complete transition.
+                -- Only trust the transition when we had a real cache hit; on a
+                -- cache miss we cannot distinguish "was already complete" from
+                -- "first seen as complete", so fall back to safe full invalidation
+                -- (status_changed = true) without writing date_finished.
+                if cache_hit then
+                    status_changed = pre_complete ~= post_complete
+                else
+                    -- Cache miss: assume counts may have changed (safe default).
+                    -- pre_complete is unknown, so treat it as equal to post_complete
+                    -- to avoid spurious date_finished writes below.
+                    status_changed = true
+                    pre_complete   = post_complete  -- suppress the date_finished today-fallback
+                end
+
+                -- Auto-populate date_finished if missing for a completed book.
+                -- Sources tried in priority order:
+                --   1. pre_s.date_finished (already a SimpleUI string).
+                --   2. pre_s.modified      (the sidecar's pre-session modified,
+                --        which for books marked complete via KOReader's library
+                --        is the string date set by filemanagerutil.saveSummary).
+                --   3. Today's date        — ONLY when the cache confirmed the
+                --        book was NOT complete before this session (cache_hit AND
+                --        not pre_complete). Never written on a cache miss, because
+                --        we cannot distinguish a genuine new completion from an
+                --        already-complete book outside the prefetch window.
+                if post_complete and closed_fp then
+                    if RUI and RUI.instance and type(RUI.instance.doc_settings) == "table" then
+                        local s = RUI.instance.doc_settings:readSetting("summary") or {}
+                        if not s.date_finished then
+                            local finished_date
+                            if cache_hit then
+                                local cached = SH and (SH._cacheGetRaw or SH._cacheGet) and
+                                               (SH._cacheGetRaw or SH._cacheGet)(closed_fp)
+                                local pre_s  = cached and cached.summary
+                                if type(pre_s) == "table" then
+                                    if type(pre_s.date_finished) == "string" then
+                                        finished_date = pre_s.date_finished
+                                    elseif type(pre_s.modified) == "string" then
+                                        -- filemanagerutil.saveSummary writes modified as
+                                        -- "YYYY-MM-DD" when the user taps a status button.
+                                        -- This is the correct completion date for books
+                                        -- that were marked complete before SimpleUI.
+                                        finished_date = pre_s.modified
+                                    elseif type(pre_s.modified) == "number" then
+                                        finished_date = os.date("%Y-%m-%d", pre_s.modified)
+                                    elseif type(pre_s.modified) == "table" and pre_s.modified.year then
+                                        finished_date = string.format("%04d-%02d-%02d",
+                                            pre_s.modified.year, pre_s.modified.month, pre_s.modified.day)
+                                    end
+                                end
+                                -- Only fall back to today if we confirmed (via cache) that
+                                -- this is a genuine new completion, not a re-open.
+                                if not finished_date and not pre_complete then
+                                    finished_date = os.date("%Y-%m-%d")
+                                end
+                            end
+                            -- cache_hit = false → finished_date stays nil → nothing written.
+                            -- The book keeps no date_finished until the next homescreen
+                            -- open warm the sidecar cache, after which the next close will
+                            -- succeed via the cache-hit path above.
+                            if finished_date then
+                                s.date_finished = finished_date
+                                RUI.instance.doc_settings:saveSetting("summary", s)
+                                RUI.instance.doc_settings:flush()
+                            end
+                        end
+                    end
+                end
             end
 
             if status_changed then

--- a/sui_patches.lua
+++ b/sui_patches.lua
@@ -2641,7 +2641,6 @@ local function _onStatusChanged(file)
     --    to disk before caller_callback() is invoked, so this is always current.
     pcall(function()
         local DB = SUISettings.DeletedBooks
-        if not (DB and DB.isEnabled()) then return end
         local ok_DS, DocSettings = pcall(require, "docsettings")
         if not ok_DS or not DocSettings then return end
         local ds = DocSettings:open(file)
@@ -2649,9 +2648,27 @@ local function _onStatusChanged(file)
         local new_status = type(summary) == "table" and summary.status or nil
         if new_status ~= "complete" then
             local md5 = ds:readSetting("partial_md5_checksum")
+            local changed = false
+            if type(summary) == "table" and summary.date_finished ~= nil then
+                summary.date_finished = nil
+                changed = true
+            end
+            if changed then
+                ds:saveSetting("summary", summary)
+                pcall(function() ds:flush() end)
+            end
             pcall(function() ds:close() end)
-            if md5 then DB.removeByMd5(md5) end
+            if DB and DB.isEnabled() and md5 then DB.removeByMd5(md5) end
         else
+            local changed = false
+            if type(summary) == "table" and summary.date_finished == nil then
+                summary.date_finished = os.date("%Y-%m-%d")
+                changed = true
+            end
+            if changed then
+                ds:saveSetting("summary", summary)
+                pcall(function() ds:flush() end)
+            end
             pcall(function() ds:close() end)
         end
     end)
@@ -2862,7 +2879,7 @@ function M.patchFontGetFace(plugin)
     local Font = require("ui/font")
     if Font._simpleui_getface_patched then return end
 
-    local scale = Config.getFontScalePct() / 100
+    local scale = (Config.getFontScalePct and Config.getFontScalePct() or 100) / 100
     if scale == 1 then return end  -- default: leave getFace fully untouched
 
     Font._simpleui_getface_patched = true
@@ -3875,9 +3892,9 @@ function M.patchDeleteFile(FileManager, plugin)
                 local doc_props = ds:readSetting("doc_props")
                 local title   = doc_props and doc_props.title   or ""
                 local authors = doc_props and doc_props.authors or ""
-                -- Derive year from summary.modified (same source as countMarkedReadBoth).
+                -- Derive year from summary.date_finished or summary.modified (same source as countMarkedReadBoth).
                 local year = 0
-                local mod = summary.modified
+                local mod = summary.date_finished or summary.modified
                 if type(mod) == "number" then
                     year = tonumber(os.date("%Y", mod)) or 0
                 elseif type(mod) == "string" and #mod >= 4 then

--- a/sui_stats_windows.lua
+++ b/sui_stats_windows.lua
@@ -40,7 +40,24 @@ local UI              = require("sui_core")
 -- _riMonthlyChart, _buildInsightsPage2) take SZ as an explicit trailing
 -- parameter from their caller's ctx.SZ, falling back to UI.SZ if ever called
 -- without one.
-local function SZ(n) return UI.SZ(n) end
+local function SZ(n)
+    if UI.SZ then return UI.SZ(n) end
+    if UI.getLandscapeFactor then return math.floor(n * UI.getLandscapeFactor()) end
+    return n
+end
+local UI_SZ = UI.SZ or SZ
+
+--- Returns the portrait-mode screen height (the long axis), regardless of
+--- the current rotation. Falls back to a simple max(w, h) if sui_core is
+--- an older version that does not yet export getPortraitDims.
+local function _portraitH()
+    if UI.getPortraitDims then
+        return select(2, UI.getPortraitDims())
+    end
+    local w, h = Screen:getWidth(), Screen:getHeight()
+    return w > h and w or h
+end
+
 
 local StatsWindows = {}
 
@@ -66,18 +83,22 @@ local function _getFinishedBooksThisYear()
     local SH = package.loaded["desktop_modules/module_books_shared"]
 
     -- Mirrors _modifiedInYear from module_stats_provider — same logic, no dependency.
+    -- Only summary.date_finished or a STRING summary.modified is accepted as a
+    -- completion-year signal.  A numeric modified (KOReader unix timestamp) is
+    -- rewritten on every reader session close and must NOT be used as a
+    -- "completed this year" indicator — see module_stats_provider.lua for rationale.
     local function modifiedInYear(summary)
-        local mod = summary and summary.modified
-        if mod == nil then return false end
-        if type(mod) == "number" then
-            local t = os.date("*t", mod)
-            return t and tostring(t.year) == year_str
+        local mod
+        if summary then
+            if summary.date_finished ~= nil then
+                mod = summary.date_finished
+            elseif type(summary.modified) == "string" then
+                mod = summary.modified
+            end
         end
+        if mod == nil then return false end
         if type(mod) == "string" then
             return #mod >= 4 and mod:sub(1, 4) == year_str
-        end
-        if type(mod) == "table" and mod.year then
-            return tostring(mod.year) == year_str
         end
         return false
     end
@@ -134,9 +155,12 @@ local function _getFinishedBooksThisYear()
                     title         = title   or entry.text or fp,
                     authors       = authors or "",
                     filepath      = fp,
-                    date_finished = (type(summary.modified)    == "string" and summary.modified)    or nil,
+                    date_finished = (type(summary.date_finished) == "string" and summary.date_finished)
+                                    or (type(summary.modified)   == "string" and summary.modified)
+                                    or nil,
                     date_started  = (type(summary.date_started) == "string" and summary.date_started) or nil,
                     md5           = md5_checksum,
+                    exclude_from_goals = summary.exclude_from_goals,
                 })
             end
         end
@@ -498,6 +522,7 @@ local function _writeSummaryModified(filepath, date_str)
     if not ok_open or not ds then return false end
     local summary = ds:readSetting("summary") or {}
     summary.modified = date_str
+    summary.date_finished = date_str
     if summary.status ~= "complete" then
         summary.status = "complete"
     end
@@ -543,6 +568,29 @@ end
 -- Builds a date range card with independently tappable start/end halves.
 --
 -- Parameters:
+-- Writes summary.exclude_from_goals to the sidecar and flushes it.
+local function _writeSummaryExclude(filepath, val)
+    if not filepath then return false end
+    local ok_ds, DocSettings = pcall(require, "docsettings")
+    if not ok_ds then return false end
+    local ok_open, ds = pcall(function() return DocSettings:open(filepath) end)
+    if not ok_open or not ds then return false end
+    local summary = ds:readSetting("summary") or {}
+    summary.exclude_from_goals = val and true or nil
+    ds:saveSetting("summary", summary)
+    pcall(function() ds:flush() end)
+    pcall(function() ds:close() end)
+    local SH = package.loaded["desktop_modules/module_books_shared"]
+    if SH then
+        if SH._cacheInvalidate then
+            SH._cacheInvalidate(filepath)
+        elseif SH._cache and filepath then
+            SH._cache[filepath] = nil
+        end
+    end
+    return true
+end
+
 -- Removes a single key from summary in the sidecar (sets it to nil).
 -- Used by the Reset button to revert to the DB-derived fallback.
 local function _deleteSummaryField(filepath, key)
@@ -586,7 +634,7 @@ local function _makeDateCard(inner_w, PAD_H,
                              original_start_str, original_end_str,
                              filepath,
                              on_start_saved, on_end_saved, SZ)
-    SZ = SZ or UI.SZ
+    SZ = SZ or UI_SZ
     local face_date  = Font:getFace(SUIStyle.FACE_REGULAR, SZ(SUIStyle.FS_BODY))
     local face_arrow = Font:getFace(SUIStyle.FACE_ICONS,   SZ(SUIStyle.FS_BODY))
     local CLR_BLACK  = Blitbuffer.COLOR_BLACK
@@ -690,7 +738,10 @@ local function _makeDateCard(inner_w, PAD_H,
     local end_widget = makeSideTappable(
         date_end_str, _("Date finished"),
         _writeSummaryModified,
-        function(fp) _deleteSummaryField(fp, "modified") end,
+        function(fp)
+            _deleteSummaryField(fp, "date_finished")
+            _deleteSummaryField(fp, "modified")
+        end,
         original_end_str,
         on_end_saved)
 
@@ -800,11 +851,24 @@ function StatsWindows.showFinishedBooksDialog(initial_page)
         local rows = {}
         for i, book in ipairs(books) do
             local date_range = book_date_range[book.filepath] or "\xe2\x80\x93"
+            local sub_text
+            if book.authors and book.authors ~= "" then
+                if book.exclude_from_goals then
+                    sub_text = string.format("%s · %s", book.authors, _("Excluded"))
+                else
+                    sub_text = book.authors
+                end
+            else
+                if book.exclude_from_goals then
+                    sub_text = _("Excluded")
+                end
+            end
             rows[#rows + 1] = SUIWindow.ListRow{
                 inner_w      = inner_w,
                 title        = book.title,
-                subtitle     = (book.authors and book.authors ~= "") and book.authors or nil,
+                subtitle     = sub_text,
                 right_value  = date_range,
+                dim          = book.exclude_from_goals,
                 show_chevron = true,
                 separator    = true,
                 on_tap       = book.filepath and function()
@@ -1086,6 +1150,23 @@ function StatsWindows.showFinishedBooksDialog(initial_page)
                 makeIconRow(SUIStyle.icon("highlights"), _("Highlights"),     tostring(d.highlights), on_tap_highlights),
                 makeRowSep(),
                 makeIconRow(SUIStyle.icon("notes"),      _("Notes"),          tostring(d.notes),      on_tap_notes),
+                makeRowSep(),
+                makeIconRow(
+                    book.exclude_from_goals and SUIStyle.icon("check") or SUIStyle.icon("uncheck"),
+                    _("Exclude from goals"),
+                    book.exclude_from_goals and _("Yes") or _("No"),
+                    function()
+                        local next_val = not book.exclude_from_goals
+                        book.exclude_from_goals = next_val and true or nil
+                        _writeSummaryExclude(fp, book.exclude_from_goals)
+                        
+                        -- Force full stats invalidation so homescreen widget / stats provider update
+                        local SP = package.loaded["desktop_modules/module_stats_provider"]
+                        if SP and SP.invalidate then SP.invalidate() end
+                        
+                        ctx.repaint()
+                    end
+                ),
             },
         }
 
@@ -1135,15 +1216,21 @@ function StatsWindows.showFinishedBooksDialog(initial_page)
     end
 
     local function titleFn(ctx)
+        local count = 0
+        for _, book in ipairs(books) do
+            if not book.exclude_from_goals then
+                count = count + 1
+            end
+        end
         return string.format(
-            N_("%d book read in %s", "%d books read in %s", #books),
-            #books, year_str)
+            N_("%d book read in %s", "%d books read in %s", count),
+            count, year_str)
     end
 
     local win = SUIWindow:new{
         name           = "sui_win_reading_history",
         title          = titleFn,
-        height         = math.floor((select(2, UI.getPortraitDims())) * 0.75),
+        height         = math.floor(_portraitH() * 0.75),
         position       = "bottom",
         navpager_mode  = require("sui_config").isNavpagerEnabled(),
         screens        = {
@@ -1674,7 +1761,7 @@ end
 -- SZ threaded in by the caller (ctx.SZ); falls back to UI.SZ if ever called
 -- without one (identical value during a synchronous window build).
 local function _riYearHeader(inner_w, year, year_range, on_prev, on_next, SZ)
-    SZ = SZ or UI.SZ
+    SZ = SZ or UI_SZ
     local face = Font:getFace(SUIStyle.FACE_REGULAR, SZ(SUIStyle.FS_SUBTITLE))
     local face_chev = Font:getFace(SUIStyle.FACE_ICONS, math.floor(SZ(SUIStyle.FS_TITLE * 1.8)))
     local CLR_BLACK = Blitbuffer.COLOR_BLACK
@@ -1743,7 +1830,7 @@ end
 -- SZ threaded in by the caller (ctx.SZ); falls back to UI.SZ if ever called
 -- without one (identical value during a synchronous window build).
 local function _riYearlyRow(inner_w, yearly_stats, mode_key, on_toggle_mode, avail_h, SZ)
-    SZ = SZ or UI.SZ
+    SZ = SZ or UI_SZ
     local CLR_BLACK = Blitbuffer.COLOR_BLACK
     local face_val  = Font:getFace(SUIStyle.FACE_REGULAR, SZ(SUIStyle.FS_TITLE))
     local face_lbl  = Font:getFace(SUIStyle.FACE_REGULAR, SZ(SUIStyle.FS_DETAIL))
@@ -1813,7 +1900,7 @@ end
 -- SZ threaded in by the caller (ctx.SZ); falls back to UI.SZ if ever called
 -- without one (identical value during a synchronous window build).
 local function _riMonthlyChart(inner_w, monthly_data, value_key, selected_year, avail_h, SZ)
-    SZ = SZ or UI.SZ
+    SZ = SZ or UI_SZ
     if not monthly_data or #monthly_data == 0 then return VerticalGroup:new{} end
 
     local current_year  = tonumber(os.date("%Y"))
@@ -1919,7 +2006,7 @@ end
 -- SZ threaded in by the caller (ctx.SZ); falls back to UI.SZ if ever called
 -- without one (identical value during a synchronous window build).
 local function _buildInsightsPage2(inner_w, avail_h, streaks, SZ)
-    SZ = SZ or UI.SZ
+    SZ = SZ or UI_SZ
     _lazyLoad()      -- ensure _CenterContainer, _LeftContainer, etc. are loaded
     local Size    = require("ui/size")
     local sec_gap = math.max(SZ(Screen:scaleBySize(6)), math.floor(avail_h * 0.025))
@@ -2298,7 +2385,7 @@ function StatsWindows.showReadingInsightsWindow(on_close_extra)
         -- SUIWindow._rebuildFrame, so all sections can size themselves
         -- proportionally and the layout stays on one page on any screen.
         local Size       = require("ui/size")
-        local modal_h    = math.floor((select(2, UI.getPortraitDims())) * 0.75)
+        local modal_h    = math.floor(_portraitH() * 0.75)
         local border     = Size.border.window
         local pad_v      = Size.padding.large
         local title_h    = ctx.SZ(Screen:scaleBySize(50))  -- conservative TitleBar estimate
@@ -2506,7 +2593,7 @@ function StatsWindows.showReadingInsightsWindow(on_close_extra)
     local win = SUIWindow:new{
         name          = "sui_win_reading_insights",
         title         = titleFn,
-        height        = math.floor((select(2, UI.getPortraitDims())) * 0.75),
+        height        = math.floor(_portraitH() * 0.75),
         position      = "bottom",
         navpager_mode = Config.isNavpagerEnabled and Config.isNavpagerEnabled() or false,
         screens       = {
@@ -2551,16 +2638,19 @@ function StatsWindows.showBookStatsFromFile(filepath)
                 book.title   = doc_props.title
                 book.authors = doc_props.authors
             end
-            -- Read date_finished (summary.modified) and date_started so the
+            -- Read date_finished and date_started so the
             -- date card shows the user-visible dates rather than raw DB timestamps.
             local summary = ds:readSetting("summary")
             if type(summary) == "table" then
-                if summary.status == "complete" and type(summary.modified) == "string" then
-                    book.date_finished = summary.modified
+                if summary.status == "complete" then
+                    book.date_finished = (type(summary.date_finished) == "string" and summary.date_finished)
+                                         or (type(summary.modified)   == "string" and summary.modified)
+                                         or nil
                 end
                 if type(summary.date_started) == "string" then
                     book.date_started = summary.date_started
                 end
+                book.exclude_from_goals = summary.exclude_from_goals
             end
             pcall(function() ds:close() end)
         end
@@ -2862,7 +2952,7 @@ function StatsWindows.showBookStatsFromFile(filepath)
     local win = SUIWindow:new{
         name     = "sui_win_book_stats_standalone",
         title    = _("Book Statistics"),
-        height   = math.floor((select(2, UI.getPortraitDims())) * 0.75),
+        height   = math.floor(_portraitH() * 0.75),
         position = "bottom",
         navpager_mode = require("sui_config").isNavpagerEnabled(),
         screens  = { __root__ = buildStatsScreen },

--- a/sui_window.lua
+++ b/sui_window.lua
@@ -197,8 +197,13 @@ function SUIWindow:new(opts)
     -- shrink on top of an already-swapped axis, squashing height instead of
     -- scaling both axes down uniformly. opts.width/opts.height, when passed
     -- explicitly by callers, are likewise expected to be portrait-based.
-    local portrait_w, portrait_h = UI.getPortraitDims()
-    local landscape_factor = UI.getLandscapeFactor()
+    local portrait_w, portrait_h
+    if UI.getPortraitDims then
+        portrait_w, portrait_h = UI.getPortraitDims()
+    else
+        portrait_w, portrait_h = sw < sh and sw or sh, sw < sh and sh or sw
+    end
+    local landscape_factor = UI.getLandscapeFactor and UI.getLandscapeFactor() or 1
     o._scale         = landscape_factor
     o._modal_w       = math.floor((opts.width  or math.floor(portrait_w * 5 / 6))  * landscape_factor)
     o._modal_h       = math.floor((opts.height or math.floor(portrait_h * 23 / 30)) * landscape_factor)


### PR DESCRIPTION
This PR fixes issue #429

Multiple changes to how completion dates are read, written and used for statistics, plus UI/compatibility fixes.

Key points:
- Prefer summary.date_finished and only accept string summary.modified as a completion date; numeric modified (KOReader unix timestamps) is ignored to avoid inflating yearly counts.
- Expose SH._cacheGetRaw for raw cache reads and add cache pre-warming on reader open (SimpleUIPlugin:onReaderReady) so onCloseDocument can rely on pre-session data.
- onCloseDocument: only auto-populate summary.date_finished when cache confirmed a real new completion (avoid writing dates on cache misses), and use cached values as fallbacks where appropriate.
- Add support for summary.exclude_from_goals: allow marking finished books to be excluded from goals, persist it, dim list rows and omit them from year counts.
- Stats UI: read/write date_finished, show exclude toggle in finished-books dialog, adjust list subtitle/dimming and title count to reflect exclusions.
- Add _writeSummaryExclude helper, ensure write/delete of date_finished alongside modified, and update DeletedBooks handling to guard .isEnabled.
- UI compatibility fallbacks: provide UI_SZ wrapper, _portraitH for older sui_core, and SZ fallbacks across stats windows; add safe fallbacks for font scale and SUIWindow portrait/landscape sizing.

Rationale: avoid false positives in "books read this year" caused by KOReader writing numeric modified timestamps on every session close; provide a reliable date_written pipeline, preserve backwards compatibility with older KOReader/SimpleUI data shapes, and give users control to exclude items from goals.