### PR TITLE
Improve translation support​

### DIFF
--- a/_meta.lua
+++ b/_meta.lua
@@ -1,9 +1,10 @@
-
+local I18n = require("sui_i18n")
+local _    = I18n.translate
 
 return {
     name        = "simpleui",
-    fullname    = "Simple UI",
-    description = [[A simple UI for KOReader]],
+    fullname    = _("Simple UI"),
+    description = _([[A simple UI for KOReader]]),
     version     = "2.1",
     author      = "Doctor Hetfield",
 }

--- a/locale/simpleui.pot
+++ b/locale/simpleui.pot
@@ -4511,3 +4511,7 @@ msgid "page read"
 msgid_plural "pages read"
 msgstr[0] ""
 msgstr[1] ""
+
+#: _meta.lua:7
+msgid "A simple UI for KOReader"
+msgstr ""

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -4033,3 +4033,7 @@ msgstr "书籍统计"
 #: desktop_modules/module_quote.lua:1440
 msgid "Fixed Height"
 msgstr "固定高度"
+
+#: _meta.lua:7
+msgid "A simple UI for KOReader"
+msgstr "用于 KOReader 的界面插件，提供一套简约美观的 UI 界面。"


### PR DESCRIPTION
Add translation for "description" in _meta.lua, and complete the translation of plugin metadata displayed in KOReader's plugin manager.