### PR TITLE
Fix OOM crash when Global Text Size is above 100%

### DIFF
--- a/sui_patches.lua
+++ b/sui_patches.lua
@@ -3336,6 +3336,10 @@ end
 -- users who never touch it pay zero extra cost on this very hot path.
 -- Like the UI Font picker itself, a change only takes full effect after a
 -- restart — the scale is captured once, at install time.
+--
+-- The wrapper scales on the way in and restores face.orig_size on the way
+-- out, so the scaling stays invisible to callers — see the comment in
+-- Font.getFace below for why that write-back is load-bearing.
 -- ---------------------------------------------------------------------------
 
 function M.patchFontGetFace(plugin)
@@ -3351,8 +3355,29 @@ function M.patchFontGetFace(plugin)
 
     Font.getFace = function(self, font, size, faceindex)
         if not size then size = self.sizemap[font] end
-        if size then size = math.max(1, math.floor(size * scale)) end
-        return orig_getFace(self, font, size, faceindex)
+        if not size then
+            -- Nothing to scale; let ui/font.lua handle it as it always has.
+            return orig_getFace(self, font, size, faceindex)
+        end
+        local requested = size
+        local face = orig_getFace(self, font,
+            math.max(1, math.floor(size * scale)), faceindex)
+        if face then
+            -- Report the size the caller asked for, not the scaled one.
+            -- Widgets treat face.orig_size as "the size I requested" and feed
+            -- it straight back into Font:getFace() to step one size up or down
+            -- (Button, VirtualKeyboard, ConfirmBox and InfoMessage all shrink
+            -- text that way; BookMapWidget, TitleBar, TouchMenu and
+            -- NumberPickerWidget derive sibling sizes from it). Those calls
+            -- re-enter this wrapper, so handing back the scaled size puts them
+            -- in the wrong unit and they re-scale a value that was already
+            -- scaled. At scale > 100% that turns every "one size smaller" loop
+            -- into unbounded growth, instantiating an ever-larger FreeType face
+            -- per pass until KOReader is OOM-killed.
+            -- ui/font.lua does the same write-back itself on a cache hit.
+            face.orig_size = requested
+        end
+        return face
     end
 end
 


### PR DESCRIPTION
When `Style > Global Text Size` is set above 100%, opening a dialogue with a button whose label has to be truncated causes KOReader to consume memory until it crashes due to OOM.

`patchFontGetFace()` scales the requested size before calling `Font:getFace()`. The returned face exposes the scaled value as `face.orig_size`. KOReader's text-shrinking loop in `frontend/ui/widget/button.lua` treats `orig_size` as the caller's original request, subtracts one, and passes it back to `Font:getFace()`. The wrapper then scales that value again, so the loop never reaches `if new_size < 8 then break end`.

## Proposed fix

Keep the caller's requested size and restore it to `face.orig_size` before returning the face:

```lua
local requested = size
local face = orig_getFace(self, font,
    math.max(1, math.floor(size * scale)), faceindex)
if face then
    face.orig_size = requested
end
return face
```

This preserves the documented contract (`orig_size` being the raw size before scaling) and mirrors the write-back already used by `ui/font.lua` on a cache hit. Callers can safely derive another face size without applying the global scale repeatedly.

Disclosure: I used Claude Opus 5 to diagnose and fix this issue.
