### PR TITLE
Update Vietnamese typo and some text

### DIFF
--- a/locale/vi.po
+++ b/locale/vi.po
@@ -80,7 +80,7 @@ msgstr "(%d/%d — đã đạt giới hạn)"
 
 #: sui_menu.lua:2698
 msgid "4-Cover Grid (Mosaic View Only)"
-msgstr "Lười 4 bìa (Chế độ khảm)"
+msgstr "Lưới 4 bìa (Chế độ khảm)"
 
 #: sui_menu.lua:3863
 #: sui_menu.lua:3948
@@ -368,7 +368,7 @@ msgstr "Tác giả"
 
 #: sui_menu.lua:2709
 msgid "Auto (Single ↔ 4-Cover Grid)"
-msgstr "Tự động (Đơn ↔ Lười 4 bìa)"
+msgstr "Tự động (Đơn ↔ Lưới 4 bìa)"
 
 #: sui_foldercovers.lua:769
 #: sui_foldercovers.lua:826
@@ -533,19 +533,19 @@ msgstr "Duyệt"
 
 #: sui_style.lua:102
 msgid "Browse Button (author)"
-msgstr "Nũt duyệt (tác giả)"
+msgstr "Nút duyệt (tác giả)"
 
 #: sui_style.lua:96
 msgid "Browse Button (default)"
-msgstr "Nũt duyệt (mặc định)"
+msgstr "Nút duyệt (mặc định)"
 
 #: sui_style.lua:108
 msgid "Browse Button (series)"
-msgstr "Nũt duyệt (loạt)"
+msgstr "Nút duyệt (loạt)"
 
 #: sui_style.lua:114
 msgid "Browse Button (tags)"
-msgstr "Nũt duyệt (thẻ)"
+msgstr "Nút duyệt (thẻ)"
 
 #: sui_style.lua:1081
 msgid "Browse Icons"
@@ -713,7 +713,7 @@ msgstr "Đang đóng sách…"
 
 #: sui_quickactions.lua:1315
 msgid "Codepoint out of valid Unicode range (0–10FFFF)."
-msgstr "Điểm mã nẽngoài phạm vi Unicode hợp lệ (0–10FFFF)."
+msgstr "Mã ký tự ngoài phạm vi của Unicode (0–10FFFF)."
 
 #: sui_quickactions.lua:1723
 #: sui_quickactions.lua:1784
@@ -764,7 +764,7 @@ msgstr "Bộ sưu tập không khả dụng."
 
 #: sui_style.lua:164
 msgid "Collections: Back Button"
-msgstr "Bộ sưu tập: Nũt quay lại"
+msgstr "Bộ sưu tập: Nút quay lại"
 
 #: sui_menu.lua:2807
 #: sui_menu.lua:2861
@@ -896,7 +896,7 @@ msgstr "Văn bản tùy chỉnh"
 
 #: sui_onboarding.lua:168
 msgid "Custom wallpapers and icons"
-msgstr "Tường nền và biểu tượng tùy chỉnh"
+msgstr "Tùy chỉnh tường nền và biểu tượng"
 
 #: sui_onboarding.lua:160
 msgid "Customize even more"
@@ -904,7 +904,7 @@ msgstr "Tùy chỉnh thêm"
 
 #: sui_stats_windows.lua:2064
 msgid "DAY STREAK"
-msgstr "CHUỞI NGÀY"
+msgstr "CHUỖI NGÀY"
 
 #: desktop_modules/module_reading_goals.lua:861
 #: desktop_modules/module_reading_goals.lua:889
@@ -1840,7 +1840,7 @@ msgstr "Mô-đun"
 
 #: sui_menu.lua:2134
 msgid "Modules  (%d)"
-msgstr "Mô-đún (%d)"
+msgstr "Mô-đun (%d)"
 
 #: sui_homescreen.lua:2415
 msgid "Modules exceed the visible area.\nMove some to another page or adjust the scale."
@@ -2160,7 +2160,7 @@ msgstr "Chưa chọn mục nào."
 #: sui_settings_window.lua:364
 #: sui_settings_window.lua:526
 msgid "No modules"
-msgstr "Không có mô-đún"
+msgstr "Không có mô-đun"
 
 #: sui_settings_window.lua:512
 msgid "No other pages available."
@@ -3043,19 +3043,19 @@ msgstr "Mười bảy"
 
 #: desktop_modules/module_clock.lua:821
 msgid "Show Battery"
-msgstr "Hiển thị pin"
+msgstr "Hiện pin"
 
 #: desktop_modules/module_clock.lua:809
 msgid "Show Clock"
-msgstr "Hiển thị đồng hồ"
+msgstr "Hiện đồng hồ"
 
 #: desktop_modules/module_clock.lua:815
 msgid "Show Date"
-msgstr "Hiển thị ngày"
+msgstr "Hiện ngày"
 
 #: desktop_modules/module_action_list.lua:578
 msgid "Show Icon"
-msgstr "Hiển thị biểu tượng"
+msgstr "Hiện biểu tượng"
 
 #: sui_menu.lua:588
 msgid "Show Page Count in Title Bar"
@@ -3063,7 +3063,7 @@ msgstr "Hiển thị số trang trong thanh tiêu đề"
 
 #: sui_menu.lua:2476
 msgid "Show a brief \"Closing book…\" notice when closing a book, preventing accidental double-taps while e-ink refreshes."
-msgstr "Hiển thị thông báo ngắn "Đang đóng sách…" khi đóng sách, ngăn chặn nhấn nhầm trong khi e-ink làm mới."
+msgstr "Hiển thị thông báo \"Đang đóng sách…\" khi đóng sách, ngăn chặn nhấn đúp trong khi làm mới e-ink."
 
 #: desktop_modules/module_recent.lua:397
 #: desktop_modules/module_coverdeck.lua:1038
@@ -3080,7 +3080,7 @@ msgstr "Hiển thị tường nền trên tất cả màn hình"
 
 #: sui_menu.lua:593
 msgid "Shows \"Page X of Y\" in the title bar subtitle when browsing the library, history or collections.\nNavpager enables this automatically.\nNot available when Navpager is active."
-msgstr "Hiển thị "Trang X trên Y" trong phụ đề thanh tiêu đề khi duyệt thư viện, lịch sử hoặc bộ sưu tập.\nNavpager tự động bật tính năng này.\nKhông khả dụng khi Navpager đang hoạt động."
+msgstr "Hiển thị \"Trang X trên Y\" trong phụ đề của thanh tiêu đề khi mở thư viện, lịch sử hoặc bộ sưu tập.\nNavpager tự động bật tính năng này.\nKhông khả dụng khi Navpager đang hoạt động."
 
 #: sui_menu.lua:489
 msgid "Shows a row of dots at the bottom of the homescreen.\nThe active page dot is filled; the others are dimmed.\nAlways active when Navpager is selected."
@@ -4079,8 +4079,8 @@ msgstr[1] "Đã đạt tối đa %d ô. Xóa một cái trước."
 #: sui_menu.lua:895
 msgid "Text shown in the top bar.\nMaximum %d character."
 msgid_plural "Text shown in the top bar.\nMaximum %d characters."
-msgstr[0] "Chử hiển thị trên thanh trên.\nTối đa %d ký tự."
-msgstr[1] "Chử hiển thị trên thanh trên.\nTối đa %d ký tự."
+msgstr[0] "Chữ hiển thị trên thanh trên.\nTối đa %d ký tự."
+msgstr[1] "Chữ hiển thị trên thanh trên.\nTối đa %d ký tự."
 
 #: sui_menu.lua:1886
 #: sui_menu.lua:2005
@@ -4090,8 +4090,8 @@ msgstr[1] "Chử hiển thị trên thanh trên.\nTối đa %d ký tự."
 #: desktop_modules/module_quick_actions.lua:460
 msgid "The maximum of %d action per module has been reached. Remove one first."
 msgid_plural "The maximum of %d actions per module has been reached. Remove one first."
-msgstr[0] "Đã đạt tối đa %d hành động mỗi mô-đún. Xóa một cái trước."
-msgstr[1] "Đã đạt tối đa %d hành động mỗi mô-đún. Xóa một cái trước."
+msgstr[0] "Đã đạt tối đa %d hành động mỗi mô-đun. Xóa một cái trước."
+msgstr[1] "Đã đạt tối đa %d hành động mỗi mô-đun. Xóa một cái trước."
 
 #: sui_quickactions.lua:905
 #: sui_quickactions.lua:1974


### PR DESCRIPTION
Update Vietnamese typo, and change some text to correct with the context

**Typo texts:**
- Grid: Lười -> Lưới
- Button: Nũt -> Nút
- STREAK: CHUỞI -> CHUỖI
- Module: Mô-đún -> Mô-đun
- Text: Chử -> Chữ
- Show: Hiển Thị -> Hiện (use in some cases: Show battery / clock / date / icon)