### PR TITLE
fix: titlebar reapply crash, arrange list duplicates, and button offset

### DIFF
--- a/sui_menu.lua
+++ b/sui_menu.lua
@@ -1388,6 +1388,23 @@ SimpleUIPlugin.addToMainMenu = function(self, menu_items)
     -- Title Bar menu builder
     -- -----------------------------------------------------------------------
 
+    -- Forward-declare _reapplyAllTitlebars here so it is in scope for
+    -- makeTitleBarItemsForCtx and makeTitleBarArrangeMenu below. Both call
+    -- it from closures defined before the old declaration site further down
+    -- this file. A Lua local is only visible to code that lexically follows
+    -- its declaration, so those closures used to resolve the name as a
+    -- nonexistent global and crash with "attempt to call global
+    -- '_reapplyAllTitlebars' (a nil value)" on any Titlebar Buttons change.
+    local _reapplyAllTitlebars
+    _reapplyAllTitlebars = function()
+        local Titlebar = require("sui_titlebar")
+        local FM = package.loaded["apps/filemanager/filemanager"]
+        local fm = FM and FM.instance
+        local stack = require("sui_core").getWindowStack()
+        Titlebar.reapplyAll(fm, stack)
+        if fm then UIManager:setDirty(fm[1], "ui") end
+    end
+
     -- Builds a visibility toggle list for one context ("fm" or "inj").
     local function makeTitleBarItemsForCtx(ctx)
         local Titlebar = require("sui_titlebar")
@@ -1436,8 +1453,15 @@ SimpleUIPlugin.addToMainMenu = function(self, menu_items)
         sort_items[#sort_items + 1] = {
             text = _("Left"):upper(), orig_item = SEP_LEFT, is_divider = true, pin_top = true,
         }
+        -- Only list currently visible items here. Hidden items are preserved
+        -- separately by the "preserve hidden items" step in on_save() below,
+        -- which appends them from cfg.order_left/order_right every time it
+        -- runs. Listing them here too meant every on_save() call (each drag
+        -- reorder fires one, plus one more on close) re-appended a hidden
+        -- item on top of the copies already carried over from the previous
+        -- save, so the hidden item count kept doubling with every use.
         for _i, id in ipairs(cfg.order_left) do
-            if labels[id] then
+            if labels[id] and Titlebar.isItemVisible(id) then
                 sort_items[#sort_items + 1] = { text = labels[id](), orig_item = id }
             end
         end
@@ -1445,7 +1469,7 @@ SimpleUIPlugin.addToMainMenu = function(self, menu_items)
             text = _("Right"):upper(), orig_item = SEP_RIGHT, is_divider = true,
         }
         for _i, id in ipairs(cfg.order_right) do
-            if labels[id] then
+            if labels[id] and Titlebar.isItemVisible(id) then
                 sort_items[#sort_items + 1] = { text = labels[id](), orig_item = id }
             end
         end
@@ -1480,12 +1504,26 @@ SimpleUIPlugin.addToMainMenu = function(self, menu_items)
                         cfg.side[item.orig_item]   = "right"
                     end
                 end
-                -- Preserve hidden items at the end of each order list.
+                -- Preserve hidden items at the end of each order list. seen_left and
+                -- seen_right guard against re-adding an id already placed above. With
+                -- the sort_items visibility filter above, that should not happen, but
+                -- this also defends against order_left/order_right that already have a
+                -- duplicate saved from before this fix (repeated use of this menu could
+                -- accumulate duplicates without it).
+                local seen_left, seen_right = {}, {}
+                for _i, id in ipairs(new_left)  do seen_left[id]  = true end
+                for _i, id in ipairs(new_right) do seen_right[id] = true end
                 for _i, id in ipairs(cfg.order_left)  do
-                    if not Titlebar.isItemVisible(id) then new_left[#new_left + 1]   = id end
+                    if not Titlebar.isItemVisible(id) and not seen_left[id] then
+                        new_left[#new_left + 1] = id
+                        seen_left[id] = true
+                    end
                 end
                 for _i, id in ipairs(cfg.order_right) do
-                    if not Titlebar.isItemVisible(id) then new_right[#new_right + 1] = id end
+                    if not Titlebar.isItemVisible(id) and not seen_right[id] then
+                        new_right[#new_right + 1] = id
+                        seen_right[id] = true
+                    end
                 end
                 cfg.order_left  = new_left
                 cfg.order_right = new_right
@@ -1509,18 +1547,6 @@ SimpleUIPlugin.addToMainMenu = function(self, menu_items)
                 callback          = on_save,
             })
         end
-    end
-
-    -- Forward-declare _reapplyAllTitlebars so it is locally available inside
-    -- the arrange closures without triggering strict.lua global-access errors.
-    local _reapplyAllTitlebars
-    _reapplyAllTitlebars = function()
-        local Titlebar = require("sui_titlebar")
-        local FM = package.loaded["apps/filemanager/filemanager"]
-        local fm = FM and FM.instance
-        local stack = require("sui_core").getWindowStack()
-        Titlebar.reapplyAll(fm, stack)
-        if fm then UIManager:setDirty(fm[1], "ui") end
     end
 
     local function makeTitleBarSUIBuild(ctx_menu, title_str, tb_ctx, cfg_getter, cfg_saver)

--- a/sui_titlebar.lua
+++ b/sui_titlebar.lua
@@ -923,8 +923,15 @@ function M.apply(fm_self)
                     local dslot     = s.slot > up_slot2 and s.slot - 1 or s.slot
                     local compact_x = _buttonX("left", dslot, iw, pad, gap, sw)
                     fm_self._simpleui_search_x_compact = compact_x
-                    -- If already at root on first apply, shift to compact position now.
-                    if show_up and _isAtRoot(fm_self.file_chooser) then
+                    -- Shift to the compact (flush left) position whenever the up/back
+                    -- button is not actually occupying its slot: either it is disabled
+                    -- entirely (not show_up), or it is enabled but hidden because we
+                    -- are already at root on first apply (show_up and _isAtRoot(...)).
+                    -- The old "show_up and _isAtRoot(...)" condition never applied the
+                    -- compact position when the up button was disabled entirely, so
+                    -- search sat one slot too far right, as if the missing button were
+                    -- still there.
+                    if (not show_up) or _isAtRoot(fm_self.file_chooser) then
                         search_btn.overlap_offset = { compact_x, 0 }
                     end
                 end
@@ -1026,8 +1033,12 @@ function M.apply(fm_self)
                     local dslot_b   = s.slot > up_slot_b and s.slot - 1 or s.slot
                     local compact_x_b = _buttonX("left", dslot_b, iw, pad, gap, sw)
                     fm_self._simpleui_browse_x_compact = compact_x_b
-                    -- If already at root on first apply, shift to compact position now.
-                    if show_up and _isAtRoot(fm_self.file_chooser) then
+                    -- Shift to the compact (flush left) position whenever the up/back
+                    -- button is not actually occupying its slot: either it is disabled
+                    -- entirely (not show_up), or it is enabled but hidden because we
+                    -- are already at root on first apply (show_up and _isAtRoot(...)).
+                    -- Same fix as the search button above.
+                    if (not show_up) or _isAtRoot(fm_self.file_chooser) then
                         browse_btn.overlap_offset = { compact_x_b, 0 }
                     end
                 end


### PR DESCRIPTION
Three bugs in Titlebar Buttons (Bars > Title Bar > Library Buttons), found together while chasing a crash. I wasn't sure at first if this only effects me but hopefully this will fix it.

_reapplyAllTitlebars was declared local after the functions that call it, so those closures resolved it as a nonexistent global instead and crashed with "attempt to call global '_reapplyAllTitlebars' (a nil value)" on any toggle or arrange. Moved the declaration above them.

The Arrange Buttons list included hidden items, and on_save() also carries hidden items forward from the saved order list on every call. Every reorder or close re-appended a hidden item on top of the copy already carried over, so the count doubled with each use and snowballed into dozens of duplicates over a session. Filtered the list to visible items only and added a seen-id guard in the carry-forward step so it can't reintroduce duplicates even from already corrupted saved data.

Search and browse buttons compute a compact flush left offset for when the up button isn't present, but only applied it when show_up was true. With the up button disabled entirely that's never true, so the button stayed shifted right as if a missing button still had a slot. Extended the condition to cover the disabled case too.
