### PR TITLE
Updated Chinese translations to 2.5 version

### DIFF
--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -4,8 +4,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: simpleui\n"
-"POT-Creation-Date: 2026-07-08 23:58\n"
-"PO-Revision-Date: 2026-07-13 11:21+0800\n"
+"POT-Creation-Date: 2026-08-17 08:26\n"
+"PO-Revision-Date: 2026-08-18 19:16+0800\n"
 "Last-Translator: \n"
 "Language-Team: Chinese (Simplified)\n"
 "Language: zh_CN\n"
@@ -13,4523 +13,4877 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.9\n"
 
-#: desktop_modules/module_reading_goals.lua:868
+#: modules/module_reading_goals.lua:853
 msgid "  Set Goal  (%d hr/month)"
 msgstr "  设定目标（%d 小时/月）"
 
-#: desktop_modules/module_reading_goals.lua:888
+#: modules/module_reading_goals.lua:873
 msgid "  Set Goal  (%d min/day)"
 msgstr "  设定目标（%d 分钟/天）"
 
-#: desktop_modules/module_reading_goals.lua:848
+#: modules/module_reading_goals.lua:833
 msgid "  Set Goal  (%s)"
 msgstr "  设置目标（%s）"
 
-#: desktop_modules/module_reading_goals.lua:867
-#: desktop_modules/module_reading_goals.lua:887
+#: modules/module_reading_goals.lua:852
+#: modules/module_reading_goals.lua:872
 msgid "  Set Goal  (disabled)"
 msgstr "  设置目标（已禁用）"
 
-#: sui_foldercovers.lua:2395
+#: modules/module_coverdeck.lua:87
+msgid " et al."
+msgstr " 等"
+
+#: engines/sui_book_grid.lua:480
+#: features/library/sui_foldercovers.lua:1222
 msgid " p."
 msgstr " 页"
 
-#: desktop_modules/module_reading_goals.lua:967
+#: modules/module_feat_coll.lua:171
+#: modules/module_tbr.lua:271
+msgid "% Read (ascending)"
+msgstr "阅读进度（升序）"
+
+#: modules/module_feat_coll.lua:172
+#: modules/module_tbr.lua:272
+msgid "% Read (descending)"
+msgstr "阅读进度（降序）"
+
+#: engines/sui_book_grid.lua:1779
+#: engines/sui_book_grid.lua:1784
+msgid "%1 × %2"
+msgstr "%1 × %2"
+
+#: modules/module_reading_goals.lua:952
 msgid "%d hr/month"
 msgstr "%d 小时/月"
 
-#: desktop_modules/module_reading_goals.lua:982
+#: modules/module_reading_goals.lua:967
 msgid "%d min/day"
 msgstr "%d 分钟/天"
 
-#: desktop_modules/module_recent.lua:162 desktop_modules/module_recent.lua:434
-#: desktop_modules/module_tbr.lua:372
+#: engines/sui_book_grid.lua:865
 msgid "%d%%"
 msgstr "%d%%"
 
-#: desktop_modules/module_recent.lua:196 desktop_modules/module_recent.lua:456
-#: desktop_modules/module_tbr.lua:402 desktop_modules/module_coverdeck.lua:838
-#: desktop_modules/module_new_books.lua:218
-#: desktop_modules/module_currently.lua:627
-#: desktop_modules/module_currently.lua:636
+#: modules/module_coverdeck.lua:915
+#: modules/module_new_books.lua:139
+#: modules/module_currently.lua:729
+#: modules/module_currently.lua:738
+#: engines/sui_book_grid.lua:924
+#: engines/sui_book_grid.lua:935
 msgid "%d%% Read"
 msgstr "已读 %d%%"
 
-#: desktop_modules/module_coll_row.lua:142
-msgid "% Read (ascending)"
-msgstr "阅读率（升序）"
-
-#: desktop_modules/module_coll_row.lua:143
-msgid "% Read (descending)"
-msgstr "阅读率（降序）"
-
-#: sui_stats_windows.lua:3443
+#: screens/sui_stats_windows.lua:3450
 msgid "%d/%d days · %d/%d min to next freeze"
 msgstr "%d/%d 天 · %d/%d 分钟（下一次冻结）"
 
-#: desktop_modules/module_currently.lua:730
+#: modules/module_currently.lua:832
 msgid "%s left"
 msgstr "剩余 %s"
 
-#: desktop_modules/module_reading_goals.lua:496
-#: desktop_modules/module_reading_goals.lua:524
-#: desktop_modules/module_coverdeck.lua:843
-#: desktop_modules/module_currently.lua:670
-#: desktop_modules/module_currently.lua:671
-#: desktop_modules/module_currently.lua:728
-#: desktop_modules/module_currently.lua:739
+#: modules/module_reading_goals.lua:488
+#: modules/module_reading_goals.lua:508
+#: modules/module_coverdeck.lua:920
+#: modules/module_currently.lua:772
+#: modules/module_currently.lua:773
+#: modules/module_currently.lua:830
+#: modules/module_currently.lua:841
 msgid "%s read"
 msgstr "已读 %s"
 
-#: desktop_modules/module_coverdeck.lua:849
-#: desktop_modules/module_currently.lua:693
-#: desktop_modules/module_currently.lua:697
+#: modules/module_coverdeck.lua:926
+#: modules/module_currently.lua:795
+#: modules/module_currently.lua:799
 msgid "%s remaining"
 msgstr "剩余 %s"
 
-#: desktop_modules/module_collections.lua:354
-#: desktop_modules/module_reading_stats.lua:312
-#: desktop_modules/module_quick_actions.lua:492
+#: modules/module_reading_stats.lua:379
+#: modules/module_quick_actions.lua:599
 msgid "(%d/%d — at limit)"
 msgstr "（%d/%d — 已达上限）"
 
-#: desktop_modules/module_coll_row.lua:64
+#: modules/module_feat_coll.lua:95
 msgid "(collection not found)"
 msgstr "（未找到收藏夹）"
 
-#: sui_menu.lua:2802
+#: modules/module_collections.lua:1364
+msgid "4-Cover Grid"
+msgstr "四封面网格"
+
+#: screens/sui_menu.lua:2876
 msgid "4-Cover Grid (Mosaic View Only)"
 msgstr "四封面网格（仅限马赛克视图）"
 
-#: sui_stats_windows.lua:3120
-msgid ""
-"A freeze can only bridge a single missed day right after an active one — "
-"yesterday doesn't qualify."
+#: screens/sui_stats_windows.lua:3125
+msgid "A freeze can only bridge a single missed day right after an active one — yesterday doesn't qualify."
 msgstr "冻结仅可衔接一次紧接有效阅读日之后的缺勤，昨天不符合条件。"
 
-#: sui_menu.lua:4034 sui_menu.lua:4119 sui_presets.lua:914 sui_presets.lua:1000
+#: features/sui_presets.lua:862
+#: features/sui_presets.lua:948
+#: screens/sui_menu.lua:4064
+#: screens/sui_menu.lua:4149
 msgid "A preset named \"%s\" already exists."
 msgstr "名为“%s”的预设已存在。"
 
-#: sui_menu.lua:3980 sui_presets.lua:855
-msgid ""
-"A preset named \"%s\" already exists.\n"
-"Overwrite it?"
-msgstr ""
-"名为“%s”的预设已存在。\n"
-"是否覆盖？"
+#: features/sui_presets.lua:803
+#: screens/sui_menu.lua:4010
+msgid "A preset named \"%s\" already exists.\nOverwrite it?"
+msgstr "名为“%s”的预设已存在。\n是否覆盖？"
 
-#: sui_menu.lua:1046 sui_menu.lua:1323
-msgid ""
-"A restart is required to apply the new bar size across all layouts.\n"
-"\n"
-"Restart now?"
-msgstr ""
-"需要重启才能使新栏大小在所有布局中生效。\n"
-"\n"
-"是否立即重启？"
+#: screens/sui_menu.lua:1063
+#: screens/sui_menu.lua:1343
+msgid "A restart is required to apply the new bar size across all layouts.\n\nRestart now?"
+msgstr "需要重启才能使新栏大小在所有布局中生效。\n\n是否立即重启？"
 
-#: sui_menu.lua:4302
-msgid ""
-"A restart is required to apply the new text size everywhere.\n"
-"\n"
-"Restart now?"
-msgstr ""
-"需要重启才能全局应用新的字体大小。\n"
-"\n"
-"是否立即重启？"
+#: screens/sui_menu.lua:4332
+msgid "A restart is required to apply the new text size everywhere.\n\nRestart now?"
+msgstr "需要重启才能全局应用新的字体大小。\n\n是否立即重启？"
 
-#: _meta.lua:7
+#: _meta.lua:6
 msgid "A simple UI for KOReader"
-msgstr "Simple UI 是 KOReader 的一个界面 UI 插件，提供一个简约美观的界面 UI。"
+msgstr "Simple UI 是 KOReader 的一个界面插件，提供一个简约美观的界面。"
 
-#: sui_stats_windows.lua:2706
+#: screens/sui_stats_windows.lua:2711
 msgid "ALL TIME"
 msgstr "总计"
 
-#: sui_menu.lua:4555 sui_settings_window.lua:298 sui_settings_window.lua:855
+#: screens/sui_menu.lua:4607
+#: screens/sui_settings_window.lua:324
+#: screens/sui_settings_window.lua:1025
 msgid "About"
 msgstr "关于"
 
-#: sui_style.lua:2085
+#: features/sui_style.lua:2098
 msgid "Accent / Active Color"
 msgstr "强调色/活动色"
 
-#: sui_quickactions.lua:2180 sui_quickactions.lua:2226
+#: features/sui_quickactions.lua:2356
+#: features/sui_quickactions.lua:2402
 msgid "Action"
 msgstr "操作"
 
-#: desktop_modules/module_action_list.lua:329
+#: modules/module_action_list.lua:333
 msgid "Action List"
 msgstr "操作列表"
 
-#: sui_quickactions.lua:2430
+#: features/sui_quickactions.lua:2606
 msgid "Action Type"
 msgstr "操作类型"
 
-#: sui_quickactions.lua:1046
+#: features/sui_quickactions.lua:1091
 msgid "Action error: %s"
 msgstr "操作错误：%s"
 
-#: sui_quickactions.lua:2202
+#: features/sui_quickactions.lua:2378
 msgid "Action name…"
 msgstr "操作名称…"
 
-#: sui_quickactions.lua:1039
+#: features/sui_quickactions.lua:1084
 msgid "Action not available: %s"
 msgstr "操作不可用：%s"
 
-#: sui_quicksettings_bar.lua:1234 sui_quicksettings_bar.lua:1261
+#: screens/sui_quicksettings_bar.lua:1234
+#: screens/sui_quicksettings_bar.lua:1261
 msgid "Add Action"
 msgstr "添加操作"
 
-#: sui_menu.lua:1555 sui_menu.lua:1593
+#: screens/sui_menu.lua:1605
+#: screens/sui_menu.lua:1643
 msgid "Add Button"
 msgstr "添加按钮"
 
-#: desktop_modules/module_collections.lua:853
-#: desktop_modules/module_collections.lua:887
-msgid "Add Collection"
-msgstr "添加收藏夹"
-
-#: sui_homescreen.lua:1899 sui_menu.lua:974 sui_menu.lua:1011 sui_menu.lua:1197
-#: sui_menu.lua:1243 sui_menu.lua:1992 sui_menu.lua:2028
-#: sui_quicksettings_bar.lua:1048 sui_window.lua:766
-#: sui_settings_window.lua:860 desktop_modules/module_action_list.lua:513
-#: desktop_modules/module_action_list.lua:549
-#: desktop_modules/module_reading_stats.lua:668
-#: desktop_modules/module_reading_stats.lua:700
-#: desktop_modules/module_reading_goals.lua:913
-#: desktop_modules/module_reading_goals.lua:942
-#: desktop_modules/module_coverdeck.lua:1250
-#: desktop_modules/module_coverdeck.lua:1286
-#: desktop_modules/module_coverdeck.lua:1400
-#: desktop_modules/module_coverdeck.lua:1430
-#: desktop_modules/module_currently.lua:1207
-#: desktop_modules/module_currently.lua:1254
-#: desktop_modules/module_quick_actions.lua:440
-#: desktop_modules/module_quick_actions.lua:476
+#: modules/module_action_list.lua:518
+#: modules/module_action_list.lua:554
+#: modules/module_reading_stats.lua:773
+#: modules/module_reading_stats.lua:805
+#: modules/module_reading_goals.lua:898
+#: modules/module_reading_goals.lua:927
+#: modules/module_coverdeck.lua:1339
+#: modules/module_coverdeck.lua:1359
+#: modules/module_coverdeck.lua:1474
+#: modules/module_coverdeck.lua:1491
+#: modules/module_currently.lua:1560
+#: modules/module_currently.lua:1607
+#: modules/module_quick_actions.lua:547
+#: modules/module_quick_actions.lua:583
+#: engines/sui_screen_engine.lua:2146
+#: engines/sui_window.lua:848
+#: screens/sui_menu.lua:988
+#: screens/sui_menu.lua:1025
+#: screens/sui_menu.lua:1214
+#: screens/sui_menu.lua:1260
+#: screens/sui_menu.lua:2042
+#: screens/sui_menu.lua:2078
+#: screens/sui_quicksettings_bar.lua:1048
+#: screens/sui_settings_window.lua:1033
 msgid "Add Item"
 msgstr "添加项目"
 
-#: sui_settings_window.lua:857 sui_settings_window.lua:954
+#: screens/sui_settings_window.lua:1030
+#: screens/sui_settings_window.lua:1170
 msgid "Add Module"
 msgstr "添加模块"
 
-#: sui_settings_window.lua:920
+#: screens/sui_settings_window.lua:1136
 msgid "Add Page"
 msgstr "添加页面"
 
-#: sui_menu.lua:1912 sui_quicksettings_bar.lua:1107
-#: desktop_modules/module_action_list.lua:424
-#: desktop_modules/module_quick_actions.lua:345
+#: modules/module_action_list.lua:429
+#: modules/module_quick_actions.lua:452
+#: screens/sui_menu.lua:1962
+#: screens/sui_quicksettings_bar.lua:1107
 msgid "Add at least 2 actions to arrange."
 msgstr "请至少添加 2 个操作以进行排列。"
 
-#: desktop_modules/module_tbr.lua:582
+#: modules/module_feat_coll.lua:220
+#: modules/module_tbr.lua:328
 msgid "Add at least 2 books to arrange."
 msgstr "请至少添加 2 本书以便排序。"
 
-#: desktop_modules/module_reading_stats.lua:617
+#: modules/module_reading_stats.lua:722
 msgid "Add at least 2 stats to arrange."
 msgstr "请至少添加 2 个统计项以便排序。"
 
-#: desktop_modules/module_tbr.lua:294
+#: modules/module_tbr.lua:532
 msgid "Add to To Be Read"
 msgstr "添加到待读"
 
-#: sui_window.lua:2115
+#: engines/sui_window.lua:2301
 msgid "Advanced"
 msgstr "高级"
 
-#: sui_window.lua:2024
+#: engines/sui_window.lua:2210
 msgid "Advanced option"
 msgstr "高级选项"
 
-#: desktop_modules/module_quote.lua:1507
-#: desktop_modules/module_action_list.lua:587
-#: desktop_modules/module_reading_stats.lua:773
-#: desktop_modules/module_clock.lua:851
+#: modules/module_quote.lua:1559
+#: modules/module_action_list.lua:597
+#: modules/module_reading_stats.lua:878
+#: modules/module_clock.lua:1029
+#: modules/module_quick_actions.lua:759
 msgid "Alignment"
 msgstr "对齐方式"
 
-#: sui_window.lua:3149 sui_settings_window.lua:633
+#: engines/sui_window.lua:3350
+#: screens/sui_settings_window.lua:808
 msgid "All items have already been added."
 msgstr "所有项目都已添加。"
 
-#: sui_settings_window.lua:611
+#: screens/sui_settings_window.lua:786
 msgid "All modules have already been added."
 msgstr "所有模块都已添加。"
 
-#: sui_quickactions.lua:3143
+#: features/sui_quickactions.lua:3407
 msgid "All recent books are finished."
 msgstr "近期书籍已全部读完。"
 
-#: desktop_modules/module_reading_stats.lua:93
+#: modules/module_reading_stats.lua:123
 msgid "All time — Books"
 msgstr "总计 — 书籍"
 
-#: desktop_modules/module_reading_stats.lua:92
+#: modules/module_reading_stats.lua:122
 msgid "All time — Time"
 msgstr "总计 — 时间"
 
-#: sui_menu.lua:2503
+#: screens/sui_menu.lua:2553
 msgid "Always"
 msgstr "总是"
 
-#: desktop_modules/module_reading_goals.lua:835
-#: desktop_modules/module_reading_goals.lua:901
-#: desktop_modules/module_reading_goals.lua:938
-#: desktop_modules/module_reading_goals.lua:955
+#: modules/module_clock.lua:1001
+#: modules/module_clock.lua:1020
+msgid "Analogue"
+msgstr "模拟"
+
+#: modules/module_reading_goals.lua:820
+#: modules/module_reading_goals.lua:886
+#: modules/module_reading_goals.lua:923
+#: modules/module_reading_goals.lua:940
 msgid "Annual Goal"
 msgstr "年度目标"
 
-#: desktop_modules/module_reading_goals.lua:387
+#: modules/module_reading_goals.lua:396
 msgid "Annual Reading Goal"
 msgstr "年度阅读目标"
 
-#: sui_menu.lua:1771 sui_menu.lua:1774
+#: modules/module_reading_goals.lua:1035
+#: modules/module_currently.lua:1838
+#: modules/module_quick_actions.lua:685
+#: engines/sui_book_grid.lua:1844
+#: screens/sui_menu.lua:1821
+#: screens/sui_menu.lua:1824
 msgid "Appearance"
 msgstr "外观"
 
-#: sui_config.lua:853 sui_config.lua:925 sui_menu.lua:1036 sui_menu.lua:1313
-#: sui_menu.lua:2344 sui_menu.lua:2416 sui_menu.lua:2453 sui_menu.lua:2850
-#: sui_menu.lua:3211 sui_menu.lua:4296 sui_style.lua:2109
-#: desktop_modules/module_clock.lua:894 desktop_modules/module_clock.lua:920
+#: modules/module_clock.lua:1075
+#: modules/module_clock.lua:1101
+#: features/sui_style.lua:2122
+#: infra/sui_config.lua:885
+#: infra/sui_config.lua:919
+#: infra/sui_config.lua:1034
+#: screens/sui_menu.lua:1050
+#: screens/sui_menu.lua:1330
+#: screens/sui_menu.lua:2394
+#: screens/sui_menu.lua:2466
+#: screens/sui_menu.lua:2503
+#: screens/sui_menu.lua:2924
+#: screens/sui_menu.lua:3285
+#: screens/sui_menu.lua:4326
 msgid "Apply"
 msgstr "应用"
 
-#: sui_style.lua:2159
+#: features/sui_style.lua:2172
 msgid "Apply Palette…"
 msgstr "应用调色板…"
 
-#: sui_stats_windows.lua:2835 desktop_modules/module_clock.lua:60
+#: modules/module_clock.lua:61
+#: screens/sui_stats_windows.lua:2840
 msgid "April"
 msgstr "4月"
 
-#: desktop_modules/module_tbr.lua:570 desktop_modules/module_tbr.lua:643
-#: desktop_modules/module_tbr.lua:666
+#: modules/module_feat_coll.lua:206
+#: modules/module_feat_coll.lua:281
+#: modules/module_feat_coll.lua:300
+#: modules/module_tbr.lua:316
+#: modules/module_tbr.lua:389
+#: modules/module_tbr.lua:412
 msgid "Arrange"
 msgstr "排序"
 
-#: sui_menu.lua:1916 desktop_modules/module_action_list.lua:444
-#: desktop_modules/module_quick_actions.lua:363
+#: modules/module_action_list.lua:449
+#: modules/module_quick_actions.lua:470
+#: screens/sui_menu.lua:1966
 msgid "Arrange %s"
 msgstr "排序 %s"
 
-#: sui_menu.lua:1499 sui_menu.lua:1506 sui_menu.lua:1695 sui_menu.lua:1710
+#: screens/sui_menu.lua:1561
+#: screens/sui_menu.lua:1568
+#: screens/sui_menu.lua:1745
+#: screens/sui_menu.lua:1760
 msgid "Arrange Buttons"
 msgstr "排序按钮"
 
-#: desktop_modules/module_coll_row.lua:159 desktop_modules/module_coll_row.lua:194
+#: modules/module_feat_coll.lua:214
+#: modules/module_feat_coll.lua:249
 msgid "Arrange Collection"
 msgstr "整理收藏夹"
 
-#: sui_homescreen.lua:1898 sui_menu.lua:686 sui_menu.lua:757 sui_menu.lua:764
-#: sui_menu.lua:1906 sui_topbar.lua:514 sui_bottombar.lua:889
-#: sui_quicksettings_bar.lua:1047 sui_quicksettings_bar.lua:1098
-#: sui_settings_window.lua:41 sui_settings_window.lua:882
-#: desktop_modules/module_action_list.lua:415
-#: desktop_modules/module_coverdeck.lua:1340
-#: desktop_modules/module_coverdeck.lua:1346
-#: desktop_modules/module_currently.lua:1081
-#: desktop_modules/module_currently.lua:1124
-#: desktop_modules/module_quick_actions.lua:336
+#: modules/module_action_list.lua:420
+#: modules/module_coverdeck.lua:1414
+#: modules/module_coverdeck.lua:1420
+#: modules/module_currently.lua:1433
+#: modules/module_currently.lua:1476
+#: modules/module_quick_actions.lua:443
+#: engines/sui_screen_engine.lua:2145
+#: screens/sui_menu.lua:700
+#: screens/sui_menu.lua:771
+#: screens/sui_menu.lua:778
+#: screens/sui_menu.lua:1956
+#: screens/sui_topbar.lua:514
+#: screens/sui_bottombar.lua:889
+#: screens/sui_quicksettings_bar.lua:1047
+#: screens/sui_quicksettings_bar.lua:1098
+#: screens/sui_settings_window.lua:43
+#: screens/sui_settings_window.lua:1054
 msgid "Arrange Items"
 msgstr "排序项目"
 
-#: sui_quicksettings_bar.lua:1123
+#: screens/sui_quicksettings_bar.lua:1123
 msgid "Arrange Quick Settings"
 msgstr "排序快捷设置"
 
-#: desktop_modules/module_reading_stats.lua:628
+#: modules/module_reading_stats.lua:733
 msgid "Arrange Reading Stats"
 msgstr "排序阅读统计"
 
-#: desktop_modules/module_coverdeck.lua:1361
+#: modules/module_coverdeck.lua:1435
 msgid "Arrange Statistics"
 msgstr "排序统计项"
 
-#: sui_menu.lua:293 sui_menu.lua:311
+#: screens/sui_menu.lua:307
+#: screens/sui_menu.lua:325
 msgid "Arrange Tabs"
 msgstr "排序标签"
 
-#: desktop_modules/module_tbr.lua:575 desktop_modules/module_tbr.lua:613
+#: modules/module_tbr.lua:321
+#: modules/module_tbr.lua:359
 msgid "Arrange To Be Read List"
 msgstr "整理待读列表"
 
-#: sui_presets.lua:136
+#: features/sui_presets.lua:137
 msgid "At a Glance"
 msgstr "概览"
 
-#: sui_stats_windows.lua:2836 desktop_modules/module_clock.lua:61
+#: modules/module_clock.lua:62
+#: screens/sui_stats_windows.lua:2841
 msgid "August"
 msgstr "8月"
 
-#: desktop_modules/module_coverdeck.lua:91
-#: desktop_modules/module_currently.lua:247
+#: modules/module_coverdeck.lua:176
+#: modules/module_currently.lua:282
 msgid "Author"
 msgstr "作者"
 
-#: desktop_modules/module_coll_row.lua:141
+#: modules/module_library.lua:214
+#: modules/module_feat_coll.lua:170
+#: modules/module_tbr.lua:270
 msgid "Author (A–Z)"
 msgstr "作者（A–Z）"
 
-#: sui_menu.lua:4384
+#: screens/sui_menu.lua:4414
 msgid "Author: %s"
 msgstr "作者：%s"
 
-#: sui_quickactions.lua:845 sui_config.lua:131 sui_browsemeta.lua:77
+#: features/sui_quickactions.lua:879
+#: infra/sui_config.lua:132
+#: features/library/sui_library_browse.lua:58
 msgid "Authors"
 msgstr "作者"
 
-#: sui_menu.lua:2813
+#: modules/module_collections.lua:1373
+#: screens/sui_menu.lua:2887
 msgid "Auto (Single ↔ 4-Cover Grid)"
 msgstr "自动（单栏 ↔ 四封面网格）"
 
-#: sui_foldercovers.lua:803 sui_foldercovers.lua:860 sui_browsemeta.lua:1161
-#: desktop_modules/module_collections.lua:748
+#: modules/module_collections.lua:348
+#: features/library/sui_group_actions.lua:52
 msgid "Auto (first book)"
 msgstr "自动（第一本书）"
 
-#: sui_menu.lua:2301
+#: screens/sui_menu.lua:2351
 msgid "Auto-rotate"
 msgstr "自动旋转"
 
-#: sui_menu.lua:4389
+#: screens/sui_menu.lua:4419
 msgid "Automatic Update Check"
 msgstr "自动检查更新"
 
-#: sui_stats_windows.lua:1210 sui_stats_windows.lua:2415
-#: sui_stats_windows.lua:3906
+#: screens/sui_stats_windows.lua:1215
+#: screens/sui_stats_windows.lua:2420
+#: screens/sui_stats_windows.lua:3913
 msgid "Average per day"
 msgstr "日均值"
 
-#: sui_stats_windows.lua:1212 sui_stats_windows.lua:3908
+#: screens/sui_stats_windows.lua:1217
+#: screens/sui_stats_windows.lua:3915
 msgid "Average per page"
 msgstr "每页平均值"
 
-#: sui_titlebar.lua:103 sui_titlebar.lua:109
+#: screens/sui_titlebar.lua:103
+#: screens/sui_titlebar.lua:109
 msgid "Back"
 msgstr "返回"
 
-#: sui_style.lua:100
+#: features/sui_style.lua:100
 msgid "Back Button"
 msgstr "返回按钮"
 
-#: sui_menu.lua:3115 sui_menu.lua:3124 sui_menu.lua:3130
-#: desktop_modules/module_collections.lua:929
+#: modules/module_collections.lua:1395
+#: engines/sui_book_grid.lua:2013
+#: screens/sui_menu.lua:3189
+#: screens/sui_menu.lua:3198
+#: screens/sui_menu.lua:3204
 msgid "Badge"
 msgstr "徽章"
 
-#: sui_menu.lua:2843
+#: modules/module_collections.lua:1439
+#: modules/module_collections.lua:1442
+#: engines/sui_book_grid.lua:1946
+#: engines/sui_book_grid.lua:1948
+#: screens/sui_menu.lua:2917
 msgid "Badge Size"
 msgstr "标签大小"
 
-#: sui_menu.lua:2831
+#: screens/sui_menu.lua:2905
 msgid "Badges"
 msgstr "徽章"
 
-#: sui_foldercovers.lua:293 sui_menu.lua:3048 sui_menu.lua:3057
-#: sui_menu.lua:3063
+#: screens/sui_menu.lua:3122
+#: screens/sui_menu.lua:3131
+#: screens/sui_menu.lua:3137
+#: features/library/sui_foldercovers.lua:309
 msgid "Banner"
 msgstr "横幅"
 
-#: sui_menu.lua:552 sui_menu.lua:1299
+#: engines/sui_book_grid.lua:1895
+msgid "Bar"
+msgstr "条形"
+
+#: engines/sui_book_grid.lua:1897
+msgid "Bar + Text"
+msgstr "条形 + 文字"
+
+#: screens/sui_menu.lua:566
+#: screens/sui_menu.lua:1316
 msgid "Bar Size"
 msgstr "栏大小"
 
-#: sui_menu.lua:1257
+#: screens/sui_menu.lua:1274
 msgid "Bar Style"
 msgstr "栏样式"
 
-#: sui_menu.lua:1284 sui_quicksettings_bar.lua:1338
-#: desktop_modules/module_quick_actions.lua:595
+#: modules/module_quick_actions.lua:711
+#: screens/sui_menu.lua:1301
+#: screens/sui_quicksettings_bar.lua:1338
 msgid "Bare"
 msgstr "极简模式"
 
-#: sui_menu.lua:4517 sui_settings_window.lua:258 sui_settings_window.lua:852
+#: screens/sui_menu.lua:4569
+#: screens/sui_settings_window.lua:289
+#: screens/sui_settings_window.lua:1022
 msgid "Bars"
 msgstr "栏样式"
 
-#: sui_config.lua:169
+#: infra/sui_config.lua:170
 msgid "Battery"
 msgstr "电池"
 
-#: desktop_modules/module_clock.lua:905 desktop_modules/module_clock.lua:913
+#: modules/module_clock.lua:1086
+#: modules/module_clock.lua:1094
 msgid "Battery Spacing"
 msgstr "电池间距"
 
-#: sui_menu.lua:2678 sui_settings_window.lua:330 sui_settings_window.lua:863
+#: screens/sui_menu.lua:2752
+#: screens/sui_settings_window.lua:373
+#: screens/sui_settings_window.lua:1035
 msgid "Behaviour"
 msgstr "行为"
 
-#: sui_stats_windows.lua:2185 sui_stats_windows.lua:2205
+#: screens/sui_stats_windows.lua:2190
+#: screens/sui_stats_windows.lua:2210
 msgid "Best streak"
 msgstr "最佳连续纪录"
 
-#: sui_menu.lua:2542
+#: screens/sui_menu.lua:2592
 msgid "Book Cover Transition"
 msgstr "书籍封面过渡效果"
 
-#: sui_quickactions.lua:1959
+#: features/sui_quickactions.lua:2127
 msgid "Book Info"
 msgstr "书籍信息"
 
-#: sui_stats_windows.lua:3959
+#: infra/sui_config.lua:1104
+msgid "Book Menu"
+msgstr "图书菜单"
+
+#: screens/sui_stats_windows.lua:3966
 msgid "Book Statistics"
 msgstr "书籍统计"
 
-#: main.lua:1110
+#: main.lua:1139
 msgid "Book statistics"
 msgstr "书籍统计"
 
-#: sui_settings_window.lua:266
+#: screens/sui_settings_window.lua:297
 msgid "Book-browser settings"
 msgstr "书库浏览设置"
 
-#: sui_quickactions.lua:430
+#: features/sui_quickactions.lua:453
 msgid "Bookmark browser"
 msgstr "书签浏览器"
 
-#: sui_quickactions.lua:369
+#: features/sui_quickactions.lua:387
 msgid "Bookmark browser not available."
 msgstr "书签浏览器不可用。"
 
-#: sui_quickactions.lua:742 sui_config.lua:124
+#: features/sui_quickactions.lua:776
+#: infra/sui_config.lua:125
 msgid "Bookmarks"
 msgstr "书签"
 
-#: desktop_modules/module_coll_row.lua:202
+#: modules/module_library.lua:294
+#: modules/module_feat_coll.lua:257
 msgid "Books"
 msgstr "书籍"
 
-#: desktop_modules/module_reading_goals.lua:388
+#: modules/module_reading_goals.lua:397
 msgid "Books to read in %s:"
 msgstr "%s 年需要阅读的书籍："
 
-#: sui_menu.lua:2866 sui_menu.lua:2873 sui_menu.lua:2888 sui_menu.lua:3279
-#: sui_menu.lua:3298 desktop_modules/module_collections.lua:950
+#: modules/module_collections.lua:1416
+#: screens/sui_menu.lua:2940
+#: screens/sui_menu.lua:2947
+#: screens/sui_menu.lua:2962
+#: screens/sui_menu.lua:3353
+#: screens/sui_menu.lua:3372
 msgid "Bottom"
 msgstr "底部"
 
-#: sui_bottombar.lua:890
-msgid "Bottom Bar"
-msgstr "底部栏"
-
-#: sui_style.lua:2078
-msgid "Bottom Bar — Background"
-msgstr "底部栏 — 背景"
-
-#: sui_style.lua:2081
-msgid "Bottom Bar — Text and Icons"
-msgstr "底部栏 — 文本与图标"
-
-#: sui_menu.lua:1356 sui_menu.lua:1357
+#: screens/sui_menu.lua:1376
+#: screens/sui_menu.lua:1377
 msgid "Bottom Margin"
 msgstr "底部边距"
 
-#: sui_menu.lua:2543
-msgid ""
-"Briefly show the book cover full-screen when opening or closing a book, "
-"masking the page-layout flash. Normally requires the book to already be "
-"indexed by the cover browser (its cover must have been seen at least once in "
-"a grid/list view) — see \"High-Quality Cover\" below to also cover un-"
-"indexed books."
-msgstr ""
-"在打开或关闭书籍时，以全屏封面短暂显示，以遮盖页面布局刷新。通常要求该书已被"
-"封面浏览器索引（即在网格/列表视图中至少显示过一次封面）。如需覆盖未索引书籍，"
-"请参阅下方的「高质量封面」选项。"
+#: screens/sui_menu.lua:2593
+msgid "Briefly show the book cover full-screen when opening or closing a book, masking the page-layout flash. Normally requires the book to already be indexed by the cover browser (its cover must have been seen at least once in a grid/list view) — see \"High-Quality Cover\" below to also cover un-indexed books."
+msgstr "在打开或关闭书籍时，以全屏封面短暂显示，以遮盖页面布局刷新。通常要求该书已被封面浏览器索引（即在网格/列表视图中至少显示过一次封面）。如需覆盖未索引书籍，请参阅下方的「高质量封面」选项。"
 
-#: sui_quickactions.lua:783 sui_config.lua:126 sui_config.lua:168
+#: features/sui_quickactions.lua:817
+#: infra/sui_config.lua:127
+#: infra/sui_config.lua:169
 msgid "Brightness"
 msgstr "亮度"
 
-#: sui_titlebar.lua:105
+#: screens/sui_titlebar.lua:105
 msgid "Browse"
 msgstr "浏览"
 
-#: sui_style.lua:115
+#: features/sui_style.lua:115
 msgid "Browse Button (author)"
 msgstr "浏览按钮（作者）"
 
-#: sui_style.lua:109
+#: features/sui_style.lua:109
 msgid "Browse Button (default)"
 msgstr "浏览按钮（默认）"
 
-#: sui_style.lua:121
+#: features/sui_style.lua:121
 msgid "Browse Button (series)"
 msgstr "浏览按钮（系列）"
 
-#: sui_style.lua:127
+#: features/sui_style.lua:127
 msgid "Browse Button (tags)"
 msgstr "浏览按钮（标签）"
 
-#: sui_style.lua:1383
+#: features/sui_style.lua:1383
 msgid "Browse Icons"
 msgstr "浏览图标"
 
-#: sui_browsemeta.lua:630
+#: features/library/sui_library_browse.lua:416
 msgid "Browse by"
 msgstr "浏览方式"
 
-#: sui_quickactions.lua:852 sui_quickactions.lua:870 sui_quickactions.lua:888
+#: features/sui_quickactions.lua:886
+#: features/sui_quickactions.lua:904
+#: features/sui_quickactions.lua:922
 msgid "Browse by Authors/Series/Tags not available."
 msgstr "按作者/系列/标签浏览不可用。"
 
-#: sui_titlebar.lua:993
+#: screens/sui_titlebar.lua:1000
 msgid "Browse library"
 msgstr "书库浏览方式"
 
-#: sui_quicksettings_bar.lua:1351 desktop_modules/module_quick_actions.lua:608
+#: modules/module_quick_actions.lua:723
+#: screens/sui_quicksettings_bar.lua:1351
 msgid "Button Background"
 msgstr "按钮背景"
 
-#: sui_menu.lua:1782
+#: screens/sui_menu.lua:1832
 msgid "Button Size"
 msgstr "按钮大小"
 
-#: sui_quicksettings_bar.lua:1315 desktop_modules/module_quick_actions.lua:572
+#: modules/module_quick_actions.lua:688
+#: screens/sui_quicksettings_bar.lua:1315
 msgid "Button Type"
 msgstr "按钮类型"
 
-#: sui_titlebar.lua:997
+#: screens/sui_titlebar.lua:1004
 msgid "By author"
 msgstr "作者"
 
-#: sui_menu.lua:2582
-msgid ""
-"By default the cover is stretched to fill the whole screen, which can "
-"distort it if its proportions don't match your screen's. When on, the cover "
-"keeps its original proportions instead, centered over a black background."
-msgstr ""
-"默认情况下，封面会被拉伸至铺满屏幕；若其比例与屏幕尺寸不符，可能导致变形。开"
-"启后，封面将保持原始比例，并以黑色背景居中显示。"
+#: screens/sui_menu.lua:2632
+msgid "By default the cover is stretched to fill the whole screen, which can distort it if its proportions don't match your screen's. When on, the cover keeps its original proportions instead, centered over a black background."
+msgstr "默认情况下，封面会被拉伸至铺满屏幕；若其比例与屏幕尺寸不符，可能导致变形。开启后，封面将保持原始比例，并以黑色背景居中显示。"
 
-#: sui_titlebar.lua:998
+#: screens/sui_titlebar.lua:1005
 msgid "By series"
 msgstr "系列"
 
-#: sui_titlebar.lua:999
+#: screens/sui_titlebar.lua:1006
 msgid "By tags"
 msgstr "按标签"
 
-#: sui_stats_windows.lua:3141
+#: screens/sui_stats_windows.lua:3146
 msgid "CALENDAR"
 msgstr "日历"
 
-#: sui_quickactions.lua:455 sui_quickactions.lua:1416 sui_quickactions.lua:1699
-#: sui_quickactions.lua:1823 sui_quickactions.lua:1845
-#: sui_quickactions.lua:1939 sui_quickactions.lua:2217
-#: sui_quickactions.lua:2288 sui_quickactions.lua:2314
-#: sui_quickactions.lua:2339 sui_quickactions.lua:2417
-#: sui_quickactions.lua:2441 sui_quickactions.lua:2716
-#: sui_quickactions.lua:3081 sui_titlebar.lua:1000 sui_foldercovers.lua:747
-#: sui_foldercovers.lua:831 sui_foldercovers.lua:888 sui_foldercovers.lua:1257
-#: sui_config.lua:854 sui_config.lua:926 sui_menu.lua:642 sui_menu.lua:907
-#: sui_menu.lua:1037 sui_menu.lua:1314 sui_menu.lua:2345 sui_menu.lua:2417
-#: sui_menu.lua:2454 sui_menu.lua:2851 sui_menu.lua:3212 sui_menu.lua:3948
-#: sui_menu.lua:3982 sui_menu.lua:4011 sui_menu.lua:4028 sui_menu.lua:4054
-#: sui_menu.lua:4095 sui_menu.lua:4113 sui_menu.lua:4140 sui_menu.lua:4297
-#: sui_menu.lua:4424 sui_stats_windows.lua:645 sui_stats_windows.lua:771
-#: sui_browsemeta.lua:1085 sui_browsemeta.lua:1193 sui_browsemeta.lua:1403
-#: sui_style.lua:1401 sui_style.lua:2105 sui_updater.lua:483
-#: sui_updater.lua:500 sui_presets.lua:818 sui_presets.lua:857
-#: sui_presets.lua:887 sui_presets.lua:904 sui_presets.lua:932
-#: sui_presets.lua:972 sui_presets.lua:990 sui_presets.lua:1019
-#: desktop_modules/module_quote.lua:1254
-#: desktop_modules/module_collections.lua:774
-#: desktop_modules/module_reading_goals.lua:391
-#: desktop_modules/module_reading_goals.lua:407
-#: desktop_modules/module_reading_goals.lua:424
-#: desktop_modules/module_reading_goals.lua:442
-#: desktop_modules/module_clock.lua:895 desktop_modules/module_clock.lua:921
+#: modules/module_quote.lua:1305
+#: modules/module_collections.lua:374
+#: modules/module_reading_goals.lua:383
+#: modules/module_clock.lua:1076
+#: modules/module_clock.lua:1102
+#: features/sui_quickactions.lua:478
+#: features/sui_quickactions.lua:1521
+#: features/sui_quickactions.lua:1867
+#: features/sui_quickactions.lua:1991
+#: features/sui_quickactions.lua:2013
+#: features/sui_quickactions.lua:2107
+#: features/sui_quickactions.lua:2393
+#: features/sui_quickactions.lua:2464
+#: features/sui_quickactions.lua:2490
+#: features/sui_quickactions.lua:2515
+#: features/sui_quickactions.lua:2593
+#: features/sui_quickactions.lua:2617
+#: features/sui_quickactions.lua:2941
+#: features/sui_quickactions.lua:3345
+#: features/sui_style.lua:1401
+#: features/sui_style.lua:2118
+#: features/sui_presets.lua:766
+#: features/sui_presets.lua:805
+#: features/sui_presets.lua:835
+#: features/sui_presets.lua:852
+#: features/sui_presets.lua:880
+#: features/sui_presets.lua:920
+#: features/sui_presets.lua:938
+#: features/sui_presets.lua:967
+#: infra/sui_config.lua:886
+#: infra/sui_config.lua:920
+#: infra/sui_config.lua:1035
+#: infra/sui_updater.lua:510
+#: infra/sui_updater.lua:527
+#: screens/sui_titlebar.lua:1007
+#: screens/sui_menu.lua:656
+#: screens/sui_menu.lua:921
+#: screens/sui_menu.lua:1051
+#: screens/sui_menu.lua:1331
+#: screens/sui_menu.lua:2395
+#: screens/sui_menu.lua:2467
+#: screens/sui_menu.lua:2504
+#: screens/sui_menu.lua:2925
+#: screens/sui_menu.lua:3286
+#: screens/sui_menu.lua:3978
+#: screens/sui_menu.lua:4012
+#: screens/sui_menu.lua:4041
+#: screens/sui_menu.lua:4058
+#: screens/sui_menu.lua:4084
+#: screens/sui_menu.lua:4125
+#: screens/sui_menu.lua:4143
+#: screens/sui_menu.lua:4170
+#: screens/sui_menu.lua:4327
+#: screens/sui_menu.lua:4454
+#: screens/sui_stats_windows.lua:650
+#: screens/sui_stats_windows.lua:776
+#: screens/sui_settings_window.lua:442
+#: screens/sui_settings_window.lua:1113
+#: features/library/sui_library_browse.lua:826
+#: features/library/sui_series_grouping.lua:377
+#: features/library/sui_group_actions.lua:75
+#: features/library/sui_group_actions.lua:109
 msgid "Cancel"
 msgstr "取消"
 
-#: desktop_modules/module_reading_stats.lua:731
+#: modules/module_reading_stats.lua:836
 msgid "Cards"
 msgstr "卡片"
 
-#: desktop_modules/module_reading_stats.lua:741
+#: modules/module_reading_stats.lua:846
 msgid "Cards - Transparent"
 msgstr "卡片 — 透明"
 
-#: sui_menu.lua:702 sui_menu.lua:937 sui_menu.lua:3278 sui_menu.lua:3291
-#: desktop_modules/module_quote.lua:128 desktop_modules/module_quote.lua:1517
-#: desktop_modules/module_action_list.lua:75
-#: desktop_modules/module_action_list.lua:597
-#: desktop_modules/module_reading_stats.lua:68
-#: desktop_modules/module_reading_stats.lua:787
-#: desktop_modules/module_clock.lua:117 desktop_modules/module_clock.lua:863
+#: modules/module_quote.lua:128
+#: modules/module_quote.lua:1569
+#: modules/module_action_list.lua:75
+#: modules/module_action_list.lua:607
+#: modules/module_reading_stats.lua:98
+#: modules/module_reading_stats.lua:892
+#: modules/module_clock.lua:146
+#: modules/module_clock.lua:1041
+#: screens/sui_menu.lua:716
+#: screens/sui_menu.lua:951
+#: screens/sui_menu.lua:3352
+#: screens/sui_menu.lua:3365
 msgid "Center"
 msgstr "居中"
 
-#: sui_menu.lua:4400
+#: screens/sui_menu.lua:4430
 msgid "Check for Updates"
 msgstr "检查更新"
 
-#: sui_updater.lua:616
+#: infra/sui_updater.lua:643
 msgid "Checking for updates…"
 msgstr "检查更新中…"
 
-#: sui_onboarding.lua:55
+#: screens/sui_onboarding.lua:55
 msgid "Choose your initial layout"
 msgstr "选择初始布局"
 
-#: sui_config.lua:166 sui_presets.lua:137 desktop_modules/module_clock.lua:534
+#: modules/module_clock.lua:700
+#: features/sui_presets.lua:150
+#: infra/sui_config.lua:167
 msgid "Clock"
 msgstr "时钟"
 
-#: desktop_modules/module_clock.lua:829
+#: modules/module_clock.lua:997
 msgid "Clock Style"
 msgstr "时钟样式"
 
-#: sui_titlebar.lua:108
+#: screens/sui_titlebar.lua:108
 msgid "Close"
 msgstr "关闭"
 
-#: sui_menu.lua:2499
+#: screens/sui_menu.lua:2549
 msgid "Closing Book Notice"
 msgstr "关闭书籍时是否提示"
 
-#: main.lua:1766
+#: main.lua:1901
 msgid "Closing book…"
 msgstr "正在关闭书籍…"
 
-#: sui_quickactions.lua:1871
+#: features/sui_quickactions.lua:2039
 msgid "Codepoint out of valid Unicode range (0–10FFFF)."
 msgstr "代码点超出有效的 Unicode 范围（0–10FFFF）。"
 
-#: sui_quickactions.lua:2290 sui_quickactions.lua:2433
+#: features/sui_quickactions.lua:2466
+#: features/sui_quickactions.lua:2609
 msgid "Collection"
 msgstr "收藏夹"
 
-#: sui_foldercovers.lua:774 sui_browsemeta.lua:1125
+#: modules/module_collections.lua:1503
+msgid "Collection Menu"
+msgstr "收藏夹菜单"
+
+#: features/library/sui_group_actions.lua:138
 msgid "Collection \"%1\" created with %2 books."
 msgstr "收藏夹“%1”已创建，包含 %2 本书。"
 
-#: sui_foldercovers.lua:759 sui_browsemeta.lua:1100
+#: features/library/sui_group_actions.lua:122
 msgid "Collection already exists: %1"
 msgstr "收藏夹已存在：%1"
 
-#: desktop_modules/module_collections.lua:735
-#: desktop_modules/module_collections.lua:741
+#: modules/module_collections.lua:335
+#: modules/module_collections.lua:341
 msgid "Collection is empty."
 msgstr "收藏夹为空。"
 
-#: sui_quickactions.lua:2797
+#: features/sui_quickactions.lua:3031
 msgid "Collection not available: %s"
 msgstr "收藏夹不可用：%s"
 
-#: desktop_modules/module_coll_row.lua:96
+#: modules/module_feat_coll.lua:127
 msgid "Collection: "
 msgstr "收藏夹："
 
-#: desktop_modules/module_coll_row.lua:96
+#: modules/module_feat_coll.lua:127
 msgid "Collection: (none)"
 msgstr "收藏夹：（无）"
 
-#: desktop_modules/module_coll_row.lua:318 desktop_modules/module_coll_row.lua:334
-msgid "Collection Row"
-msgstr "收藏夹行"
-
-#: desktop_modules/module_coll_row.lua:56
-msgid "Collection Row — tap to configure"
-msgstr "收藏夹行 — 点击以配置"
-
-#: sui_quickactions.lua:441 sui_quickactions.lua:627 sui_quickactions.lua:1961
-#: sui_config.lua:118 desktop_modules/module_collections.lua:338
-#: desktop_modules/module_collections.lua:339
-#: desktop_modules/module_collections.lua:359
-#: desktop_modules/module_collections.lua:786
-#: desktop_modules/module_collections.lua:806
-#: desktop_modules/module_collections.lua:815
-#: desktop_modules/module_collections.lua:841
-#: desktop_modules/module_collections.lua:909
-#: desktop_modules/module_coverdeck.lua:1209
+#: modules/module_collections.lua:1196
+#: modules/module_collections.lua:1216
+#: modules/module_collections.lua:1225
+#: modules/module_collections.lua:1244
+#: modules/module_collections.lua:1494
+#: modules/module_collections.lua:1495
+#: modules/module_coverdeck.lua:1264
+#: features/sui_quickactions.lua:464
+#: features/sui_quickactions.lua:661
+#: features/sui_quickactions.lua:2129
+#: infra/sui_config.lua:119
 msgid "Collections"
 msgstr "收藏夹"
 
-#: sui_patches.lua:1127
+#: infra/sui_patches.lua:1385
 msgid "Collections (%1)"
 msgstr "收藏夹（%1）"
 
-#: sui_quickactions.lua:634
+#: features/sui_quickactions.lua:668
 msgid "Collections not available."
 msgstr "收藏夹不可用。"
 
-#: sui_style.lua:177
+#: features/sui_style.lua:177
 msgid "Collections: Back Button"
 msgstr "收藏夹：返回按钮"
 
-#: sui_menu.lua:2911 sui_menu.lua:2965 sui_menu.lua:3019 sui_menu.lua:3086
-#: sui_menu.lua:3153 sui_menu.lua:3307
+#: screens/sui_menu.lua:2985
+#: screens/sui_menu.lua:3039
+#: screens/sui_menu.lua:3093
+#: screens/sui_menu.lua:3160
+#: screens/sui_menu.lua:3227
+#: screens/sui_menu.lua:3381
 msgid "Color"
 msgstr "颜色"
 
-#: sui_menu.lua:1785 desktop_modules/module_reading_goals.lua:1059
-#: desktop_modules/module_currently.lua:1535
+#: engines/sui_book_grid.lua:1790
+msgid "Columns"
+msgstr "列"
+
+#: modules/module_reading_goals.lua:1047
+#: modules/module_currently.lua:1880
+#: screens/sui_menu.lua:1835
 msgid "Compact"
 msgstr "紧凑"
 
-#: sui_quickactions.lua:1822
+#: features/sui_quickactions.lua:1990
 msgid "Confirm"
 msgstr "确认"
 
-#: sui_quickactions.lua:660 sui_config.lua:121 sui_onboarding.lua:253
-#: sui_onboarding.lua:259 sui_onboarding.lua:265
+#: features/sui_quickactions.lua:694
+#: infra/sui_config.lua:122
+#: screens/sui_onboarding.lua:253
+#: screens/sui_onboarding.lua:259
+#: screens/sui_onboarding.lua:265
 msgid "Continue"
 msgstr "继续"
 
-#: sui_style.lua:2034
+#: features/sui_style.lua:2047
 msgid "Cool Mist"
 msgstr "冷雾"
 
-#: sui_style.lua:2346
+#: engines/sui_book_grid.lua:1899
+msgid "Corner Badge"
+msgstr "角落徽章"
+
+#: features/sui_style.lua:2359
 msgid "Could not determine packs folder"
 msgstr "无法确定包文件夹位置"
 
-#: sui_stats_windows.lua:172
+#: screens/sui_stats_windows.lua:172
 msgid "Could not open statistics database."
 msgstr "无法打开统计数据库。"
 
-#: sui_style.lua:2348
+#: features/sui_style.lua:2361
 msgid "Could not open zip (invalid format or corrupted)"
 msgstr "无法打开 .zip 文件（格式无效或已损坏）"
 
-#: sui_presets.lua:207 sui_presets.lua:230
-#: desktop_modules/module_coverdeck.lua:451
+#: modules/module_coverdeck.lua:559
+#: features/sui_presets.lua:165
+#: features/sui_presets.lua:183
 msgid "Cover Deck"
 msgstr "封面轮播"
 
-#: sui_menu.lua:2783
+#: screens/sui_menu.lua:2857
 msgid "Cover Settings"
 msgstr "封面设置"
 
-#: desktop_modules/module_collections.lua:900
-#: desktop_modules/module_collections.lua:902
-#: desktop_modules/module_tbr.lua:746 desktop_modules/module_tbr.lua:748
+#: engines/sui_book_grid.lua:1743
+#: engines/sui_book_grid.lua:1745
 msgid "Cover Size"
 msgstr "封面大小"
 
-#: desktop_modules/module_currently.lua:1038
-#: desktop_modules/module_currently.lua:1040
+#: modules/module_currently.lua:1363
+#: modules/module_currently.lua:1364
 msgid "Cover Spacing"
 msgstr "封面间距"
 
-#: desktop_modules/module_collections.lua:778
+#: modules/module_collections.lua:1350
+msgid "Cover Style"
+msgstr "封面样式"
+
+#: modules/module_collections.lua:378
 msgid "Cover for \"%s\""
 msgstr "“%s”的封面"
 
-#: desktop_modules/module_recent.lua:515 desktop_modules/module_recent.lua:517
-#: desktop_modules/module_coverdeck.lua:1097
-#: desktop_modules/module_coverdeck.lua:1098
-#: desktop_modules/module_new_books.lua:339
-#: desktop_modules/module_new_books.lua:341
-#: desktop_modules/module_currently.lua:1011
-#: desktop_modules/module_currently.lua:1012
+#: modules/module_coverdeck.lua:1160
+#: modules/module_coverdeck.lua:1161
+#: modules/module_currently.lua:1336
+#: modules/module_currently.lua:1337
 msgid "Cover size"
 msgstr "封面大小"
 
-#: desktop_modules/module_coverdeck.lua:89
+#: modules/module_coverdeck.lua:174
 msgid "Covers"
 msgstr "封面"
 
-#: sui_foldercovers.lua:752 sui_browsemeta.lua:1092
+#: screens/sui_settings_window.lua:1118
+#: features/library/sui_group_actions.lua:114
 msgid "Create"
 msgstr "创建"
 
-#: sui_quickactions.lua:1448 sui_quickactions.lua:2623
+#: features/sui_quickactions.lua:1557
+#: features/sui_quickactions.lua:2844
 msgid "Create Quick Action"
 msgstr "创建快捷操作"
 
-#: sui_foldercovers.lua:965 sui_foldercovers.lua:1249 sui_browsemeta.lua:1395
+#: screens/sui_settings_window.lua:1101
+msgid "Create Screen"
+msgstr "创建屏幕"
+
+#: features/library/sui_foldercovers.lua:726
+#: features/library/sui_library_browse.lua:819
+#: features/library/sui_series_grouping.lua:369
 msgid "Create collection"
 msgstr "创建收藏夹"
 
-#: sui_stats_windows.lua:2183 sui_stats_windows.lua:2203
+#: screens/sui_settings_window.lua:1108
+msgid "Create screen"
+msgstr "创建屏幕"
+
+#: screens/sui_stats_windows.lua:2188
+#: screens/sui_stats_windows.lua:2208
 msgid "Current streak"
 msgstr "当前连续纪录"
 
-#: sui_presets.lua:137 sui_presets.lua:172
-#: desktop_modules/module_currently.lua:285
-#: desktop_modules/module_currently.lua:286
-#: desktop_modules/module_currently.lua:408
-#: desktop_modules/module_currently.lua:1477
+#: modules/module_currently.lua:331
+#: modules/module_currently.lua:332
+#: modules/module_currently.lua:413
+#: modules/module_currently.lua:1841
+#: features/sui_presets.lua:138
+#: features/sui_presets.lua:150
 msgid "Currently Reading"
 msgstr "正在阅读"
 
-#: sui_config.lua:1304
+#: infra/sui_config.lua:1836
 msgid "Custom"
 msgstr "自定义"
 
-#: sui_quickactions.lua:1678 sui_quickactions.lua:1681
+#: features/sui_quickactions.lua:1836
+#: features/sui_quickactions.lua:1839
 msgid "Custom Actions"
 msgstr "自定义操作"
 
-#: desktop_modules/module_quote.lua:1404
+#: modules/module_quote.lua:1456
 msgid "Custom File"
 msgstr "自定义文件"
 
-#: desktop_modules/module_quote.lua:1453
+#: modules/module_quote.lua:1505
 msgid "Custom File + My Highlights"
 msgstr "自定义文件 + 我的高亮标注"
 
-#: sui_config.lua:172 sui_menu.lua:634 sui_menu.lua:900
+#: features/sui_quickactions.lua:1450
+#: features/sui_quickactions.lua:1554
+msgid "Custom Quick Actions"
+msgstr "自定义快捷操作"
+
+#: infra/sui_custom_screens.lua:158
+msgid "Custom Screen"
+msgstr "自定义屏幕"
+
+#: features/sui_quickactions.lua:1846
+#: features/sui_quickactions.lua:1849
+msgid "Custom Screens"
+msgstr "自定义屏幕"
+
+#: screens/sui_settings_window.lua:393
+msgid "Custom Screens unavailable."
+msgstr "自定义屏幕不可用。"
+
+#: infra/sui_config.lua:173
+#: screens/sui_menu.lua:648
+#: screens/sui_menu.lua:914
 msgid "Custom Text"
 msgstr "自定义文字"
 
-#: sui_onboarding.lua:172
+#: screens/sui_onboarding.lua:172
 msgid "Custom wallpapers and icons"
 msgstr "自定义壁纸和图标"
 
-#: sui_onboarding.lua:164
+#: screens/sui_onboarding.lua:164
 msgid "Customize even more"
 msgstr "更多自定义设置"
 
-#: sui_stats_windows.lua:2737 sui_stats_windows.lua:3383
+#: screens/sui_stats_windows.lua:2742
+#: screens/sui_stats_windows.lua:3388
 msgid "DAY STREAK"
 msgstr "连续天数"
 
-#: desktop_modules/module_reading_goals.lua:875
-#: desktop_modules/module_reading_goals.lua:903
-#: desktop_modules/module_reading_goals.lua:940
-#: desktop_modules/module_reading_goals.lua:985
+#: modules/module_reading_goals.lua:860
+#: modules/module_reading_goals.lua:888
+#: modules/module_reading_goals.lua:925
+#: modules/module_reading_goals.lua:970
 msgid "Daily Goal"
 msgstr "每日目标"
 
-#: desktop_modules/module_reading_goals.lua:439
+#: modules/module_reading_goals.lua:430
 msgid "Daily Reading Goal"
 msgstr "每日阅读目标"
 
-#: desktop_modules/module_reading_stats.lua:89
+#: modules/module_reading_stats.lua:119
 msgid "Daily avg — Pages"
 msgstr "日均 — 页数"
 
-#: desktop_modules/module_reading_stats.lua:88
+#: modules/module_reading_stats.lua:118
 msgid "Daily avg — Time"
 msgstr "日均 — 时间"
 
-#: sui_menu.lua:2913 sui_menu.lua:2918 sui_menu.lua:2967 sui_menu.lua:2972
-#: sui_menu.lua:3021 sui_menu.lua:3026 sui_menu.lua:3088 sui_menu.lua:3093
-#: sui_menu.lua:3155 sui_menu.lua:3160 sui_menu.lua:3309 sui_menu.lua:3321
-#: desktop_modules/module_collections.lua:959
+#: modules/module_collections.lua:1425
+#: engines/sui_book_grid.lua:1870
+#: screens/sui_menu.lua:2987
+#: screens/sui_menu.lua:2992
+#: screens/sui_menu.lua:3041
+#: screens/sui_menu.lua:3046
+#: screens/sui_menu.lua:3095
+#: screens/sui_menu.lua:3100
+#: screens/sui_menu.lua:3162
+#: screens/sui_menu.lua:3167
+#: screens/sui_menu.lua:3229
+#: screens/sui_menu.lua:3234
+#: screens/sui_menu.lua:3383
+#: screens/sui_menu.lua:3395
 msgid "Dark"
 msgstr "深色"
 
-#: sui_style.lua:2020
+#: features/sui_style.lua:2033
 msgid "Dark Slate"
 msgstr "深石板灰"
 
-#: desktop_modules/module_clock.lua:879 desktop_modules/module_clock.lua:887
+#: modules/module_clock.lua:1060
+#: modules/module_clock.lua:1068
 msgid "Date Spacing"
 msgstr "日期间距"
 
-#: sui_stats_windows.lua:723
+#: modules/module_library.lua:215
+msgid "Date added (newest)"
+msgstr "添加日期（最新）"
+
+#: modules/module_library.lua:216
+msgid "Date added (oldest)"
+msgstr "添加日期（最早）"
+
+#: screens/sui_stats_windows.lua:728
 msgid "Date finished"
 msgstr "完成日期"
 
-#: sui_stats_windows.lua:716
+#: screens/sui_stats_windows.lua:721
 msgid "Date started"
 msgstr "开始日期"
 
-#: sui_stats_windows.lua:950 sui_stats_windows.lua:3675
+#: screens/sui_stats_windows.lua:955
+#: screens/sui_stats_windows.lua:3682
 msgid "Days"
 msgstr "天"
 
-#: desktop_modules/module_coverdeck.lua:79
-#: desktop_modules/module_currently.lua:250
+#: modules/module_coverdeck.lua:164
+#: modules/module_currently.lua:287
 msgid "Days of reading"
 msgstr "阅读天数"
 
-#: sui_stats_windows.lua:2837 desktop_modules/module_clock.lua:62
+#: modules/module_clock.lua:63
+#: screens/sui_stats_windows.lua:2842
 msgid "December"
 msgstr "12月"
 
-#: sui_quickactions.lua:1900 sui_quickactions.lua:2157 sui_titlebar.lua:996
-#: sui_menu.lua:451 sui_menu.lua:580 sui_menu.lua:1260 sui_menu.lua:1786
-#: desktop_modules/module_reading_goals.lua:1051
-#: desktop_modules/module_currently.lua:1525
+#: modules/module_reading_goals.lua:1039
+#: modules/module_currently.lua:1387
+#: modules/module_currently.lua:1878
+#: features/sui_quickactions.lua:2068
+#: features/sui_quickactions.lua:2333
+#: screens/sui_titlebar.lua:1003
+#: screens/sui_menu.lua:465
+#: screens/sui_menu.lua:594
+#: screens/sui_menu.lua:1277
+#: screens/sui_menu.lua:1836
 msgid "Default"
 msgstr "默认"
 
-#: sui_quickactions.lua:2158
+#: features/sui_quickactions.lua:2334
 msgid "Default (Folder)"
 msgstr "默认（文件夹）"
 
-#: sui_quickactions.lua:2159
+#: features/sui_quickactions.lua:2335
 msgid "Default (Plugin)"
 msgstr "默认（插件）"
 
-#: sui_quickactions.lua:2160
+#: features/sui_quickactions.lua:2336
 msgid "Default (System)"
 msgstr "默认（系统）"
 
-#: desktop_modules/module_quote.lua:1340
+#: modules/module_quote.lua:1392
 msgid "Default Quotes"
 msgstr "默认名言"
 
-#: sui_style.lua:184
+#: features/sui_style.lua:184
 msgid "Default: Folder"
 msgstr "默认：文件夹"
 
-#: sui_style.lua:202
+#: features/sui_style.lua:202
 msgid "Default: Group"
 msgstr "默认：分组"
 
-#: sui_style.lua:190
+#: features/sui_style.lua:190
 msgid "Default: Plugin"
 msgstr "默认：插件"
 
-#: sui_style.lua:196
+#: features/sui_style.lua:196
 msgid "Default: System"
 msgstr "默认：系统"
 
-#: sui_quickactions.lua:1415 sui_quickactions.lua:2710
-#: sui_quickactions.lua:2715 sui_menu.lua:4050 sui_menu.lua:4053
-#: sui_menu.lua:4094 sui_window.lua:1790 sui_window.lua:2632
-#: sui_presets.lua:928 sui_presets.lua:931 sui_presets.lua:971
-#: sui_settings_window.lua:352 sui_settings_window.lua:468
+#: engines/sui_window.lua:1926
+#: engines/sui_window.lua:2826
+#: features/sui_quickactions.lua:1520
+#: features/sui_quickactions.lua:2935
+#: features/sui_quickactions.lua:2940
+#: features/sui_presets.lua:876
+#: features/sui_presets.lua:879
+#: features/sui_presets.lua:919
+#: screens/sui_menu.lua:4080
+#: screens/sui_menu.lua:4083
+#: screens/sui_menu.lua:4124
+#: screens/sui_settings_window.lua:469
+#: screens/sui_settings_window.lua:514
+#: screens/sui_settings_window.lua:643
+#: features/library/sui_book_hold_dialog.lua:151
 msgid "Delete"
 msgstr "删除"
 
-#: sui_menu.lua:4423
+#: screens/sui_menu.lua:4453
 msgid "Delete Settings"
 msgstr "删除设置"
 
-#: sui_menu.lua:4052 sui_menu.lua:4093 sui_presets.lua:930 sui_presets.lua:970
+#: screens/sui_settings_window.lua:467
+msgid "Delete \"%s\"? This removes its layout, modules and Quick Action."
+msgstr "删除“%s”？这将移除其布局、模块和快捷操作。"
+
+#: features/sui_presets.lua:878
+#: features/sui_presets.lua:918
+#: screens/sui_menu.lua:4082
+#: screens/sui_menu.lua:4123
 msgid "Delete preset \"%s\"?"
 msgstr "删除预设“%s”？"
 
-#: sui_quickactions.lua:1414 sui_quickactions.lua:2714
+#: features/sui_quickactions.lua:1519
+#: features/sui_quickactions.lua:2939
 msgid "Delete quick action \"%s\"?"
 msgstr "删除快捷操作“%s”？"
 
-#: sui_quickactions.lua:1964
+#: modules/module_currently.lua:284
+msgid "Description"
+msgstr "描述"
+
+#: features/sui_quickactions.lua:2132
 msgid "Dictionary Lookup"
 msgstr "词典查询"
 
-#: desktop_modules/module_clock.lua:831 desktop_modules/module_clock.lua:835
+#: modules/module_clock.lua:1002
+#: modules/module_clock.lua:1006
 msgid "Digital"
 msgstr "数字"
 
-#: sui_menu.lua:2438
+#: screens/sui_menu.lua:2488
 msgid "Disable \"Lock Scale\" first to set a custom label scale."
 msgstr "请先禁用“锁定缩放比例”以设置自定义标签缩放。"
 
-#: sui_config.lua:838
+#: infra/sui_config.lua:870
 msgid "Disable \"Lock Scale\" first to set a per-module scale."
-msgstr "请先禁用\"锁定比例\"以设置每个模块的比例。"
+msgstr "请先禁用“锁定比例”以设置每个模块的比例。"
 
-#: sui_config.lua:170
+#: infra/sui_config.lua:171
 msgid "Disk Usage"
 msgstr "磁盘使用"
 
-#: sui_quickactions.lua:2765
+#: features/sui_quickactions.lua:2990
 msgid "Dispatcher not available."
 msgstr "调度器不可用。"
 
-#: sui_menu.lua:3479
+#: screens/sui_menu.lua:3553
 msgid "Display"
 msgstr "显示"
 
-#: sui_window.lua:67
+#: engines/sui_window.lua:67
 msgid "Do something"
 msgstr "执行操作"
 
-#: sui_quickactions.lua:2408
+#: features/sui_quickactions.lua:2584
 msgid "Done"
 msgstr "完成"
 
-#: sui_menu.lua:488
+#: screens/sui_menu.lua:502
 msgid "Dot Pager"
 msgstr "点分页器"
 
-#: sui_updater.lua:499
+#: infra/sui_updater.lua:526
 msgid "Download and install"
 msgstr "下载并安装"
 
-#: sui_updater.lua:498
+#: infra/sui_updater.lua:525
 msgid "Download and install now?"
 msgstr "是否立即下载并安装？"
 
-#: sui_updater.lua:420
+#: infra/sui_updater.lua:447
 msgid "Download error: "
 msgstr "下载错误："
 
-#: sui_updater.lua:394
+#: infra/sui_updater.lua:421
 msgid "Downloading Simple UI %s…"
 msgstr "正在下载 Simple UI %s…"
 
-#: sui_quickactions.lua:2699
+#: modules/module_currently.lua:1390
+msgid "Dynamic"
+msgstr "动态"
+
+#: features/sui_quickactions.lua:2922
 msgid "Edit"
 msgstr "编辑"
 
-#: sui_menu.lua:626 sui_menu.lua:628 sui_menu.lua:894
+#: screens/sui_menu.lua:640
+#: screens/sui_menu.lua:642
+#: screens/sui_menu.lua:908
 msgid "Edit Custom Text"
 msgstr "编辑自定义文字"
 
-#: sui_menu.lua:2146 sui_settings_window.lua:312
-msgid "Edit Layout"
-msgstr "编辑布局"
+#: screens/sui_menu.lua:2196
+#: screens/sui_settings_window.lua:338
+msgid "Edit Home Screen Layout"
+msgstr "编辑主屏幕布局"
 
-#: sui_quickactions.lua:2083
+#: features/sui_quickactions.lua:2251
 msgid "Edit Quick Action"
 msgstr "编辑快捷操作"
 
-#: desktop_modules/module_clock.lua:199 desktop_modules/module_clock.lua:248
+#: modules/module_clock.lua:239
 msgid "Eight"
 msgstr "八"
 
-#: desktop_modules/module_clock.lua:209 desktop_modules/module_clock.lua:251
+#: modules/module_clock.lua:242
 msgid "Eighteen"
 msgstr "十八"
 
-#: desktop_modules/module_clock.lua:202 desktop_modules/module_clock.lua:249
+#: modules/module_clock.lua:240
 msgid "Eleven"
 msgstr "十一"
 
-#: sui_menu.lua:887
+#: screens/sui_menu.lua:901
 msgid "Empty"
 msgstr "空"
 
-#: sui_quickactions.lua:853 sui_quickactions.lua:871 sui_quickactions.lua:889
+#: features/sui_quickactions.lua:887
+#: features/sui_quickactions.lua:905
+#: features/sui_quickactions.lua:923
 msgid "Enable 'Browse by Author / Series / Tags' in the library menu first."
 msgstr "请先在书库菜单中启用「按作者/系列/标签浏览」。"
 
-#: sui_menu.lua:2734
+#: screens/sui_menu.lua:2808
 msgid "Enable Browse by Author / Series / Tags"
 msgstr "启用按作者/系列/标签浏览"
 
-#: sui_menu.lua:2718
+#: screens/sui_menu.lua:2792
 msgid "Enable Library Custom Covers"
 msgstr "启用书库自定义封面"
 
-#: sui_menu.lua:1100
+#: screens/sui_menu.lua:1117
 msgid "Enable Navigation Bar"
 msgstr "启用导航栏"
 
-#: sui_quicksettings_bar.lua:1172
+#: screens/sui_quicksettings_bar.lua:1172
 msgid "Enable Quick Settings Bar"
 msgstr "启用快捷设置栏"
 
-#: sui_menu.lua:834
+#: screens/sui_menu.lua:848
 msgid "Enable Status Bar"
 msgstr "启用状态栏"
 
-#: sui_menu.lua:1736
+#: screens/sui_menu.lua:1786
 msgid "Enable Title Bar"
 msgstr "启用标题栏"
 
-#: sui_menu.lua:2194
+#: screens/sui_menu.lua:2244
 msgid "Enable Wallpaper"
 msgstr "启用壁纸"
 
-#: sui_style.lua:1769
+#: features/sui_style.lua:1782
 msgid "Enable custom UI font"
 msgstr "启用自定义 UI 字体"
 
-#: sui_style.lua:2102
-msgid ""
-"Enter a hex color (#RRGGBB). On greyscale e-ink the perceived brightness is "
-"used."
+#: features/sui_style.lua:2115
+msgid "Enter a hex color (#RRGGBB). On greyscale e-ink the perceived brightness is used."
 msgstr "输入十六进制颜色值（#RRGGBB）。灰度电子墨水屏将使用感知亮度。"
 
-#: sui_quickactions.lua:1842
-msgid ""
-"Enter the Unicode codepoint (hex) of a Nerd Fonts symbol.\n"
-"You can look up codes with wakamaifondue.com using the file:\n"
-"  /koreader/fonts/nerdfonts/symbols.ttf\n"
-"Leave blank and press OK to remove a Nerd Font icon."
-msgstr ""
-"输入 Nerd Fonts 符号的 Unicode 码点（十六进制）。\n"
-"您可以使用 wakamaifondue.com 查看代码，使用文件：\n"
-" /koreader/fonts/nerdfonts/symbols.ttf\n"
-"留空并按确定可移除 Nerd Font 图标。"
+#: features/sui_quickactions.lua:2010
+msgid "Enter the Unicode codepoint (hex) of a Nerd Fonts symbol.\nYou can look up codes with wakamaifondue.com using the file:\n  /koreader/fonts/nerdfonts/symbols.ttf\nLeave blank and press OK to remove a Nerd Font icon."
+msgstr "输入 Nerd Fonts 符号的 Unicode 码点（十六进制）。\n您可以使用 wakamaifondue.com 查看代码，使用文件：\n  /koreader/fonts/nerdfonts/symbols.ttf\n留空并按确定可移除 Nerd Font 图标。"
 
-#: sui_menu.lua:3811
+#: screens/sui_menu.lua:3843
 msgid "Error applying pack:"
 msgstr "应用包时出错："
 
-#: sui_updater.lua:621
+#: infra/sui_updater.lua:648
 msgid "Error checking for updates."
 msgstr "检查更新时出错。"
 
-#: sui_updater.lua:626
+#: infra/sui_updater.lua:653
 msgid "Error checking for updates: "
 msgstr "检查更新时出错："
 
-#: sui_menu.lua:4232 sui_presets.lua:1109
+#: features/sui_presets.lua:1057
+#: screens/sui_menu.lua:4262
 msgid "Error exporting preset: "
 msgstr "导出预设时出错："
 
-#: sui_style.lua:2395
+#: features/sui_style.lua:2408
 msgid "Error extracting zip: "
 msgstr "解压 .zip 文件时出错："
 
-#: sui_menu.lua:4199 sui_presets.lua:1077
+#: features/sui_presets.lua:1025
+#: screens/sui_menu.lua:4229
 msgid "Error importing preset: "
 msgstr "导入预设时出错："
 
-#: desktop_modules/module_reading_goals.lua:757
+#: modules/module_reading_goals.lua:741
 msgid "Error in Reading Goals: check crash.log"
 msgstr "阅读目标出错：请查看 crash.log"
 
-#: sui_menu.lua:3772
+#: screens/sui_menu.lua:3804
 msgid "Error installing pack:"
 msgstr "安装包时出错："
 
-#: sui_stats_windows.lua:1221
+#: screens/sui_stats_windows.lua:1226
 msgid "Exclude from goals"
 msgstr "不计入阅读目标"
 
-#: sui_stats_windows.lua:841 sui_stats_windows.lua:847
+#: screens/sui_stats_windows.lua:846
+#: screens/sui_stats_windows.lua:852
 msgid "Excluded"
 msgstr "已排除"
 
-#: sui_menu.lua:4215 sui_presets.lua:1093
+#: features/sui_presets.lua:1041
+#: screens/sui_menu.lua:4245
 msgid "Export preset"
 msgstr "导出预设"
 
-#: sui_menu.lua:556
+#: screens/sui_settings_window.lua:349
+#: screens/sui_settings_window.lua:1021
+msgid "Extra Custom Screens"
+msgstr "额外自定义屏幕"
+
+#: screens/sui_menu.lua:570
 msgid "Extra Small"
 msgstr "超小"
 
-#: sui_updater.lua:421
+#: infra/sui_updater.lua:448
 msgid "Extraction error: "
 msgstr "提取错误："
 
-#: sui_stats_windows.lua:3493
+#: screens/sui_stats_windows.lua:3500
 msgid "FREEZES"
 msgstr "冻结次数"
 
-#: sui_menu.lua:4416
+#: screens/sui_menu.lua:4446
 msgid "Factory Reset"
 msgstr "恢复出厂设置"
 
-#: sui_menu.lua:3188
+#: screens/sui_menu.lua:3262
 msgid "Fade Finished Books"
 msgstr "淡化已读完的书籍"
 
-#: sui_menu.lua:3204
+#: screens/sui_menu.lua:3278
 msgid "Fade Intensity"
 msgstr "淡化强度"
 
-#: sui_menu.lua:3205
-msgid ""
-"Fades finished book covers towards white.\n"
-"50% is the default."
-msgstr ""
-"将已读完的书籍封面向白色淡化。\n"
-"默认值为50%。"
+#: screens/sui_menu.lua:3279
+msgid "Fades finished book covers towards white.\n50% is the default."
+msgstr "将已读完的书籍封面向白色淡化。\n默认值为50%。"
 
-#: sui_menu.lua:2338
-msgid ""
-"Fades the wallpaper towards white to improve text readability.\n"
-"0% is the default (no lightening)."
-msgstr ""
-"将壁纸向白色渐变，提升文本可读性。\n"
-"默认值为0%（无增亮）。"
+#: screens/sui_menu.lua:2388
+msgid "Fades the wallpaper towards white to improve text readability.\n0% is the default (no lightening)."
+msgstr "将壁纸向白色渐变，提升文本可读性。\n默认值为0%（无增亮）。"
 
-#: sui_quickactions.lua:729 sui_quickactions.lua:1960 sui_config.lua:123
-#: desktop_modules/module_coverdeck.lua:1167
-#: desktop_modules/module_coverdeck.lua:1196
+#: modules/module_coverdeck.lua:1246
+#: features/sui_quickactions.lua:763
+#: features/sui_quickactions.lua:2128
+#: infra/sui_config.lua:124
 msgid "Favorites"
 msgstr "收藏"
 
-#: sui_quickactions.lua:736
+#: features/sui_quickactions.lua:770
 msgid "Favorites not available."
 msgstr "收藏不可用。"
 
-#: sui_stats_windows.lua:2835 desktop_modules/module_clock.lua:60
+#: modules/module_feat_coll.lua:373
+#: modules/module_feat_coll.lua:430
+msgid "Featured Collection"
+msgstr "精选收藏夹"
+
+#: modules/module_feat_coll.lua:87
+msgid "Featured Collection — tap to configure"
+msgstr "精选收藏夹 — 点击以配置"
+
+#: modules/module_clock.lua:61
+#: screens/sui_stats_windows.lua:2840
 msgid "February"
 msgstr "2月"
 
-#: sui_quickactions.lua:385
+#: features/sui_quickactions.lua:409
 msgid "Fetching bookmarks…"
 msgstr "正在获取书签…"
 
-#: desktop_modules/module_clock.lua:206 desktop_modules/module_clock.lua:250
+#: modules/module_clock.lua:241
 msgid "Fifteen"
 msgstr "十五"
 
-#: desktop_modules/module_clock.lua:218 desktop_modules/module_clock.lua:256
+#: modules/module_clock.lua:247
 msgid "Fifty"
 msgstr "五十"
 
-#: sui_quickactions.lua:717
+#: features/sui_quickactions.lua:751
 msgid "File Manager not available."
 msgstr "文件管理器不可用。"
 
-#: sui_quickactions.lua:1962
+#: features/sui_quickactions.lua:2130
 msgid "File Search"
 msgstr "文件搜索"
 
-#: sui_style.lua:2342
+#: features/sui_style.lua:2355
 msgid "File not found: "
 msgstr "文件未找到："
 
-#: sui_menu.lua:3181
+#: modules/module_library.lua:217
+msgid "File size (largest)"
+msgstr "文件大小（最大）"
+
+#: modules/module_library.lua:218
+msgid "File size (smallest)"
+msgstr "文件大小（最小）"
+
+#: screens/sui_menu.lua:3255
 msgid "Finished Books"
 msgstr "已读完书籍"
 
-#: desktop_modules/module_clock.lua:196 desktop_modules/module_clock.lua:247
+#: modules/module_clock.lua:238
 msgid "Five"
 msgstr "五"
 
-#: desktop_modules/module_quote.lua:1532
+#: modules/module_quote.lua:1584
 msgid "Fixed Height"
 msgstr "固定高度"
 
-#: sui_menu.lua:4318 sui_quicksettings_bar.lua:1375
-#: desktop_modules/module_reading_stats.lua:751
-#: desktop_modules/module_quick_actions.lua:632
+#: modules/module_reading_stats.lua:856
+#: modules/module_quick_actions.lua:747
+#: screens/sui_menu.lua:4348
+#: screens/sui_quicksettings_bar.lua:1375
 msgid "Flat"
 msgstr "扁平"
 
-#: sui_quickactions.lua:2431
+#: modules/module_library.lua:293
+msgid "Flat Library"
+msgstr "平面书库"
+
+#: features/sui_quickactions.lua:2607
 msgid "Folder"
 msgstr "文件夹"
 
-#: sui_menu.lua:2788
+#: screens/sui_menu.lua:2862
 msgid "Folder Cover Type"
 msgstr "文件夹封面类型"
 
-#: sui_style.lua:1386
+#: features/sui_style.lua:1386
 msgid "Folder Covers"
 msgstr "文件夹封面"
 
-#: sui_style.lua:209
+#: features/sui_style.lua:209
 msgid "Folder Covers: Empty Folder"
 msgstr "文件夹封面：空文件夹"
 
-#: sui_menu.lua:3225
+#: screens/sui_menu.lua:3299
 msgid "Folder Name"
 msgstr "文件夹名称"
 
-#: sui_menu.lua:3334
+#: screens/sui_menu.lua:3408
 msgid "Folder Name Text Size"
 msgstr "文件夹名称文字大小"
 
-#: sui_quickactions.lua:1963
+#: features/sui_quickactions.lua:2131
 msgid "Folder Shortcuts"
 msgstr "文件夹快捷方式"
 
-#: sui_foldercovers.lua:835 sui_foldercovers.lua:892 sui_browsemeta.lua:1197
+#: features/library/sui_foldercovers.lua:647
+#: features/library/sui_library_browse.lua:366
+#: features/library/sui_series_grouping.lua:87
+#: features/library/sui_group_actions.lua:80
 msgid "Folder cover"
 msgstr "文件夹封面"
 
-#: sui_window.lua:2047 sui_window.lua:2052
+#: engines/sui_book_grid.lua:1869
+msgid "Follow Library"
+msgstr "跟随书库"
+
+#: engines/sui_window.lua:2233
+#: engines/sui_window.lua:2238
 msgid "Font weight"
 msgstr "字体粗细"
 
-#: desktop_modules/module_clock.lua:217 desktop_modules/module_clock.lua:256
+#: modules/module_clock.lua:247
 msgid "Forty"
 msgstr "四十"
 
-#: desktop_modules/module_clock.lua:195 desktop_modules/module_clock.lua:247
+#: modules/module_clock.lua:238
 msgid "Four"
 msgstr "四"
 
-#: desktop_modules/module_clock.lua:205 desktop_modules/module_clock.lua:250
+#: modules/module_clock.lua:241
 msgid "Fourteen"
 msgstr "十四"
 
-#: desktop_modules/module_collections.lua:911
-#: desktop_modules/module_recent.lua:543 desktop_modules/module_tbr.lua:757
-#: desktop_modules/module_reading_goals.lua:1071
-#: desktop_modules/module_new_books.lua:360
-#: desktop_modules/module_currently.lua:1479
+#: modules/module_reading_goals.lua:1059
+#: modules/module_currently.lua:1843
+#: engines/sui_book_grid.lua:1825
 msgid "Frame"
 msgstr "边框框架"
 
-#: sui_menu.lua:1272 sui_menu.lua:4329
+#: screens/sui_menu.lua:1289
+#: screens/sui_menu.lua:4359
 msgid "Framed"
 msgstr "有边框"
 
-#: desktop_modules/module_reading_stats.lua:830
-#: desktop_modules/module_reading_stats.lua:835
+#: modules/module_reading_stats.lua:935
+#: modules/module_reading_stats.lua:940
 msgid "Freezes"
 msgstr "冻结"
 
-#: sui_stats_windows.lua:3097
-msgid ""
-"Freezes can only cover a single missed day, and only right after an active "
-"one. Tap yesterday's cell to use one, when eligible."
-msgstr ""
-"冻结只能补一天，且必须是紧接着的有效阅读日。符合条件时，点击昨天的格子即可使"
-"用。"
+#: screens/sui_stats_windows.lua:3102
+msgid "Freezes can only cover a single missed day, and only right after an active one. Tap yesterday's cell to use one, when eligible."
+msgstr "冻结只能补一天，且必须是紧接着的有效阅读日。符合条件时，点击昨天的格子即可使用。"
 
-#: sui_stats_windows.lua:2825
+#: screens/sui_stats_windows.lua:2830
 msgid "Fri"
 msgstr "星期五"
 
-#: desktop_modules/module_clock.lua:57
+#: modules/module_clock.lua:58
 msgid "Friday"
 msgstr "星期五"
 
-#: sui_quicksettings_bar.lua:396 sui_quicksettings_bar.lua:418
+#: screens/sui_quicksettings_bar.lua:396
+#: screens/sui_quicksettings_bar.lua:418
 msgid "Frontlight"
 msgstr "前光灯"
 
-#: sui_quicksettings_bar.lua:1270
+#: screens/sui_quicksettings_bar.lua:1270
 msgid "Frontlight Slider"
 msgstr "前光灯滑块"
 
-#: sui_quickactions.lua:355
+#: features/sui_quickactions.lua:373
 msgid "Frontlight not available on this device."
 msgstr "此设备不支持前光。"
 
-#: sui_menu.lua:2516
+#: screens/sui_menu.lua:2566
 msgid "Gesture Only"
 msgstr "仅手势"
 
-#: sui_menu.lua:4282 sui_menu.lua:4289
+#: screens/sui_menu.lua:4312
+#: screens/sui_menu.lua:4319
 msgid "Global Text Size"
 msgstr "全局字体大小"
 
-#: sui_settings_window.lua:283
-msgid "Global custom quick actions"
-msgstr "全局自定义快捷操作"
+#: screens/sui_settings_window.lua:311
+msgid "Global custom actions & icons"
+msgstr "全局自定义操作与图标"
 
-#: sui_settings_window.lua:284
-msgid "Global custom quick actions  (%d/%d)"
-msgstr "全局自定义快捷操作（%d/%d）"
+#: screens/sui_menu.lua:4320
+msgid "Global scale applied to all of KOReader's interface text — menus, dialogs, titles, and Simple UI. It does not change the book's reading font size, which has its own setting.\n100% is the default size. Useful when a chosen UI font (see UI Font above) renders smaller or larger than usual."
+msgstr "作用于 KOReader 所有界面文字的全局缩放比例，包括菜单、对话框、标题及 Simple UI。不影响书籍正文的阅读字体大小（其有独立设置）。\n默认大小为100%。当所选 UI 字体（见上方「UI 字体」）显示偏大或偏小时，可通过此项调整。"
 
-#: sui_menu.lua:4290
-msgid ""
-"Global scale applied to all of KOReader's interface text — menus, dialogs, "
-"titles, and Simple UI. It does not change the book's reading font size, "
-"which has its own setting.\n"
-"100% is the default size. Useful when a chosen UI font (see UI Font above) "
-"renders smaller or larger than usual."
-msgstr ""
-"作用于 KOReader 所有界面文字的全局缩放比例，包括菜单、对话框、标题及 Simple "
-"UI。不影响书籍正文的阅读字体大小（其有独立设置）。\n"
-"默认大小为100%。当所选 UI 字体（见上方「UI 字体」）显示偏大或偏小时，可通过此项"
-"调整。"
+#: screens/sui_menu.lua:2460
+msgid "Global scale for all modules.\nIndividual overrides in Module Settings take precedence.\n100% is the default size."
+msgstr "所有模块的全局比例。\n模块设置中的单独覆盖将优先。\n默认大小为100%。"
 
-#: sui_menu.lua:2410
-msgid ""
-"Global scale for all modules.\n"
-"Individual overrides in Module Settings take precedence.\n"
-"100% is the default size."
-msgstr ""
-"所有模块的全局比例。\n"
-"模块设置中的单独覆盖将优先。\n"
-"默认大小为100%。"
-
-#: sui_onboarding.lua:165
+#: screens/sui_onboarding.lua:165
 msgid "Go to Settings > Home Screen to edit your layout whenever you want."
 msgstr "随时前往「主屏幕」编辑您的布局。"
 
-#: desktop_modules/module_reading_goals.lua:832
-#: desktop_modules/module_reading_goals.lua:897
-#: desktop_modules/module_reading_goals.lua:911
+#: modules/module_reading_goals.lua:817
+#: modules/module_reading_goals.lua:882
+#: modules/module_reading_goals.lua:896
 msgid "Goals"
 msgstr "目标"
 
-#: sui_quickactions.lua:2094 sui_quickactions.lua:2414
+#: engines/sui_book_grid.lua:1777
+#: engines/sui_book_grid.lua:1788
+msgid "Grid size"
+msgstr "网格大小"
+
+#: features/sui_quickactions.lua:2262
+#: features/sui_quickactions.lua:2590
 msgid "Group"
 msgstr "分组"
 
-#: sui_menu.lua:2770
+#: screens/sui_menu.lua:2844
 msgid "Group by Book Series"
 msgstr "按书籍系列分组"
 
-#: sui_quickactions.lua:2439
+#: features/sui_quickactions.lua:2615
 msgid "Group of Quick Actions"
 msgstr "快捷操作分组"
 
-#: sui_quickactions.lua:2421
+#: features/sui_quickactions.lua:2597
 msgid "Group: select actions"
 msgstr "分组：选择操作"
 
-#: sui_menu.lua:1307
-msgid ""
-"Height of the bottom navigation bar.\n"
-"100% is the default size."
-msgstr ""
-"底部导航栏的高度。\n"
-"默认大小为100%。"
+#: modules/module_currently.lua:1398
+msgid "Grows or shrinks the cover so its height always matches the text column, keeping the cover's proportions.\nThe spacing between cover and text stays as set above.\nThe Cover size setting still applies on top of this, and the cover never shrinks below its 100% size."
+msgstr "根据文字栏高度自动放大或缩小封面，并保持封面比例。\n封面与文字之间的间距保持为上述设置。\n“封面大小”设置仍在此基础上叠加生效，且封面永远不会小于其 100% 大小。"
 
-#: desktop_modules/module_spacer.lua:89
-msgid ""
-"Height of the spacer.\n"
-"100% is the default size."
-msgstr ""
-"间隔元件的高度。\n"
-"默认大小为100%。"
+#: screens/sui_menu.lua:1324
+msgid "Height of the bottom navigation bar.\n100% is the default size."
+msgstr "底部导航栏的高度。\n默认大小为100%。"
 
-#: sui_menu.lua:1030
-msgid ""
-"Height of the top status bar.\n"
-"100% is the default size."
-msgstr ""
-"顶部状态栏的高度。\n"
-"默认大小为100%。"
+#: modules/module_spacer.lua:89
+msgid "Height of the spacer.\n100% is the default size."
+msgstr "间隔元件的高度。\n默认大小为100%。"
 
-#: sui_menu.lua:472 sui_menu.lua:531 sui_menu.lua:2865 sui_menu.lua:2872
-#: sui_menu.lua:2899 sui_menu.lua:2939 sui_menu.lua:2945 sui_menu.lua:2956
-#: sui_menu.lua:2993 sui_menu.lua:2999 sui_menu.lua:3010 sui_menu.lua:3231
-#: sui_menu.lua:3262 desktop_modules/module_collections.lua:932
+#: screens/sui_menu.lua:1044
+msgid "Height of the top status bar.\n100% is the default size."
+msgstr "顶部状态栏的高度。\n默认大小为100%。"
+
+#: modules/module_collections.lua:1398
+#: screens/sui_menu.lua:486
+#: screens/sui_menu.lua:545
+#: screens/sui_menu.lua:2939
+#: screens/sui_menu.lua:2946
+#: screens/sui_menu.lua:2973
+#: screens/sui_menu.lua:3013
+#: screens/sui_menu.lua:3019
+#: screens/sui_menu.lua:3030
+#: screens/sui_menu.lua:3067
+#: screens/sui_menu.lua:3073
+#: screens/sui_menu.lua:3084
+#: screens/sui_menu.lua:3305
+#: screens/sui_menu.lua:3336
 msgid "Hidden"
 msgstr "隐藏"
 
-#: sui_menu.lua:3436
+#: modules/module_collections.lua:1387
+msgid "Hide Book Spine"
+msgstr "隐藏书脊"
+
+#: screens/sui_menu.lua:3510
 msgid "Hide Folder Book Spine"
 msgstr "隐藏文件夹书脊"
 
-#: sui_menu.lua:1939 sui_quicksettings_bar.lua:1303
-#: desktop_modules/module_quick_actions.lua:387
-#: desktop_modules/module_quick_actions.lua:540
+#: modules/module_quick_actions.lua:494
+#: modules/module_quick_actions.lua:653
+#: screens/sui_menu.lua:1989
+#: screens/sui_quicksettings_bar.lua:1303
 msgid "Hide Label"
 msgstr "隐藏标签"
 
-#: sui_menu.lua:3430
+#: screens/sui_menu.lua:3504
 msgid "Hide Selection Underline"
 msgstr "隐藏选择下划线"
 
-#: sui_menu.lua:1069
+#: screens/sui_menu.lua:1086
 msgid "Hide Wi-Fi Icon When Off"
 msgstr "Wi-Fi 关闭时隐藏图标"
 
-#: sui_menu.lua:539
-msgid ""
-"Hides the pagination bar on the homescreen.\n"
-"Not available when Navpager is active."
-msgstr ""
-"隐藏主屏幕上的分页栏。\n"
-"启用导航分页器时不可用。"
+#: screens/sui_menu.lua:553
+msgid "Hides the pagination bar on the homescreen.\nNot available when Navpager is active."
+msgstr "隐藏主屏幕上的分页栏。\n启用导航分页器时不可用。"
 
-#: sui_menu.lua:2569
+#: screens/sui_menu.lua:2619
 msgid "High-Quality Cover"
 msgstr "高质量封面"
 
-#: sui_stats_windows.lua:1215 sui_stats_windows.lua:3911
+#: screens/sui_stats_windows.lua:1220
+#: screens/sui_stats_windows.lua:3918
 msgid "Highlights"
 msgstr "高亮标注"
 
-#: sui_quickactions.lua:434 sui_quickactions.lua:639 sui_quickactions.lua:1958
-#: sui_config.lua:119
+#: features/sui_quickactions.lua:457
+#: features/sui_quickactions.lua:673
+#: features/sui_quickactions.lua:2126
+#: infra/sui_config.lua:120
 msgid "History"
 msgstr "历史"
 
-#: sui_quickactions.lua:646
+#: features/sui_quickactions.lua:680
 msgid "History not available."
 msgstr "历史记录不可用。"
 
-#: sui_quickactions.lua:590 sui_config.lua:117
+#: features/sui_quickactions.lua:624
+#: infra/sui_config.lua:118
 msgid "Home"
 msgstr "主页"
 
-#: sui_menu.lua:4522 sui_patches.lua:843 sui_patches.lua:870
-#: sui_settings_window.lua:251 sui_settings_window.lua:851
+#: engines/sui_screen_engine.lua:1306
+#: infra/sui_patches.lua:1110
+#: infra/sui_patches.lua:1137
+#: screens/sui_menu.lua:4574
+#: screens/sui_settings_window.lua:282
+#: screens/sui_settings_window.lua:1020
 msgid "Home Screen"
 msgstr "主屏幕"
 
-#: sui_settings_window.lua:864
+#: screens/sui_settings_window.lua:1036
 msgid "Home Screen Presets"
 msgstr "主屏幕预设"
 
-#: sui_menu.lua:485
+#: screens/sui_menu.lua:499
 msgid "Home Screen Style"
 msgstr "主屏幕样式"
 
-#: sui_style.lua:2077
+#: features/sui_style.lua:2090
 msgid "Home Screen — Background"
 msgstr "主屏幕 — 背景"
 
-#: sui_style.lua:2080
+#: features/sui_style.lua:2093
 msgid "Home Screen — Text"
 msgstr "主屏幕 — 文本"
 
-#: sui_quickactions.lua:451
+#: features/sui_quickactions.lua:474
 msgid "Home folder"
 msgstr "主文件夹"
 
-#: sui_quickactions.lua:453
+#: features/sui_quickactions.lua:476
 msgid "Home folder + subfolders"
 msgstr "主文件夹 + 子文件夹"
 
-#: sui_homescreen.lua:1219
-msgid "Homescreen"
-msgstr "主屏幕"
-
-#: sui_quickactions.lua:621
+#: features/sui_quickactions.lua:655
 msgid "Homescreen not available."
 msgstr "主屏幕不可用。"
 
-#: desktop_modules/module_currently.lua:1041
-msgid ""
-"Horizontal space between the cover and the text.\n"
-"100% is the default spacing."
-msgstr ""
-"封面与文本之间的水平间距。\n"
-"默认间距为100%。"
+#: modules/module_currently.lua:1365
+msgid "Horizontal space between the cover and the text.\n100% is the default spacing."
+msgstr "封面与文本之间的水平间距。\n默认间距为100%。"
 
-#: desktop_modules/module_reading_goals.lua:422
+#: modules/module_reading_goals.lua:419
 msgid "Hours per month:"
 msgstr "每月小时数："
 
-#: sui_quickactions.lua:2119 sui_quickactions.lua:2123
+#: features/sui_quickactions.lua:2287
+#: features/sui_quickactions.lua:2291
 msgid "Icon"
 msgstr "图标"
 
-#: sui_menu.lua:3661
+#: screens/sui_menu.lua:3693
 msgid "Icon Packs"
 msgstr "图标包"
 
-#: sui_menu.lua:3828
+#: screens/sui_menu.lua:3860
 msgid "Icon Presets"
 msgstr "图标预设"
 
-#: sui_menu.lua:1336 sui_menu.lua:1337
+#: screens/sui_menu.lua:1356
+#: screens/sui_menu.lua:1357
 msgid "Icon Size"
 msgstr "图标大小"
 
-#: sui_quickactions.lua:2115
+#: features/sui_quickactions.lua:2283
 msgid "Icon: Default"
 msgstr "图标：默认"
 
-#: sui_menu.lua:201 sui_menu.lua:3565
+#: screens/sui_menu.lua:209
+#: screens/sui_menu.lua:3639
 msgid "Icons"
 msgstr "图标"
 
-#: sui_menu.lua:202
+#: screens/sui_menu.lua:210
 msgid "Icons only"
 msgstr "仅图标"
 
-#: sui_settings_window.lua:273
+#: screens/sui_settings_window.lua:304
 msgid "Icons, fonts and appearance"
 msgstr "图标、字体与外观"
 
-#: sui_onboarding.lua:169
-msgid ""
-"If you selected the Momentum Preset, long press the Reading Goal module to "
-"choose and set your reading goals."
-msgstr ""
-"如果您选择了「动量」预设，请长按「阅读目标」模块以选择和设置您的阅读目标。"
+#: screens/sui_onboarding.lua:169
+msgid "If you selected the Momentum Preset, long press the Reading Goal module to choose and set your reading goals."
+msgstr "如果您选择了「动量」预设，请长按「阅读目标」模块以选择和设置您的阅读目标。"
 
-#: sui_menu.lua:4171 sui_presets.lua:1050
+#: features/sui_presets.lua:998
+#: screens/sui_menu.lua:4201
 msgid "Import preset"
 msgstr "导入预设"
 
-#: sui_menu.lua:3735
+#: screens/sui_menu.lua:3767
 msgid "Install pack from ZIP"
 msgstr "从 .zip 文件安装包"
 
-#: sui_menu.lua:3197
+#: screens/sui_menu.lua:3271
 msgid "Intensity"
 msgstr "强度"
 
-#: sui_menu.lua:1465
-msgid ""
-"Invalid arrangement.\n"
-"Keep items between the Left and Right separators."
-msgstr ""
-"排序无效。\n"
-"请将项目保持在左侧和右侧分隔符之间。"
+#: screens/sui_menu.lua:1513
+msgid "Invalid arrangement.\nKeep items between the Left and Right separators."
+msgstr "排序无效。\n请将项目保持在左侧和右侧分隔符之间。"
 
-#: sui_menu.lua:727
-msgid ""
-"Invalid arrangement.\n"
-"Keep the Left, Center and Right separators in order."
-msgstr ""
-"排序无效。\n"
-"请按顺序保持左侧、居中、右侧分隔符。"
+#: screens/sui_menu.lua:741
+msgid "Invalid arrangement.\nKeep the Left, Center and Right separators in order."
+msgstr "排序无效。\n请按顺序保持左侧、居中、右侧分隔符。"
 
-#: sui_presets.lua:418 sui_presets.lua:598
+#: features/sui_presets.lua:366
+#: features/sui_presets.lua:546
 msgid "Invalid data"
 msgstr "无效数据"
 
-#: sui_quickactions.lua:1877
+#: features/sui_quickactions.lua:2045
 msgid "Invalid input. Please enter 1–6 hexadecimal digits (0–9, A–F)."
 msgstr "输入无效。请输入 1–6 个十六进制数字（0–9、A–F）。"
 
-#: sui_presets.lua:414 sui_presets.lua:594
+#: features/sui_presets.lua:362
+#: features/sui_presets.lua:542
 msgid "Invalid preset file"
 msgstr "无效的预设文件"
 
-#: sui_menu.lua:2312
+#: screens/sui_menu.lua:2362
 msgid "Invert in Night Mode"
 msgstr "夜间模式下反转颜色"
 
-#: sui_menu.lua:853 sui_menu.lua:858 sui_menu.lua:947 sui_menu.lua:1949
-#: sui_menu.lua:1954 sui_menu.lua:1980
-#: desktop_modules/module_reading_stats.lua:613
-#: desktop_modules/module_reading_stats.lua:634
-#: desktop_modules/module_reading_stats.lua:656
-#: desktop_modules/module_coverdeck.lua:1337
-#: desktop_modules/module_coverdeck.lua:1377
-#: desktop_modules/module_coverdeck.lua:1391
-#: desktop_modules/module_currently.lua:1178
-#: desktop_modules/module_currently.lua:1183
-#: desktop_modules/module_currently.lua:1206
+#: modules/module_reading_stats.lua:718
+#: modules/module_reading_stats.lua:739
+#: modules/module_reading_stats.lua:761
+#: modules/module_coverdeck.lua:1411
+#: modules/module_coverdeck.lua:1451
+#: modules/module_coverdeck.lua:1465
+#: modules/module_currently.lua:1531
+#: modules/module_currently.lua:1536
+#: modules/module_currently.lua:1559
+#: screens/sui_menu.lua:867
+#: screens/sui_menu.lua:872
+#: screens/sui_menu.lua:961
+#: screens/sui_menu.lua:1999
+#: screens/sui_menu.lua:2004
+#: screens/sui_menu.lua:2030
 msgid "Items"
 msgstr "项目"
 
-#: sui_stats_windows.lua:2835 desktop_modules/module_clock.lua:60
+#: modules/module_clock.lua:61
+#: screens/sui_stats_windows.lua:2840
 msgid "January"
 msgstr "1月"
 
-#: sui_stats_windows.lua:2836 desktop_modules/module_clock.lua:61
+#: modules/module_clock.lua:62
+#: screens/sui_stats_windows.lua:2841
 msgid "July"
 msgstr "7月"
 
-#: sui_stats_windows.lua:2836 desktop_modules/module_clock.lua:61
+#: modules/module_clock.lua:62
+#: screens/sui_stats_windows.lua:2841
 msgid "June"
 msgstr "6月"
 
-#: sui_menu.lua:509
+#: modules/module_quick_actions.lua:762
+msgid "Justified"
+msgstr "两端对齐"
+
+#: screens/sui_menu.lua:523
 msgid "KOReader"
 msgstr "KOReader"
 
-#: sui_stats_windows.lua:2739
+#: screens/sui_stats_windows.lua:2744
 msgid "LAST 7 DAYS"
 msgstr "最近7天"
 
-#: sui_quicksettings_bar.lua:1292 desktop_modules/module_quick_actions.lua:557
+#: modules/module_quick_actions.lua:670
+#: screens/sui_quicksettings_bar.lua:1292
 msgid "Label"
 msgstr "标签"
 
-#: sui_menu.lua:2446
+#: screens/sui_menu.lua:2496
 msgid "Label Scale"
 msgstr "标签比例"
 
-#: sui_menu.lua:1346 sui_menu.lua:1347
+#: screens/sui_menu.lua:1366
+#: screens/sui_menu.lua:1367
 msgid "Label Size"
 msgstr "标签大小"
 
-#: sui_menu.lua:2430
+#: screens/sui_menu.lua:2480
 msgid "Labels"
 msgstr "标签"
 
-#: sui_menu.lua:1787
+#: screens/sui_menu.lua:1837
 msgid "Large"
 msgstr "大"
 
-#: sui_menu.lua:436 sui_menu.lua:843 sui_menu.lua:1048 sui_menu.lua:1109
-#: sui_menu.lua:1325 sui_menu.lua:1751 sui_menu.lua:3362 sui_menu.lua:3385
-#: sui_menu.lua:3407 sui_menu.lua:4304 sui_menu.lua:4506
-#: sui_quicksettings_bar.lua:1186 sui_updater.lua:432
+#: infra/sui_updater.lua:459
+#: screens/sui_menu.lua:450
+#: screens/sui_menu.lua:857
+#: screens/sui_menu.lua:1065
+#: screens/sui_menu.lua:1126
+#: screens/sui_menu.lua:1345
+#: screens/sui_menu.lua:1801
+#: screens/sui_menu.lua:3436
+#: screens/sui_menu.lua:3459
+#: screens/sui_menu.lua:3481
+#: screens/sui_menu.lua:4334
+#: screens/sui_menu.lua:4558
+#: screens/sui_quicksettings_bar.lua:1186
 msgid "Later"
 msgstr "稍后"
 
-#: desktop_modules/module_reading_goals.lua:1049
+#: modules/module_reading_goals.lua:1037
+#: modules/module_currently.lua:1384
 msgid "Layout"
 msgstr "布局"
 
-#: sui_settings_window.lua:856
+#: screens/sui_settings_window.lua:1027
+#: screens/sui_settings_window.lua:1028
 msgid "Layout Editor"
 msgstr "布局编辑"
 
-#: sui_settings_window.lua:252
-msgid "Layout, wallpaper and behaviour"
-msgstr "布局、壁纸与行为"
+#: screens/sui_settings_window.lua:283
+msgid "Layout, wallpaper, presets and behaviour"
+msgstr "布局、壁纸、预设与行为"
 
-#: sui_menu.lua:696 sui_menu.lua:933 sui_menu.lua:1437 sui_menu.lua:1639
-#: desktop_modules/module_quote.lua:126 desktop_modules/module_quote.lua:1511
-#: desktop_modules/module_action_list.lua:73
-#: desktop_modules/module_action_list.lua:591
-#: desktop_modules/module_reading_stats.lua:66
-#: desktop_modules/module_reading_stats.lua:777
-#: desktop_modules/module_clock.lua:115 desktop_modules/module_clock.lua:856
+#: modules/module_quote.lua:126
+#: modules/module_quote.lua:1563
+#: modules/module_action_list.lua:73
+#: modules/module_action_list.lua:601
+#: modules/module_reading_stats.lua:96
+#: modules/module_reading_stats.lua:882
+#: modules/module_clock.lua:144
+#: modules/module_clock.lua:1034
+#: modules/module_quick_actions.lua:772
+#: screens/sui_menu.lua:710
+#: screens/sui_menu.lua:947
+#: screens/sui_menu.lua:1478
+#: screens/sui_menu.lua:1689
 msgid "Left"
 msgstr "左侧"
 
-#: sui_quickactions.lua:563 sui_titlebar.lua:1078 sui_config.lua:116
-#: sui_config.lua:368 sui_menu.lua:4526 sui_settings_window.lua:265
-#: sui_settings_window.lua:853
+#: features/sui_quickactions.lua:597
+#: infra/sui_config.lua:117
+#: infra/sui_config.lua:376
+#: screens/sui_titlebar.lua:1089
+#: screens/sui_menu.lua:4578
+#: screens/sui_settings_window.lua:296
+#: screens/sui_settings_window.lua:1023
 msgid "Library"
 msgstr "书库"
 
-#: sui_menu.lua:1759 sui_menu.lua:1762
+#: screens/sui_menu.lua:1809
+#: screens/sui_menu.lua:1812
 msgid "Library Buttons"
 msgstr "书库按钮"
 
-#: sui_presets.lua:229
+#: features/sui_presets.lua:182
 msgid "Library View"
 msgstr "书库视图"
 
-#: sui_menu.lua:2913 sui_menu.lua:2925 sui_menu.lua:2967 sui_menu.lua:2979
-#: sui_menu.lua:3021 sui_menu.lua:3033 sui_menu.lua:3088 sui_menu.lua:3100
-#: sui_menu.lua:3155 sui_menu.lua:3167 sui_menu.lua:3309 sui_menu.lua:3314
-#: desktop_modules/module_collections.lua:966
+#: modules/module_collections.lua:1432
+#: engines/sui_book_grid.lua:1871
+#: screens/sui_menu.lua:2987
+#: screens/sui_menu.lua:2999
+#: screens/sui_menu.lua:3041
+#: screens/sui_menu.lua:3053
+#: screens/sui_menu.lua:3095
+#: screens/sui_menu.lua:3107
+#: screens/sui_menu.lua:3162
+#: screens/sui_menu.lua:3174
+#: screens/sui_menu.lua:3229
+#: screens/sui_menu.lua:3241
+#: screens/sui_menu.lua:3383
+#: screens/sui_menu.lua:3388
 msgid "Light"
 msgstr "浅色"
 
-#: sui_menu.lua:2324
+#: screens/sui_menu.lua:2374
 msgid "Lighten"
 msgstr "增亮"
 
-#: sui_menu.lua:2337
+#: screens/sui_menu.lua:2387
 msgid "Lighten Wallpaper"
 msgstr "壁纸增亮"
 
-#: desktop_modules/module_reading_stats.lua:761
+#: modules/module_reading_stats.lua:866
 msgid "List"
 msgstr "列表"
 
-#: sui_stats_windows.lua:2499
+#: screens/sui_stats_windows.lua:2504
 msgid "Loading statistics…"
 msgstr "正在加载统计数据…"
 
-#: sui_menu.lua:2389
+#: screens/sui_menu.lua:2439
 msgid "Lock Scale"
 msgstr "锁定比例"
 
-#: sui_onboarding.lua:160
+#: infra/sui_config.lua:1106
+msgid "Long Press"
+msgstr "长按"
+
+#: screens/sui_onboarding.lua:160
 msgid "Long press to customize"
 msgstr "长按以自定义"
 
-#: sui_presets.lua:397 sui_presets.lua:409 sui_presets.lua:577
-#: sui_presets.lua:589
+#: features/sui_presets.lua:345
+#: features/sui_presets.lua:357
+#: features/sui_presets.lua:525
+#: features/sui_presets.lua:537
 msgid "LuaSettings module unavailable"
 msgstr "LuaSettings 模块不可用"
 
-#: sui_onboarding.lua:126
+#: screens/sui_onboarding.lua:126
 msgid "Make it yours"
 msgstr "打造成您的专属样式"
 
-#: sui_menu.lua:2656
-msgid ""
-"Makes the device's physical Home button always open the SimpleUI Home Screen "
-"— while reading and while browsing files — instead of KOReader's native Home "
-"behaviour."
-msgstr ""
-"使设备的实体主页键始终打开 SimpleUI 主屏幕——无论是在阅读还是浏览文件时——而"
-"非 KOReader 原生的主页行为。"
+#: screens/sui_menu.lua:2706
+msgid "Makes the device's physical Home button always open the SimpleUI Home Screen — while reading and while browsing files — instead of KOReader's native Home behaviour."
+msgstr "使设备的实体主页键始终打开 Simple UI 主屏幕 — 无论是在阅读还是浏览文件时 — 而非 KOReader 原生的主页行为。"
 
-#: sui_menu.lua:3999 sui_menu.lua:4073 sui_menu.lua:4078 sui_presets.lua:875
-#: sui_presets.lua:951 sui_presets.lua:956
+#: features/sui_presets.lua:823
+#: features/sui_presets.lua:899
+#: features/sui_presets.lua:904
+#: screens/sui_menu.lua:4029
+#: screens/sui_menu.lua:4103
+#: screens/sui_menu.lua:4108
 msgid "Manage presets"
 msgstr "管理预设"
 
-#: desktop_modules/module_reading_goals.lua:1042
+#: modules/module_collections.lua:534
+msgid "Manual order"
+msgstr "手动排序"
+
+#: modules/module_reading_goals.lua:1027
 msgid "Manually Tracked Books"
 msgstr "手动导入的书籍"
 
-#: desktop_modules/module_reading_goals.lua:1030
+#: modules/module_reading_goals.lua:1015
 msgid "Manually Tracked Books  (%s)"
 msgstr "手动导入的书籍（%s）"
 
-#: sui_stats_windows.lua:2835 desktop_modules/module_clock.lua:60
+#: modules/module_clock.lua:61
+#: screens/sui_stats_windows.lua:2840
 msgid "March"
 msgstr "3月"
 
-#: sui_quicksettings_bar.lua:443 sui_quicksettings_bar.lua:549
+#: screens/sui_quicksettings_bar.lua:443
+#: screens/sui_quicksettings_bar.lua:549
 msgid "Max"
 msgstr "最大值"
 
-#: desktop_modules/module_collections.lua:872
-#: desktop_modules/module_collections.lua:1012
-msgid "Maximum 5 collections. Remove one first."
-msgstr "最多 5 个收藏夹。请先删除一个。"
-
-#: sui_quicksettings_bar.lua:1248
+#: screens/sui_quicksettings_bar.lua:1248
 msgid "Maximum slots reached."
 msgstr "已达最大槽位数量。"
 
-#: sui_stats_windows.lua:2836 desktop_modules/module_clock.lua:61
+#: modules/module_clock.lua:62
+#: screens/sui_stats_windows.lua:2841
 msgid "May"
 msgstr "5月"
 
-#: sui_titlebar.lua:102 sui_titlebar.lua:107
+#: screens/sui_titlebar.lua:102
+#: screens/sui_titlebar.lua:107
 msgid "Menu"
 msgstr "菜单"
 
-#: sui_style.lua:88
+#: features/sui_style.lua:88
 msgid "Menu Button"
 msgstr "菜单按钮"
 
-#: desktop_modules/module_clock.lua:222 desktop_modules/module_clock.lua:304
+#: modules/module_clock.lua:295
 msgid "Midnight"
 msgstr "午夜蓝"
 
-#: sui_presets.lua:171
+#: features/sui_presets.lua:149
 msgid "Mindful Reading"
 msgstr "正念阅读"
 
-#: sui_menu.lua:360
+#: screens/sui_menu.lua:374
 msgid "Minimum 1 tab required in navpager mode."
 msgstr "导航页模式至少需要 1 个标签。"
 
-#: sui_menu.lua:361
+#: screens/sui_menu.lua:375
 msgid "Minimum 2 tabs required. Select another tab first."
 msgstr "至少需要 2 个标签。请先选择另一个标签。"
 
-#: desktop_modules/module_reading_goals.lua:440
+#: modules/module_reading_goals.lua:431
 msgid "Minutes per day:"
 msgstr "每天分钟数："
 
-#: sui_menu.lua:448
+#: screens/sui_menu.lua:462
 msgid "Mode"
 msgstr "模式"
 
-#: sui_menu.lua:2407
+#: screens/sui_menu.lua:2457
 msgid "Module Scale"
 msgstr "模块比例"
 
-#: sui_menu.lua:2153
+#: infra/sui_config.lua:1103
+#: screens/sui_menu.lua:2203
 msgid "Module Settings"
 msgstr "模块设置"
 
-#: sui_menu.lua:3665
+#: screens/sui_menu.lua:3697
 msgid "Module unavailable"
 msgstr "模块不可用"
 
-#: sui_menu.lua:2400 sui_menu.lua:2653
+#: screens/sui_menu.lua:2450
+#: screens/sui_menu.lua:2725
 msgid "Modules"
 msgstr "模块"
 
-#: sui_menu.lua:2141
+#: screens/sui_menu.lua:2191
 msgid "Modules  (%d)"
 msgstr "模块（%d）"
 
-#: sui_homescreen.lua:2496
-msgid ""
-"Modules exceed the visible area.\n"
-"Move some to another page or adjust the scale."
-msgstr ""
-"模块超出可见区域。\n"
-"请将部分模块移至其他页面，或调整缩放比例。"
+#: engines/sui_screen_engine.lua:2745
+msgid "Modules exceed the visible area.\nMove some to another page or adjust the scale."
+msgstr "模块超出可见区域。\n请将部分模块移至其他页面，或调整缩放比例。"
 
-#: sui_presets.lua:206
+#: features/sui_presets.lua:164
 msgid "Momentum"
 msgstr "动量"
 
-#: sui_stats_windows.lua:2825
+#: screens/sui_stats_windows.lua:2830
 msgid "Mon"
 msgstr "星期一"
 
-#: desktop_modules/module_clock.lua:56
+#: modules/module_clock.lua:57
 msgid "Monday"
 msgstr "星期一"
 
-#: desktop_modules/module_reading_goals.lua:855
-#: desktop_modules/module_reading_goals.lua:902
-#: desktop_modules/module_reading_goals.lua:939
-#: desktop_modules/module_reading_goals.lua:970
+#: modules/module_reading_goals.lua:840
+#: modules/module_reading_goals.lua:887
+#: modules/module_reading_goals.lua:924
+#: modules/module_reading_goals.lua:955
 msgid "Monthly Goal"
 msgstr "月度目标"
 
-#: desktop_modules/module_reading_goals.lua:421
+#: modules/module_reading_goals.lua:418
 msgid "Monthly Reading Goal"
 msgstr "月度阅读目标"
 
-#: main.lua:1059
+#: main.lua:1088
 msgid "More by %s (%d)"
 msgstr "更多 %s 的作品（%d）"
 
-#: sui_window.lua:2618
+#: engines/sui_window.lua:2812
 msgid "Move down"
 msgstr "下移"
 
-#: sui_window.lua:2612 sui_settings_window.lua:487 sui_settings_window.lua:523
+#: engines/sui_window.lua:2806
+#: screens/sui_settings_window.lua:662
+#: screens/sui_settings_window.lua:698
 msgid "Move to page"
 msgstr "移至页面"
 
-#: sui_window.lua:2615
+#: engines/sui_window.lua:2809
 msgid "Move up"
 msgstr "上移"
 
-#: sui_quickactions.lua:22
+#: features/sui_quickactions.lua:22
 msgid "My Action"
 msgstr "我的操作"
 
-#: desktop_modules/module_quote.lua:1360
+#: modules/module_quote.lua:1412
 msgid "My Highlights"
 msgstr "我的高亮标注"
 
-#: sui_presets.lua:765 sui_presets.lua:770
+#: features/sui_presets.lua:713
+#: features/sui_presets.lua:718
 msgid "My Presets"
 msgstr "我的预设"
 
-#: sui_quickactions.lua:2202
+#: features/sui_quickactions.lua:2378
 msgid "Name"
 msgstr "名称"
 
-#: sui_foldercovers.lua:298 sui_menu.lua:3049 sui_menu.lua:3058
-#: sui_menu.lua:3070
+#: modules/module_collections.lua:535
+msgid "Name (A–Z)"
+msgstr "名称（A–Z）"
+
+#: modules/module_collections.lua:536
+msgid "Name (Z–A)"
+msgstr "名称（Z–A）"
+
+#: screens/sui_menu.lua:3123
+#: screens/sui_menu.lua:3132
+#: screens/sui_menu.lua:3144
+#: features/library/sui_foldercovers.lua:314
 msgid "Native"
 msgstr "原生"
 
-#: sui_menu.lua:2687
+#: screens/sui_menu.lua:2761
+#: screens/sui_bottombar.lua:890
 msgid "Navigation Bar"
 msgstr "导航栏"
 
-#: sui_menu.lua:1306
+#: screens/sui_menu.lua:1323
 msgid "Navigation Bar Size"
 msgstr "导航栏大小"
 
-#: sui_menu.lua:1108
-msgid ""
-"Navigation Bar will be %s after restart.\n"
-"\n"
-"Restart now?"
-msgstr ""
-"重启后导航栏将变为 %s。\n"
-"\n"
-"是否立即重启？"
+#: screens/sui_menu.lua:1125
+msgid "Navigation Bar will be %s after restart.\n\nRestart now?"
+msgstr "重启后导航栏将变为 %s。\n\n是否立即重启？"
 
-#: sui_menu.lua:461 sui_style.lua:1385
+#: features/sui_style.lua:2091
+msgid "Navigation Bar — Background"
+msgstr "导航栏 — 背景"
+
+#: features/sui_style.lua:2094
+msgid "Navigation Bar — Text and Icons"
+msgstr "导航栏 — 文字与图标"
+
+#: features/sui_style.lua:1385
+#: screens/sui_menu.lua:475
 msgid "Navpager"
 msgstr "导航页"
 
-#: sui_menu.lua:468
-msgid ""
-"Navpager enabled.\n"
-"\n"
-"Restart now?"
-msgstr ""
-"导航分页器已启用。\n"
-"\n"
-"是否立即重启？"
+#: screens/sui_menu.lua:482
+msgid "Navpager enabled.\n\nRestart now?"
+msgstr "导航分页器已启用。\n\n是否立即重启？"
 
-#: sui_style.lua:168
+#: features/sui_style.lua:168
 msgid "Navpager: Next"
 msgstr "导航分页器：下一页"
 
-#: sui_style.lua:162
+#: features/sui_style.lua:162
 msgid "Navpager: Previous"
 msgstr "导航分页器：上一页"
 
-#: sui_quickactions.lua:1839
+#: features/sui_quickactions.lua:2007
 msgid "Nerd Font Icon"
 msgstr "Nerd Font 图标"
 
-#: sui_quickactions.lua:1910
+#: features/sui_quickactions.lua:2078
 msgid "Nerd Font symbol…"
 msgstr "Nerd Font 符号…"
 
-#: sui_quickactions.lua:221
+#: features/sui_quickactions.lua:236
 msgid "Network manager unavailable."
 msgstr "网络管理器不可用。"
 
-#: sui_menu.lua:2527
+#: screens/sui_menu.lua:2577
 msgid "Never"
 msgstr "从不"
 
-#: sui_foldercovers.lua:2436 sui_foldercovers.lua:3115
-#: desktop_modules/module_new_books.lua:216
+#: modules/module_new_books.lua:138
+#: engines/sui_book_grid.lua:535
+#: features/library/sui_foldercovers.lua:1263
+#: features/library/sui_foldercovers.lua:1911
+#: features/library/sui_cover_widgets.lua:421
 msgid "New"
 msgstr "新"
 
-#: sui_menu.lua:3112
+#: engines/sui_book_grid.lua:2026
+msgid "New Badge Color"
+msgstr "新徽章颜色"
+
+#: screens/sui_menu.lua:3186
 msgid "New Book"
 msgstr "新书"
 
-#: desktop_modules/module_new_books.lua:50
-#: desktop_modules/module_new_books.lua:51
-#: desktop_modules/module_new_books.lua:130
-#: desktop_modules/module_new_books.lua:381
+#: engines/sui_book_grid.lua:2018
+#: engines/sui_book_grid.lua:2031
+msgid "New Book Badge"
+msgstr "新书徽章"
+
+#: modules/module_new_books.lua:83
+#: modules/module_new_books.lua:84
 msgid "New Books"
 msgstr "新书"
 
-#: sui_quickactions.lua:2083
+#: features/sui_quickactions.lua:2251
 msgid "New Quick Action"
 msgstr "新建快捷操作"
 
-#: sui_foldercovers.lua:743 sui_browsemeta.lua:1081
+#: features/library/sui_group_actions.lua:105
 msgid "New collection name"
 msgstr "新的收藏夹名字"
 
-#: sui_bottombar.lua:569
+#: screens/sui_bottombar.lua:569
 msgid "Next"
 msgstr "下一页"
 
-#: sui_quickactions.lua:792 sui_config.lua:127
+#: features/sui_quickactions.lua:826
+#: infra/sui_config.lua:128
 msgid "Night Mode"
 msgstr "夜间模式"
 
-#: desktop_modules/module_clock.lua:200 desktop_modules/module_clock.lua:248
+#: modules/module_clock.lua:239
 msgid "Nine"
 msgstr "九"
 
-#: desktop_modules/module_clock.lua:210 desktop_modules/module_clock.lua:252
+#: modules/module_clock.lua:243
 msgid "Nineteen"
 msgstr "十九"
 
-#: sui_stats_windows.lua:1222
+#: screens/sui_stats_windows.lua:1227
 msgid "No"
 msgstr "取消"
 
-#: desktop_modules/module_quote.lua:1417 desktop_modules/module_quote.lua:1466
+#: modules/module_quote.lua:1469
+#: modules/module_quote.lua:1518
 msgid "No .lua files found in sui_quotes/"
 msgstr "sui_quotes 文件夹中未找到 .lua 文件"
 
-#: sui_menu.lua:3753
-msgid ""
-"No .zip files found.\n"
-"Place .zip files in:\n"
-"%1"
-msgstr ""
-"未找到 .zip 文件。\n"
-"请将 .zip 文件放入：\n"
-"%1"
+#: screens/sui_menu.lua:3785
+msgid "No .zip files found.\nPlace .zip files in:\n%1"
+msgstr "未找到 .zip 文件。\n请将 .zip 文件放入：\n%1"
 
-#: sui_quicksettings_bar.lua:1204 sui_quicksettings_bar.lua:1224
+#: screens/sui_quicksettings_bar.lua:1204
+#: screens/sui_quicksettings_bar.lua:1224
 msgid "No actions active yet."
 msgstr "未配置任何操作。"
 
-#: sui_quickactions.lua:1447 sui_settings_window.lua:453
-#: desktop_modules/module_action_list.lua:108
-#: desktop_modules/module_action_list.lua:135
-#: desktop_modules/module_quick_actions.lua:90
+#: modules/module_action_list.lua:108
+#: modules/module_action_list.lua:135
+#: modules/module_quick_actions.lua:166
+#: features/sui_quickactions.lua:1556
+#: screens/sui_settings_window.lua:615
 msgid "No actions configured"
 msgstr "未配置任何操作"
 
-#: desktop_modules/module_action_list.lua:107
-#: desktop_modules/module_action_list.lua:134
-#: desktop_modules/module_quick_actions.lua:89
+#: modules/module_action_list.lua:107
+#: modules/module_action_list.lua:134
+#: modules/module_quick_actions.lua:165
 msgid "No actions configured  —  long press to configure"
 msgstr "未配置任何操作 — 长按以配置"
 
-#: sui_quicksettings_bar.lua:355
-msgid ""
-"No actions configured.\n"
-"Go to Bars → Quick Settings Bar."
+#: screens/sui_quicksettings_bar.lua:355
+msgid "No actions configured.\nGo to Bars → Quick Settings Bar."
 msgstr "未配置任何操作，请前往「快捷设置栏」进行配置"
 
-#: sui_quickactions.lua:672
+#: features/sui_quickactions.lua:706
 msgid "No book in history."
 msgstr "历史记录中没有书籍。"
 
-#: desktop_modules/module_coll_row.lua:205 desktop_modules/module_coll_row.lua:229
-#: desktop_modules/module_coll_row.lua:298
-msgid "No books in this collection."
-msgstr "此收藏夹中没有书籍。"
-
-#: sui_stats_windows.lua:786
+#: screens/sui_stats_windows.lua:791
 msgid "No books finished in %s"
 msgstr "%s 年尚未读完任何书籍"
 
-#: sui_foldercovers.lua:850
+#: features/library/sui_foldercovers.lua:651
 msgid "No books found in this folder."
 msgstr "在此文件夹中未找到书籍。"
 
-#: sui_foldercovers.lua:736 sui_foldercovers.lua:793
+#: features/library/sui_series_grouping.lua:91
+#: features/library/sui_series_grouping.lua:104
 msgid "No books found in this series."
 msgstr "未在此系列中找到书籍。"
 
-#: sui_browsemeta.lua:1150
+#: features/library/sui_library_browse.lua:370
+#: features/library/sui_library_browse.lua:392
+#: features/library/sui_group_actions.lua:38
+#: features/library/sui_group_actions.lua:96
 msgid "No books found."
 msgstr "未找到书籍。"
 
-#: desktop_modules/module_tbr.lua:621 desktop_modules/module_tbr.lua:646
-#: desktop_modules/module_tbr.lua:721
+#: modules/module_tbr.lua:367
+#: modules/module_tbr.lua:392
+#: modules/module_tbr.lua:467
 msgid "No books in To Be Read list."
 msgstr "待读列表中暂无书籍。"
 
-#: sui_homescreen.lua:406
+#: modules/module_feat_coll.lua:260
+#: modules/module_feat_coll.lua:284
+#: modules/module_feat_coll.lua:353
+msgid "No books in this collection."
+msgstr "此收藏夹中没有书籍。"
+
+#: engines/sui_screen_engine.lua:391
 msgid "No books opened yet"
 msgstr "尚未打开任何书籍"
 
-#: sui_settings_window.lua:465 desktop_modules/module_coll_row.lua:358
+#: modules/module_feat_coll.lua:410
+#: screens/sui_settings_window.lua:627
 msgid "No collection selected"
 msgstr "未选择收藏夹"
 
-#: desktop_modules/module_coll_row.lua:357
+#: modules/module_feat_coll.lua:409
 msgid "No collection selected  —  long press to configure"
 msgstr "未选择收藏夹 — 长按以配置"
 
-#: desktop_modules/module_coverdeck.lua:1151
+#: modules/module_coverdeck.lua:1216
 msgid "No collections found"
 msgstr "未找到收藏夹"
 
-#: desktop_modules/module_collections.lua:976
+#: modules/module_collections.lua:1456
+#: modules/module_feat_coll.lua:136
 msgid "No collections found."
 msgstr "未找到收藏夹。"
 
-#: desktop_modules/module_collections.lua:431
+#: modules/module_collections.lua:1541
 msgid "No collections selected"
 msgstr "未选择收藏夹"
 
-#: desktop_modules/module_collections.lua:430
+#: modules/module_collections.lua:1540
 msgid "No collections selected  —  long press to configure"
 msgstr "未选择任何收藏夹 — 长按以配置"
 
-#: desktop_modules/module_quote.lua:878
-msgid ""
-"No custom quotes found. Add a .lua file to the plugin's sui_quotes/ folder "
-"and select it in Settings."
-msgstr ""
-"未找到自定义名言。请将 .lua 文件添加到插件的 sui_quotes 文件夹中，然后在设置"
-"中选择它。"
+#: modules/module_quote.lua:929
+msgid "No custom quotes found. Add a .lua file to the plugin's sui_quotes/ folder and select it in Settings."
+msgstr "未找到自定义名言。请将 .lua 文件添加到插件的 sui_quotes 文件夹中，然后在设置中选择它。"
 
-#: sui_updater.lua:481
-msgid ""
-"No download file found.\n"
-"\n"
-"Open the releases page?"
-msgstr ""
-"未找到下载文件。\n"
-"\n"
-"是否打开发布页面？"
+#: screens/sui_settings_window.lua:400
+msgid "No custom screens yet."
+msgstr "暂无自定义屏幕。"
 
-#: sui_presets.lua:389 sui_presets.lua:569
+#: infra/sui_updater.lua:508
+msgid "No download file found.\n\nOpen the releases page?"
+msgstr "未找到下载文件。\n\n是否打开发布页面？"
+
+#: features/sui_presets.lua:337
+#: features/sui_presets.lua:517
 msgid "No export directory"
 msgstr "未指定导出目录"
 
-#: sui_stats_windows.lua:159
+#: screens/sui_stats_windows.lua:159
 msgid "No filepath."
 msgstr "未提供文件路径。"
 
-#: sui_quickactions.lua:2804
-msgid ""
-"No folder, collection or plugin configured.\n"
-"Go to Simple UI → Settings → Quick Actions to set one."
-msgstr ""
-"未配置文件夹、收藏夹或插件。\n"
-"请前往「快捷操作」进行配置。"
+#: features/sui_quickactions.lua:3068
+msgid "No folder, collection or plugin configured.\nGo to Simple UI → Settings → Quick Actions to set one."
+msgstr "未配置文件夹、收藏夹或插件。\n请前往「快捷操作」进行配置。"
 
-#: sui_style.lua:1784
+#: features/sui_style.lua:1797
 msgid "No fonts found."
 msgstr "未找到字体。"
 
-#: desktop_modules/module_quote.lua:950
+#: modules/module_quote.lua:1001
 msgid "No highlights found. Open a book and highlight some passages."
 msgstr "未找到高亮标注，请打开一本书并划选一些段落。"
 
-#: sui_quickactions.lua:1923
+#: features/sui_quickactions.lua:2091
 msgid "No icons found in:"
 msgstr "未在以下位置找到图标："
 
-#: sui_window.lua:2312 sui_window.lua:2911
+#: engines/sui_window.lua:2506
+#: engines/sui_window.lua:3111
 msgid "No items available."
 msgstr "没有可用项目。"
 
-#: sui_menu.lua:871 sui_menu.lua:949 sui_menu.lua:1135 sui_menu.lua:1186
-#: sui_menu.lua:1548 sui_menu.lua:1655 sui_menu.lua:1957 sui_menu.lua:1982
-#: sui_window.lua:2821 desktop_modules/module_collections.lua:818
-#: desktop_modules/module_collections.lua:843
-#: desktop_modules/module_action_list.lua:478
-#: desktop_modules/module_action_list.lua:503
-#: desktop_modules/module_reading_stats.lua:637
-#: desktop_modules/module_reading_stats.lua:658
-#: desktop_modules/module_reading_goals.lua:905
-#: desktop_modules/module_reading_goals.lua:912
-#: desktop_modules/module_coverdeck.lua:1385
-#: desktop_modules/module_coverdeck.lua:1393
-#: desktop_modules/module_currently.lua:1200
-#: desktop_modules/module_currently.lua:1284
-#: desktop_modules/module_currently.lua:1416
-#: desktop_modules/module_currently.lua:1459
-#: desktop_modules/module_quick_actions.lua:405
-#: desktop_modules/module_quick_actions.lua:430
+#: modules/module_collections.lua:1228
+#: modules/module_collections.lua:1246
+#: modules/module_action_list.lua:483
+#: modules/module_action_list.lua:508
+#: modules/module_reading_stats.lua:742
+#: modules/module_reading_stats.lua:763
+#: modules/module_reading_goals.lua:890
+#: modules/module_reading_goals.lua:897
+#: modules/module_coverdeck.lua:1459
+#: modules/module_coverdeck.lua:1467
+#: modules/module_currently.lua:1553
+#: modules/module_currently.lua:1637
+#: modules/module_currently.lua:1769
+#: modules/module_currently.lua:1812
+#: modules/module_quick_actions.lua:512
+#: modules/module_quick_actions.lua:537
+#: engines/sui_window.lua:3021
+#: screens/sui_menu.lua:885
+#: screens/sui_menu.lua:963
+#: screens/sui_menu.lua:1152
+#: screens/sui_menu.lua:1203
+#: screens/sui_menu.lua:1598
+#: screens/sui_menu.lua:1705
+#: screens/sui_menu.lua:2007
+#: screens/sui_menu.lua:2032
 msgid "No items selected."
 msgstr "未选中任何项目。"
 
-#: sui_settings_window.lua:372 sui_settings_window.lua:534
+#: screens/sui_settings_window.lua:534
+#: screens/sui_settings_window.lua:709
 msgid "No modules"
 msgstr "无模块"
 
-#: sui_settings_window.lua:520
+#: screens/sui_settings_window.lua:695
 msgid "No other pages available."
 msgstr "没有其他可用页面。"
 
-#: sui_menu.lua:3789
+#: screens/sui_menu.lua:3821
 msgid "No packs found."
 msgstr "未找到包。"
 
-#: sui_quickactions.lua:2297
+#: features/sui_quickactions.lua:2473
 msgid "No plugins found."
 msgstr "未找到插件。"
 
-#: sui_menu.lua:4179 sui_presets.lua:1057
-msgid ""
-"No preset files found.\n"
-"Place .lua files in:\n"
-"%1"
-msgstr ""
-"未找到预设文件。\n"
-"请将 .lua 文件放入：\n"
-"%1"
+#: features/sui_presets.lua:1005
+#: screens/sui_menu.lua:4209
+msgid "No preset files found.\nPlace .lua files in:\n%1"
+msgstr "未找到预设文件。\n请将 .lua 文件放入：\n%1"
 
-#: sui_menu.lua:4155 sui_presets.lua:1034
+#: features/sui_presets.lua:982
+#: screens/sui_menu.lua:4185
 msgid "No presets found."
 msgstr "未找到预设。"
 
-#: desktop_modules/module_quote.lua:912
+#: modules/module_quote.lua:963
 msgid "No quotes found."
 msgstr "未找到名言。"
 
-#: sui_quickactions.lua:3125
+#: features/sui_quickactions.lua:3389
 msgid "No recent books."
 msgstr "暂无最近阅读。"
 
-#: sui_stats_windows.lua:168 sui_stats_windows.lua:203
-#: sui_stats_windows.lua:3591
+#: screens/sui_stats_windows.lua:168
+#: screens/sui_stats_windows.lua:203
+#: screens/sui_stats_windows.lua:3598
 msgid "No statistics found for this book."
 msgstr "未找到此书的统计数据。"
 
-#: desktop_modules/module_coverdeck.lua:1247
+#: modules/module_coverdeck.lua:1336
 msgid "No statistics selected."
 msgstr "未选择任何统计数据。"
 
-#: desktop_modules/module_reading_stats.lua:368
+#: modules/module_reading_stats.lua:467
 msgid "No stats selected"
 msgstr "未选择统计项"
 
-#: desktop_modules/module_reading_stats.lua:367
+#: modules/module_reading_stats.lua:466
 msgid "No stats selected  —  long press to configure"
 msgstr "未选择任何统计项 — 长按以配置"
 
-#: sui_quickactions.lua:2323
+#: features/sui_quickactions.lua:2499
 msgid "No system actions found."
 msgstr "未找到系统操作。"
 
-#: sui_menu.lua:2225
+#: screens/sui_menu.lua:2275
 msgid "No wallpapers found."
 msgstr "未找到壁纸。"
 
-#: sui_quickactions.lua:2195 sui_foldercovers.lua:303 sui_menu.lua:3050
-#: sui_menu.lua:3059 sui_menu.lua:3077 sui_menu.lua:3117 sui_menu.lua:3126
-#: sui_menu.lua:3144
+#: engines/sui_book_grid.lua:1894
+#: engines/sui_book_grid.lua:2012
+#: features/sui_quickactions.lua:2371
+#: screens/sui_menu.lua:3124
+#: screens/sui_menu.lua:3133
+#: screens/sui_menu.lua:3151
+#: screens/sui_menu.lua:3191
+#: screens/sui_menu.lua:3200
+#: screens/sui_menu.lua:3218
+#: features/library/sui_foldercovers.lua:319
 msgid "None"
 msgstr "无"
 
-#: desktop_modules/module_clock.lua:223 desktop_modules/module_clock.lua:307
+#: modules/module_clock.lua:298
 msgid "Noon"
 msgstr "中午"
 
-#: desktop_modules/module_reading_goals.lua:953
-#: desktop_modules/module_reading_goals.lua:968
-#: desktop_modules/module_reading_goals.lua:983
+#: modules/module_reading_goals.lua:938
+#: modules/module_reading_goals.lua:953
+#: modules/module_reading_goals.lua:968
 msgid "Not set"
 msgstr "未设置"
 
-#: sui_stats_windows.lua:1216 sui_stats_windows.lua:3912
+#: screens/sui_stats_windows.lua:1221
+#: screens/sui_stats_windows.lua:3919
 msgid "Notes"
 msgstr "笔记"
 
-#: sui_stats_windows.lua:2837 desktop_modules/module_clock.lua:62
+#: modules/module_clock.lua:63
+#: screens/sui_stats_windows.lua:2842
 msgid "November"
 msgstr "11月"
 
-#: sui_menu.lua:2863
+#: engines/sui_book_grid.lua:1761
+#: engines/sui_book_grid.lua:1762
+msgid "Number of Books"
+msgstr "图书数量"
+
+#: screens/sui_menu.lua:2937
 msgid "Number of Books in Folder"
 msgstr "文件夹中的书籍数量"
 
-#: sui_menu.lua:2937
+#: screens/sui_menu.lua:3011
 msgid "Number of Pages"
 msgstr "页数"
 
-#: desktop_modules/module_clock.lua:226 desktop_modules/module_clock.lua:325
+#: modules/module_clock.lua:316
 msgid "O'Clock"
 msgstr "点钟"
 
-#: sui_quickactions.lua:1852
+#: features/sui_quickactions.lua:2020
 msgid "OK"
 msgstr "确定"
 
-#: sui_stats_windows.lua:2837 desktop_modules/module_clock.lua:62
+#: modules/module_clock.lua:63
+#: screens/sui_stats_windows.lua:2842
 msgid "October"
 msgstr "10月"
 
-#: sui_quickactions.lua:1544 sui_quickactions.lua:2536 sui_menu.lua:1401
-#: sui_menu.lua:1606 sui_menu.lua:3183 sui_menu.lua:3348 sui_menu.lua:4488
+#: engines/sui_book_grid.lua:1979
+#: engines/sui_book_grid.lua:2005
+#: features/sui_quickactions.lua:1655
+#: features/sui_quickactions.lua:2755
+#: screens/sui_menu.lua:1442
+#: screens/sui_menu.lua:1656
+#: screens/sui_menu.lua:3257
+#: screens/sui_menu.lua:3422
+#: screens/sui_menu.lua:4540
 msgid "Off"
 msgstr "关闭"
 
-#: desktop_modules/module_clock.lua:227 desktop_modules/module_clock.lua:270
+#: modules/module_clock.lua:261
 msgid "Oh"
 msgstr "Oh"
 
-#: sui_quickactions.lua:1543 sui_quickactions.lua:2535 sui_menu.lua:1401
-#: sui_menu.lua:1606 sui_menu.lua:4488
+#: engines/sui_book_grid.lua:1979
+#: engines/sui_book_grid.lua:2005
+#: features/sui_quickactions.lua:1654
+#: features/sui_quickactions.lua:2754
+#: screens/sui_menu.lua:1442
+#: screens/sui_menu.lua:1656
+#: screens/sui_menu.lua:4540
 msgid "On"
 msgstr "开启"
 
-#: desktop_modules/module_clock.lua:192 desktop_modules/module_clock.lua:246
+#: modules/module_clock.lua:237
 msgid "One"
 msgstr "一"
 
-#: sui_quickactions.lua:3080 sui_homescreen.lua:738 sui_stats_windows.lua:770
-#: desktop_modules/module_quote.lua:1253
+#: modules/module_quote.lua:1304
+#: engines/sui_screen_engine.lua:741
+#: features/sui_quickactions.lua:3344
+#: screens/sui_stats_windows.lua:775
 msgid "Open"
 msgstr "打开"
 
-#: sui_homescreen.lua:415
+#: modules/module_collections.lua:1111
+msgid "Open Module Settings"
+msgstr "打开模块设置"
+
+#: engines/sui_screen_engine.lua:400
 msgid "Open a book to get started"
 msgstr "打开一本书开始阅读"
 
-#: sui_updater.lua:482
+#: infra/sui_updater.lua:509
 msgid "Open in browser"
 msgstr "在浏览器中打开"
 
-#: sui_quickactions.lua:3079 sui_homescreen.lua:737 sui_stats_windows.lua:768
-#: desktop_modules/module_quote.lua:1252
+#: features/library/sui_book_hold_dialog.lua:517
+msgid "Open module settings"
+msgstr "打开模块设置"
+
+#: modules/module_quote.lua:1303
+#: engines/sui_screen_engine.lua:740
+#: features/sui_quickactions.lua:3343
+#: screens/sui_stats_windows.lua:773
 msgid "Open this file?"
 msgstr "打开这个文件吗？"
 
-#: sui_menu.lua:2607
+#: features/library/sui_book_hold_dialog.lua:387
+msgid "Open with…"
+msgstr "打开方式…"
+
+#: screens/sui_menu.lua:2657
 msgid "Overflow Warning"
 msgstr "溢出警告"
 
-#: sui_menu.lua:2827
+#: screens/sui_menu.lua:2901
 msgid "Overlays"
 msgstr "叠加层"
 
-#: sui_menu.lua:3981 sui_menu.lua:4010 sui_menu.lua:4139 sui_presets.lua:856
-#: sui_presets.lua:886 sui_presets.lua:1018
+#: features/sui_presets.lua:804
+#: features/sui_presets.lua:834
+#: features/sui_presets.lua:966
+#: screens/sui_menu.lua:4011
+#: screens/sui_menu.lua:4040
+#: screens/sui_menu.lua:4169
 msgid "Overwrite"
 msgstr "覆盖"
 
-#: sui_presets.lua:885 sui_presets.lua:1017
+#: features/sui_presets.lua:833
+#: features/sui_presets.lua:965
 msgid "Overwrite preset \"%s\" with the current homescreen settings?"
 msgstr "用当前主屏幕设置覆盖预设“%s”？"
 
-#: sui_menu.lua:4009 sui_menu.lua:4138
+#: screens/sui_menu.lua:4039
+#: screens/sui_menu.lua:4168
 msgid "Overwrite preset \"%s\" with the current icon settings?"
 msgstr "用当前图标设置覆盖预设“%s”？"
 
-#: sui_menu.lua:3805
-msgid ""
-"Pack \"%s\" applied.\n"
-"%d icons replaced."
-msgstr ""
-"包“%s”已应用。\n"
-"替换了 %d 个图标。"
+#: screens/sui_menu.lua:3837
+msgid "Pack \"%s\" applied.\n%d icons replaced."
+msgstr "包“%s”已应用。\n替换了 %d 个图标。"
 
-#: sui_menu.lua:3766
-msgid ""
-"Pack \"%s\" installed.\n"
-"You can now apply it from the list."
-msgstr ""
-"包“%s”已安装。\n"
-"您现在可以从列表中选择应用。"
+#: screens/sui_menu.lua:3798
+msgid "Pack \"%s\" installed.\nYou can now apply it from the list."
+msgstr "包“%s”已安装。\n您现在可以从列表中选择应用。"
 
-#: sui_style.lua:2400
+#: features/sui_style.lua:2413
 msgid "Pack folder not accessible: "
 msgstr "无法访问包文件夹："
 
-#: sui_homescreen.lua:1793 sui_patches.lua:1924 sui_patches.lua:2430
-#: sui_window.lua:1293
+#: engines/sui_screen_engine.lua:1970
+#: engines/sui_window.lua:1406
+#: infra/sui_patches.lua:2232
+#: infra/sui_patches.lua:2805
 msgid "Page %1 of %2"
 msgstr "第 %1 页，共 %2 页"
 
-#: sui_settings_window.lua:346 sui_settings_window.lua:496
-#: sui_settings_window.lua:870
+#: screens/sui_settings_window.lua:508
+#: screens/sui_settings_window.lua:671
+#: screens/sui_settings_window.lua:1042
 msgid "Page %d"
 msgstr "第 %d 页"
 
-#: sui_settings_window.lua:345 sui_settings_window.lua:495
-#: sui_settings_window.lua:869
+#: screens/sui_settings_window.lua:507
+#: screens/sui_settings_window.lua:670
+#: screens/sui_settings_window.lua:1041
 msgid "Page 1 (Home)"
 msgstr "第 1 页（主页）"
 
-#: sui_stats_windows.lua:952 sui_stats_windows.lua:3677
+#: screens/sui_stats_windows.lua:957
+#: screens/sui_stats_windows.lua:3684
 msgid "Pages"
 msgstr "页数"
 
-#: sui_stats_windows.lua:2417
+#: engines/sui_book_grid.lua:1961
+#: engines/sui_book_grid.lua:1977
+msgid "Pages Badge"
+msgstr "页数徽章"
+
+#: engines/sui_book_grid.lua:1972
+msgid "Pages Badge Color"
+msgstr "页数徽章颜色"
+
+#: screens/sui_stats_windows.lua:2422
 msgid "Pages per day"
 msgstr "每日页数"
 
-#: sui_stats_windows.lua:2434 sui_stats_windows.lua:2450
+#: screens/sui_stats_windows.lua:2439
+#: screens/sui_stats_windows.lua:2455
 msgid "Pages read"
 msgstr "已读页数"
 
-#: sui_menu.lua:2689 sui_style.lua:1384
+#: features/sui_style.lua:1384
+#: screens/sui_menu.lua:2763
 msgid "Pagination Bar"
 msgstr "分页栏"
 
-#: sui_menu.lua:478
-msgid ""
-"Pagination bar hidden.\n"
-"\n"
-"Restart now?"
-msgstr ""
-"分页栏已隐藏。\n"
-"\n"
-"是否立即重启？"
+#: screens/sui_menu.lua:492
+msgid "Pagination bar hidden.\n\nRestart now?"
+msgstr "分页栏已隐藏。\n\n是否立即重启？"
 
-#: sui_menu.lua:457
-msgid ""
-"Pagination bar set to Default.\n"
-"\n"
-"Restart now?"
-msgstr ""
-"分页栏已设为默认。\n"
-"\n"
-"是否立即重启？"
+#: screens/sui_menu.lua:471
+msgid "Pagination bar set to Default.\n\nRestart now?"
+msgstr "分页栏已设为默认。\n\n是否立即重启？"
 
-#: sui_menu.lua:564 sui_menu.lua:576 sui_menu.lua:588
-msgid ""
-"Pagination bar size will change after restart.\n"
-"\n"
-"Restart now?"
-msgstr ""
-"分页栏大小将在重启后改变。\n"
-"\n"
-"是否立即重启？"
+#: screens/sui_menu.lua:578
+#: screens/sui_menu.lua:590
+#: screens/sui_menu.lua:602
+msgid "Pagination bar size will change after restart.\n\nRestart now?"
+msgstr "分页栏大小将在重启后改变。\n\n是否立即重启？"
 
-#: sui_style.lua:149
+#: features/sui_style.lua:149
 msgid "Pagination: First Page"
 msgstr "分页：第一页"
 
-#: sui_style.lua:155
+#: features/sui_style.lua:155
 msgid "Pagination: Last Page"
 msgstr "分页：最后一页"
 
-#: sui_style.lua:143
+#: features/sui_style.lua:143
 msgid "Pagination: Next Page"
 msgstr "分页：下一页"
 
-#: sui_style.lua:137
+#: features/sui_style.lua:137
 msgid "Pagination: Previous Page"
 msgstr "分页：上一页"
 
-#: sui_quickactions.lua:2251
+#: features/sui_quickactions.lua:2427
 msgid "Path chooser not available."
 msgstr "路径选择器不可用。"
 
-#: sui_style.lua:2389
+#: features/sui_style.lua:2402
 msgid "Path does not exist: "
 msgstr "路径不存在："
 
-#: desktop_modules/module_tbr.lua:795
-msgid "Percentage Overlay on Cover"
-msgstr "封面上叠加百分比"
-
-#: desktop_modules/module_tbr.lua:785
-msgid "Percentage Text"
-msgstr "百分比文本"
-
-#: desktop_modules/module_recent.lua:581
-msgid "Percentage overlay on cover"
-msgstr "封面上的百分比叠加层"
-
-#: desktop_modules/module_coverdeck.lua:78
-#: desktop_modules/module_currently.lua:249
-#: desktop_modules/module_currently.lua:1159
+#: modules/module_coverdeck.lua:163
+#: modules/module_currently.lua:286
+#: modules/module_currently.lua:1512
 msgid "Percentage read"
 msgstr "已读百分比"
 
-#: desktop_modules/module_recent.lua:571
-msgid "Percentage text"
-msgstr "百分比文字"
-
-#: desktop_modules/module_reading_goals.lua:404
+#: modules/module_reading_goals.lua:407
 msgid "Physical Books — %s"
 msgstr "实体书 — %s"
 
-#: desktop_modules/module_reading_goals.lua:405
+#: modules/module_reading_goals.lua:408
 msgid "Physical books read this year:"
 msgstr "今年阅读的实体书："
 
-#: desktop_modules/module_quote.lua:1442 desktop_modules/module_quote.lua:1491
+#: modules/module_quote.lua:1494
+#: modules/module_quote.lua:1543
 msgid "Place .lua files in the plugin's sui_quotes/ folder"
 msgstr "请将 .lua 文件放入插件的 sui_quotes 文件夹中"
 
-#: sui_menu.lua:3790
+#: screens/sui_menu.lua:3822
 msgid "Place a folder or .zip in:"
 msgstr "请将文件夹或 .zip 文件放入："
 
-#: sui_menu.lua:2227
+#: screens/sui_menu.lua:2277
 msgid "Place images in:"
 msgstr "请将图片放入："
 
-#: sui_onboarding.lua:173
-msgid ""
-"Place your files in koreader/settings/simpleui/sui_wallpapers or sui_icons."
-msgstr ""
-"请将文件放入 koreader/settings/simpleui/sui_wallpapers 或 sui_icons 文件夹。"
+#: screens/sui_onboarding.lua:173
+msgid "Place your files in koreader/settings/simpleui/sui_wallpapers or sui_icons."
+msgstr "请将文件放入 koreader/settings/simpleui/sui_wallpapers 或 sui_icons 文件夹。"
 
-#: sui_menu.lua:3446
+#: screens/sui_menu.lua:3520
 msgid "Placeholder Cover for Bookless Folders"
 msgstr "空文件夹的占位封面"
 
-#: sui_stats_windows.lua:665
+#: screens/sui_stats_windows.lua:670
 msgid "Please enter a date in YYYY-MM-DD format."
 msgstr "请输入 YYYY-MM-DD 格式的日期。"
 
-#: sui_menu.lua:3960 sui_presets.lua:830
+#: features/sui_presets.lua:778
+#: screens/sui_menu.lua:3990
 msgid "Please enter a name for the preset."
 msgstr "请输入预设名称。"
 
-#: sui_quickactions.lua:2222
+#: features/sui_quickactions.lua:2398
 msgid "Please select an action."
 msgstr "请选择一个操作。"
 
-#: sui_quickactions.lua:2316 sui_quickactions.lua:2435
+#: features/sui_quickactions.lua:2492
+#: features/sui_quickactions.lua:2611
 msgid "Plugin"
 msgstr "插件"
 
-#: sui_quickactions.lua:2789
+#: features/sui_quickactions.lua:3014
 msgid "Plugin error: %s"
 msgstr "插件错误：%s"
 
-#: sui_quickactions.lua:2791
+#: features/sui_quickactions.lua:3016
 msgid "Plugin not available: %s"
 msgstr "插件不可用：%s"
 
-#: sui_menu.lua:2655
+#: screens/sui_menu.lua:2705
 msgid "PocketBook Home Button Opens Home Screen"
 msgstr "PocketBook 主页键打开主屏幕"
 
-#: sui_menu.lua:2870 sui_menu.lua:3274
+#: screens/sui_menu.lua:2944
+#: screens/sui_menu.lua:3348
 msgid "Position"
 msgstr "位置"
 
-#: sui_quickactions.lua:822 sui_config.lua:129
+#: features/sui_quickactions.lua:856
+#: infra/sui_config.lua:130
 msgid "Power"
 msgstr "电源"
 
-#: sui_menu.lua:2581
+#: screens/sui_menu.lua:2631
 msgid "Preserve Cover Proportions"
 msgstr "保持封面比例"
 
-#: sui_menu.lua:2632
+#: screens/sui_menu.lua:2682
 msgid "Preserve Deleted Books in Statistics"
 msgstr "删除书籍后仍保留统计"
 
-#: sui_menu.lua:4191 sui_presets.lua:1071
+#: features/sui_presets.lua:1019
+#: screens/sui_menu.lua:4221
 msgid "Preset \"%s\" imported."
 msgstr "预设“%s”已导入。"
 
-#: sui_menu.lua:3920 sui_presets.lua:712 sui_presets.lua:790
+#: features/sui_presets.lua:660
+#: features/sui_presets.lua:738
+#: screens/sui_menu.lua:3950
 msgid "Preset \"%s\" not found."
 msgstr "未找到预设“%s”。"
 
-#: sui_menu.lua:3970 sui_presets.lua:847
+#: features/sui_presets.lua:795
+#: screens/sui_menu.lua:4000
 msgid "Preset \"%s\" saved."
 msgstr "预设“%s”已保存。"
 
-#: sui_menu.lua:4016 sui_menu.lua:4145 sui_presets.lua:892 sui_presets.lua:1024
+#: features/sui_presets.lua:840
+#: features/sui_presets.lua:972
+#: screens/sui_menu.lua:4046
+#: screens/sui_menu.lua:4175
 msgid "Preset \"%s\" updated."
 msgstr "预设“%s”已更新。"
 
-#: sui_menu.lua:4227 sui_presets.lua:1104
-msgid ""
-"Preset exported to:\n"
-"%s"
-msgstr ""
-"预设已导出至：\n"
-"%s"
+#: features/sui_presets.lua:1052
+#: screens/sui_menu.lua:4257
+msgid "Preset exported to:\n%s"
+msgstr "预设已导出至：\n%s"
 
-#: sui_menu.lua:3945 sui_presets.lua:815
+#: features/sui_presets.lua:763
+#: screens/sui_menu.lua:3975
 msgid "Preset name"
 msgstr "预设名称"
 
-#: sui_presets.lua:391 sui_presets.lua:571
+#: features/sui_presets.lua:339
+#: features/sui_presets.lua:519
 msgid "Preset not found"
 msgstr "未找到预设"
 
-#: sui_menu.lua:2661 sui_settings_window.lua:324
+#: screens/sui_menu.lua:2735
+#: screens/sui_settings_window.lua:367
 msgid "Presets"
 msgstr "预设"
 
-#: sui_settings_window.lua:684
+#: screens/sui_settings_window.lua:852
 msgid "Presets module unavailable."
 msgstr "预设模块不可用。"
 
-#: sui_onboarding.lua:161
-msgid ""
-"Press and hold any element on the screen (like modules or bars) to quickly "
-"customize its settings."
+#: screens/sui_onboarding.lua:161
+msgid "Press and hold any element on the screen (like modules or bars) to quickly customize its settings."
 msgstr "长按屏幕上的任意元素（如模块或栏），快速自定义其设置。"
 
-#: sui_bottombar.lua:569
+#: screens/sui_bottombar.lua:569
 msgid "Prev"
 msgstr "上一页"
 
-#: sui_menu.lua:3045
+#: screens/sui_menu.lua:3119
 msgid "Progress"
 msgstr "进度"
 
-#: desktop_modules/module_tbr.lua:775
-msgid "Progress Bar"
-msgstr "进度条"
+#: engines/sui_book_grid.lua:1920
+msgid "Progress Badge Color"
+msgstr "进度徽章颜色"
 
-#: sui_menu.lua:4315
+#: screens/sui_menu.lua:4345
 msgid "Progress Bar Type"
 msgstr "进度条样式"
 
-#: desktop_modules/module_recent.lua:561
-#: desktop_modules/module_coverdeck.lua:92
-#: desktop_modules/module_currently.lua:248
+#: engines/sui_book_grid.lua:1925
+msgid "Progress Indicator"
+msgstr "进度指示器"
+
+#: engines/sui_book_grid.lua:1912
+msgid "Progress Style"
+msgstr "进度样式"
+
+#: engines/sui_book_grid.lua:2045
+msgid "Progress and Badges"
+msgstr "进度与徽章"
+
+#: modules/module_currently.lua:1864
+msgid "Progress and Stats"
+msgstr "进度与统计"
+
+#: modules/module_coverdeck.lua:177
+#: modules/module_currently.lua:285
 msgid "Progress bar"
 msgstr "进度条"
 
-#: desktop_modules/module_currently.lua:1497
+#: modules/module_currently.lua:1867
 msgid "Progress bar style"
 msgstr "进度条样式"
 
-#: sui_quickactions.lua:1445 sui_quickactions.lua:3023 sui_menu.lua:2130
-#: sui_menu.lua:4543 sui_quicksettings_bar.lua:1196
-#: sui_quicksettings_bar.lua:1201 sui_quicksettings_bar.lua:1222
-#: sui_settings_window.lua:279 desktop_modules/module_action_list.lua:470
-#: desktop_modules/module_action_list.lua:475
-#: desktop_modules/module_action_list.lua:501
-#: desktop_modules/module_quick_actions.lua:397
-#: desktop_modules/module_quick_actions.lua:402
-#: desktop_modules/module_quick_actions.lua:428
-#: desktop_modules/module_quick_actions.lua:539
+#: modules/module_action_list.lua:475
+#: modules/module_action_list.lua:480
+#: modules/module_action_list.lua:506
+#: modules/module_quick_actions.lua:504
+#: modules/module_quick_actions.lua:509
+#: modules/module_quick_actions.lua:535
+#: modules/module_quick_actions.lua:652
+#: features/sui_quickactions.lua:1461
+#: features/sui_quickactions.lua:3287
+#: screens/sui_menu.lua:2180
+#: screens/sui_menu.lua:4595
+#: screens/sui_quicksettings_bar.lua:1196
+#: screens/sui_quicksettings_bar.lua:1201
+#: screens/sui_quicksettings_bar.lua:1222
+#: screens/sui_settings_window.lua:310
 msgid "Quick Actions"
 msgstr "快捷操作"
 
-#: sui_menu.lua:4547
+#: screens/sui_menu.lua:4599
 msgid "Quick Actions  (%d/%d — %d left)"
 msgstr "快捷操作（%d/%d — 剩余 %d 个）"
 
-#: sui_menu.lua:4545
+#: screens/sui_menu.lua:4597
 msgid "Quick Actions  (%d/%d — at limit)"
 msgstr "快捷操作（%d/%d — 已达上限）"
 
-#: sui_quickactions.lua:1690 sui_menu.lua:3639
+#: features/sui_quickactions.lua:1443
+#: features/sui_quickactions.lua:1858
+#: screens/sui_menu.lua:3676
 msgid "Quick Actions Icons"
 msgstr "快捷操作图标"
 
-#: sui_menu.lua:1882 desktop_modules/module_quick_actions.lua:251
-#: desktop_modules/module_quick_actions.lua:301
-#: desktop_modules/module_quick_actions.lua:654
+#: modules/module_quick_actions.lua:352
+#: modules/module_quick_actions.lua:408
+#: modules/module_quick_actions.lua:806
+#: screens/sui_menu.lua:1932
 msgid "Quick Actions Row"
 msgstr "快捷操作行"
 
-#: sui_menu.lua:2691 sui_quicksettings_bar.lua:1049
+#: screens/sui_menu.lua:2765
+#: screens/sui_quicksettings_bar.lua:1049
 msgid "Quick Settings Bar"
 msgstr "快捷设置栏"
 
-#: sui_onboarding.lua:235 sui_onboarding.lua:236
+#: screens/sui_onboarding.lua:235
+#: screens/sui_onboarding.lua:236
 msgid "Quick Tips"
 msgstr "快捷提示"
 
-#: sui_window.lua:2080
+#: engines/sui_window.lua:2266
 msgid "Quick toggles"
 msgstr "快捷开关"
 
-#: sui_quickactions.lua:508
+#: features/sui_quickactions.lua:539
 msgid "Quit"
 msgstr "退出"
 
-#: sui_presets.lua:172 desktop_modules/module_quote.lua:1067
+#: modules/module_quote.lua:1118
+#: features/sui_presets.lua:150
 msgid "Quote of the Day"
 msgstr "每日名言"
 
-#: desktop_modules/module_quote.lua:1382
+#: modules/module_quote.lua:1434
 msgid "Quotes + My Highlights"
 msgstr "名言 + 我的高亮标注"
 
-#: sui_config.lua:171
+#: infra/sui_config.lua:172
 msgid "RAM Usage"
 msgstr "内存使用"
 
-#: sui_quickactions.lua:678 sui_config.lua:122
+#: modules/module_library.lua:219
+#: features/sui_quickactions.lua:712
+#: infra/sui_config.lua:123
 msgid "Random"
 msgstr "随机"
 
-#: sui_presets.lua:207 desktop_modules/module_reading_goals.lua:540
-#: desktop_modules/module_reading_goals.lua:541
-#: desktop_modules/module_reading_goals.lua:567
-#: desktop_modules/module_reading_goals.lua:1069
+#: modules/module_reading_goals.lua:525
+#: modules/module_reading_goals.lua:526
+#: modules/module_reading_goals.lua:552
+#: modules/module_reading_goals.lua:1057
+#: features/sui_presets.lua:165
 msgid "Reading Goals"
 msgstr "阅读目标"
 
-#: sui_stats_windows.lua:2753
+#: screens/sui_stats_windows.lua:2758
 msgid "Reading Insights"
 msgstr "阅读洞察"
 
-#: sui_presets.lua:207 desktop_modules/module_reading_stats.lua:294
+#: modules/module_reading_stats.lua:350
+#: features/sui_presets.lua:165
 msgid "Reading Stats"
 msgstr "阅读统计"
 
-#: desktop_modules/module_reading_stats.lua:831
-#: desktop_modules/module_reading_stats.lua:845
+#: modules/module_reading_stats.lua:936
+#: modules/module_reading_stats.lua:950
 msgid "Real streak only"
 msgstr "仅真实连续"
 
-#: sui_quickactions.lua:496
+#: features/sui_quickactions.lua:527
 msgid "Reboot"
 msgstr "重启"
 
-#: sui_quickactions.lua:651 sui_quickactions.lua:3186 sui_config.lua:120
+#: features/sui_quickactions.lua:685
+#: features/sui_quickactions.lua:3450
+#: infra/sui_config.lua:121
 msgid "Recent"
 msgstr "最近"
 
-#: sui_presets.lua:137 sui_presets.lua:172 sui_presets.lua:230
-#: desktop_modules/module_recent.lua:69 desktop_modules/module_recent.lua:70
-#: desktop_modules/module_recent.lua:81 desktop_modules/module_recent.lua:541
-#: desktop_modules/module_coverdeck.lua:1163
-#: desktop_modules/module_coverdeck.lua:1178
+#: modules/module_recent.lua:15
+#: modules/module_recent.lua:16
+#: modules/module_coverdeck.lua:1242
+#: features/sui_presets.lua:138
+#: features/sui_presets.lua:183
 msgid "Recent Books"
 msgstr "最近书籍"
 
-#: desktop_modules/module_tbr.lua:294
+#: modules/module_tbr.lua:532
 msgid "Remove from To Be Read"
 msgstr "从待读中移除"
 
-#: sui_menu.lua:4022 sui_menu.lua:4029 sui_menu.lua:4114 sui_window.lua:1787
-#: sui_window.lua:2624 sui_presets.lua:898 sui_presets.lua:905
-#: sui_presets.lua:991
+#: engines/sui_window.lua:1923
+#: engines/sui_window.lua:2818
+#: features/sui_presets.lua:846
+#: features/sui_presets.lua:853
+#: features/sui_presets.lua:939
+#: screens/sui_menu.lua:4052
+#: screens/sui_menu.lua:4059
+#: screens/sui_menu.lua:4144
 msgid "Rename"
 msgstr "重命名"
 
-#: sui_menu.lua:4025 sui_menu.lua:4110 sui_presets.lua:901 sui_presets.lua:987
+#: features/sui_presets.lua:849
+#: features/sui_presets.lua:935
+#: screens/sui_menu.lua:4055
+#: screens/sui_menu.lua:4140
 msgid "Rename \"%s\""
 msgstr "重命名“%s”"
 
-#: sui_menu.lua:2558
-msgid ""
-"Replaces the \"Closing book…\" notice above with the cover for that close, "
-"when a cover is available."
-msgstr ""
-"若有可用封面，关闭书籍时将显示该封面，取代上方的「正在关闭书籍…」提示。"
+#: screens/sui_settings_window.lua:437
+msgid "Rename screen"
+msgstr "重命名屏幕"
 
-#: sui_menu.lua:464
-msgid ""
-"Replaces the pagination bar with Prev/Next arrows at the edges of the bottom "
-"bar.\n"
-"The arrows dim when there is no previous or next page.\n"
-"With navpager active, as few as 1 tab and at most 4 tabs can be configured."
-msgstr ""
-"用底部栏边缘的上一页/下一页箭头替换分页栏。\n"
-"没有上一页或下一页时箭头会变暗。\n"
-"启用导航页时，可配置最少 1 个标签，最多 4 个标签。"
+#: screens/sui_menu.lua:2608
+msgid "Replaces the \"Closing book…\" notice above with the cover for that close, when a cover is available."
+msgstr "若有可用封面，关闭书籍时将显示该封面，取代上方的「正在关闭书籍…」提示。"
 
-#: sui_quickactions.lua:1698 sui_menu.lua:2473 sui_stats_windows.lua:649
-#: sui_style.lua:1400
+#: screens/sui_menu.lua:478
+msgid "Replaces the pagination bar with Prev/Next arrows at the edges of the navigation bar.\nThe arrows dim when there is no previous or next page.\nWith navpager active, as few as 1 tab and at most 4 tabs can be configured."
+msgstr "用导航栏边缘的“上一页/下一页”箭头取代分页栏。\n当没有上一页或下一页时，箭头会变暗。\n启用导航分页器时，可配置的标签最少 1 个、最多 4 个。"
+
+#: features/sui_quickactions.lua:1866
+#: features/sui_style.lua:1400
+#: screens/sui_menu.lua:2523
+#: screens/sui_stats_windows.lua:654
 msgid "Reset"
 msgstr "重置"
 
-#: sui_quickactions.lua:1692 sui_style.lua:1394
+#: features/sui_quickactions.lua:1860
+#: features/sui_style.lua:1394
 msgid "Reset All"
 msgstr "全部重置"
 
-#: sui_quickactions.lua:2462
+#: features/sui_quickactions.lua:2677
 msgid "Reset All Quick Action Icons"
 msgstr "重置所有快捷操作图标"
 
-#: sui_style.lua:1147
+#: features/sui_style.lua:1147
 msgid "Reset All System Icons"
 msgstr "重置所有系统图标"
 
-#: sui_style.lua:2189
+#: features/sui_style.lua:2202
 msgid "Reset All Theme Colors"
 msgstr "重置所有主题颜色"
 
-#: sui_quickactions.lua:1697
+#: features/sui_quickactions.lua:1865
 msgid "Reset all Quick Actions icons to default?"
 msgstr "是否将所有快捷操作图标重置为默认？"
 
-#: sui_menu.lua:2472
+#: screens/sui_menu.lua:2522
 msgid "Reset all scales to default (100%)? This cannot be undone."
 msgstr "将所有比例重置为默认值（100%）？此操作不可撤销。"
 
-#: sui_style.lua:1399
+#: features/sui_style.lua:1399
 msgid "Reset all system icons to default?"
 msgstr "是否将所有系统图标重置为默认？"
 
-#: sui_menu.lua:2467
+#: screens/sui_menu.lua:2517
 msgid "Reset to Default Scale"
 msgstr "重置为默认比例"
 
-#: sui_quickactions.lua:489 sui_menu.lua:436 sui_menu.lua:843 sui_menu.lua:1047
-#: sui_menu.lua:1109 sui_menu.lua:1324 sui_menu.lua:1750 sui_menu.lua:3362
-#: sui_menu.lua:3385 sui_menu.lua:3407 sui_menu.lua:4303 sui_menu.lua:4506
-#: sui_quicksettings_bar.lua:1186 sui_window.lua:2016 sui_updater.lua:431
+#: engines/sui_window.lua:2202
+#: features/sui_quickactions.lua:511
+#: infra/sui_updater.lua:458
+#: screens/sui_menu.lua:450
+#: screens/sui_menu.lua:857
+#: screens/sui_menu.lua:1064
+#: screens/sui_menu.lua:1126
+#: screens/sui_menu.lua:1344
+#: screens/sui_menu.lua:1800
+#: screens/sui_menu.lua:3436
+#: screens/sui_menu.lua:3459
+#: screens/sui_menu.lua:3481
+#: screens/sui_menu.lua:4333
+#: screens/sui_menu.lua:4558
+#: screens/sui_quicksettings_bar.lua:1186
 msgid "Restart"
 msgstr "重启"
 
-#: sui_style.lua:1776 sui_style.lua:1820
+#: features/sui_style.lua:1789
+#: features/sui_style.lua:1833
 msgid "Restart to fully apply the UI font change."
 msgstr "重启以完全应用 UI 字体更改。"
 
-#: sui_menu.lua:2487
+#: screens/sui_menu.lua:2537
 msgid "Return to Book Folder"
 msgstr "返回书籍所在文件夹"
 
-#: sui_menu.lua:2373
+#: screens/sui_menu.lua:2423
 msgid "Return to Home Screen on Wakeup"
 msgstr "唤醒时返回主屏幕"
 
-#: sui_menu.lua:3116 sui_menu.lua:3125 sui_menu.lua:3137
+#: engines/sui_book_grid.lua:2014
+#: screens/sui_menu.lua:3190
+#: screens/sui_menu.lua:3199
+#: screens/sui_menu.lua:3211
 msgid "Ribbon"
 msgstr "丝带"
 
-#: sui_menu.lua:708 sui_menu.lua:941 sui_menu.lua:1445 sui_menu.lua:1645
-#: desktop_modules/module_quote.lua:127 desktop_modules/module_quote.lua:1523
-#: desktop_modules/module_action_list.lua:74
-#: desktop_modules/module_action_list.lua:603
-#: desktop_modules/module_reading_stats.lua:67
-#: desktop_modules/module_reading_stats.lua:797
-#: desktop_modules/module_clock.lua:116 desktop_modules/module_clock.lua:870
+#: modules/module_quote.lua:127
+#: modules/module_quote.lua:1575
+#: modules/module_action_list.lua:74
+#: modules/module_action_list.lua:613
+#: modules/module_reading_stats.lua:97
+#: modules/module_reading_stats.lua:902
+#: modules/module_clock.lua:145
+#: modules/module_clock.lua:1048
+#: modules/module_quick_actions.lua:782
+#: screens/sui_menu.lua:722
+#: screens/sui_menu.lua:955
+#: screens/sui_menu.lua:1493
+#: screens/sui_menu.lua:1695
 msgid "Right"
 msgstr "右侧"
 
-#: sui_quicksettings_bar.lua:1318 desktop_modules/module_quick_actions.lua:575
+#: modules/module_quick_actions.lua:691
+#: screens/sui_quicksettings_bar.lua:1318
 msgid "Round"
 msgstr "圆形"
 
-#: sui_quicksettings_bar.lua:1328 desktop_modules/module_quick_actions.lua:585
+#: engines/sui_book_grid.lua:1898
+msgid "Round Overlay"
+msgstr "圆形叠加层"
+
+#: modules/module_quick_actions.lua:701
+#: screens/sui_quicksettings_bar.lua:1328
 msgid "Rounded Square"
 msgstr "圆角方形"
 
-#: sui_stats_windows.lua:2825
+#: engines/sui_book_grid.lua:1798
+msgid "Rows"
+msgstr "行"
+
+#: screens/sui_stats_windows.lua:2830
 msgid "Sat"
 msgstr "星期六"
 
-#: desktop_modules/module_clock.lua:57
+#: modules/module_clock.lua:58
 msgid "Saturday"
 msgstr "星期六"
 
-#: sui_quickactions.lua:2219 sui_menu.lua:3953 sui_stats_windows.lua:658
-#: sui_presets.lua:823 desktop_modules/module_reading_goals.lua:391
-#: desktop_modules/module_reading_goals.lua:407
-#: desktop_modules/module_reading_goals.lua:424
-#: desktop_modules/module_reading_goals.lua:442
+#: modules/module_reading_goals.lua:383
+#: features/sui_quickactions.lua:2395
+#: features/sui_presets.lua:771
+#: screens/sui_menu.lua:3983
+#: screens/sui_stats_windows.lua:663
+#: screens/sui_settings_window.lua:447
 msgid "Save"
 msgstr "保存"
 
-#: sui_menu.lua:3938 sui_presets.lua:808
+#: features/sui_presets.lua:756
+#: screens/sui_menu.lua:3968
 msgid "Save as new preset"
 msgstr "另存为新预设"
 
-#: sui_menu.lua:3943
+#: screens/sui_menu.lua:3973
 msgid "Save icon preset"
 msgstr "保存图标预设"
 
-#: sui_presets.lua:813
+#: features/sui_presets.lua:761
 msgid "Save preset"
 msgstr "保存预设"
 
-#: sui_menu.lua:2385 desktop_modules/module_quote.lua:1302
-#: desktop_modules/module_quote.lua:1306
-#: desktop_modules/module_collections.lua:657
-#: desktop_modules/module_collections.lua:659
-#: desktop_modules/module_action_list.lua:560
-#: desktop_modules/module_action_list.lua:562
-#: desktop_modules/module_recent.lua:501 desktop_modules/module_recent.lua:503
-#: desktop_modules/module_tbr.lua:533 desktop_modules/module_tbr.lua:535
-#: desktop_modules/module_reading_stats.lua:572
-#: desktop_modules/module_reading_stats.lua:574
-#: desktop_modules/module_reading_goals.lua:814
-#: desktop_modules/module_reading_goals.lua:816
-#: desktop_modules/module_clock.lua:787 desktop_modules/module_clock.lua:789
-#: desktop_modules/module_coverdeck.lua:1088
-#: desktop_modules/module_coverdeck.lua:1090
-#: desktop_modules/module_new_books.lua:325
-#: desktop_modules/module_new_books.lua:327
-#: desktop_modules/module_currently.lua:997
-#: desktop_modules/module_currently.lua:999
-#: desktop_modules/module_quick_actions.lua:545
-#: desktop_modules/module_quick_actions.lua:547
+#: modules/module_quote.lua:1354
+#: modules/module_quote.lua:1358
+#: modules/module_action_list.lua:568
+#: modules/module_action_list.lua:570
+#: modules/module_reading_stats.lua:677
+#: modules/module_reading_stats.lua:679
+#: modules/module_reading_goals.lua:799
+#: modules/module_reading_goals.lua:801
+#: modules/module_clock.lua:950
+#: modules/module_clock.lua:952
+#: modules/module_coverdeck.lua:1151
+#: modules/module_coverdeck.lua:1153
+#: modules/module_currently.lua:1322
+#: modules/module_currently.lua:1324
+#: modules/module_quick_actions.lua:658
+#: modules/module_quick_actions.lua:660
+#: engines/sui_book_grid.lua:1726
+#: engines/sui_book_grid.lua:1728
+#: screens/sui_menu.lua:2435
 msgid "Scale"
 msgstr "比例"
 
-#: desktop_modules/module_currently.lua:1026
-msgid ""
-"Scale for all text elements (title, author, progress, time).\n"
-"100% is the default size."
-msgstr ""
-"所有文本元素（标题、作者、进度和时间）的缩放比例。\n"
-"默认大小为100%。"
+#: modules/module_currently.lua:1351
+msgid "Scale for all text elements (title, author, progress, time).\n100% is the default size."
+msgstr "所有文本元素（标题、作者、进度和时间）的缩放比例。\n默认大小为100%。"
 
-#: desktop_modules/module_quick_actions.lua:562
-msgid ""
-"Scale for the button label text.\n"
-"100% is the default size."
-msgstr ""
-"按钮标签文本的缩放比例。\n"
-"默认大小为100%。"
+#: modules/module_quick_actions.lua:675
+msgid "Scale for the button label text.\n100% is the default size."
+msgstr "按钮标签文本的缩放比例。\n默认大小为100%。"
 
-#: desktop_modules/module_collections.lua:673
-msgid ""
-"Scale for the collection name text.\n"
-"100% is the default size."
-msgstr ""
-"收藏夹名称文本的缩放比例。\n"
-"默认大小为100%。"
+#: modules/module_collections.lua:1443
+msgid "Scale for the collection count badge."
+msgstr "收藏计数徽章的缩放。"
 
-#: desktop_modules/module_collections.lua:903
-msgid ""
-"Scale for the collection thumbnails only.\n"
-"The label text follows the module scale.\n"
-"100% is the default size."
-msgstr ""
-"仅收藏夹缩略图的比例。\n"
-"标签文字跟随模块比例。\n"
-"默认大小为100%。"
+#: modules/module_currently.lua:1338
+msgid "Scale for the cover thumbnail only.\n100% is the default size.\nWhen Dynamic Cover Size is on, this scales the cover relative to its current dynamic size instead, and the cover never shrinks below its 100% size."
+msgstr "仅封面缩略图的缩放。\n默认大小为100%。\n启用“动态封面大小”后，此设置将相对于其当前动态大小缩放封面，且封面永远不会小于其 100% 大小。"
 
-#: desktop_modules/module_currently.lua:1013
-msgid ""
-"Scale for the cover thumbnail only.\n"
-"100% is the default size."
-msgstr ""
-"仅封面缩略图的缩放比例。\n"
-"默认大小为100%。"
+#: modules/module_coverdeck.lua:1162
+msgid "Scale for the cover thumbnails only.\n100% is the default size."
+msgstr "仅封面缩略图的缩放比例。\n默认大小为100%。"
 
-#: desktop_modules/module_coverdeck.lua:1099
-msgid ""
-"Scale for the cover thumbnails only.\n"
-"100% is the default size."
-msgstr ""
-"仅封面缩略图的缩放比例。\n"
-"默认大小为100%。"
+#: engines/sui_book_grid.lua:1746
+msgid "Scale for the cover thumbnails only.\nText and progress bar follow the module scale.\n100% is the default size."
+msgstr "仅封面缩略图的比例。\n文字和进度条跟随模块比例。\n默认大小为100%。"
 
-#: desktop_modules/module_recent.lua:518 desktop_modules/module_tbr.lua:749
-#: desktop_modules/module_new_books.lua:342
-msgid ""
-"Scale for the cover thumbnails only.\n"
-"Text and progress bar follow the module scale.\n"
-"100% is the default size."
-msgstr ""
-"仅封面缩略图的比例。\n"
-"文字和进度条跟随模块比例。\n"
-"默认大小为100%。"
+#: screens/sui_menu.lua:3409
+msgid "Scale for the folder name overlay text.\n100% is the default size."
+msgstr "文件夹名称叠加文本的缩放比例。\n默认大小为100%。"
 
-#: sui_menu.lua:3335
-msgid ""
-"Scale for the folder name overlay text.\n"
-"100% is the default size."
-msgstr ""
-"文件夹名称叠加文本的缩放比例。\n"
-"默认大小为100%。"
+#: modules/module_action_list.lua:579
+#: screens/sui_quicksettings_bar.lua:1297
+msgid "Scale for the label text.\n100% is the default size."
+msgstr "标签文字的比例。\n默认大小为100%。"
 
-#: sui_quicksettings_bar.lua:1297 desktop_modules/module_action_list.lua:571
-#: desktop_modules/module_new_books.lua:354
-msgid ""
-"Scale for the label text.\n"
-"100% is the default size."
-msgstr ""
-"标签文字的比例。\n"
-"默认大小为100%。"
+#: screens/sui_menu.lua:2918
+msgid "Scale for the library badges (progress, pages, etc.).\n100% is the default size."
+msgstr "书库徽章（进度、页数等）的缩放比例。\n默认大小为100%。"
 
-#: sui_menu.lua:2844
-msgid ""
-"Scale for the library badges (progress, pages, etc.).\n"
-"100% is the default size."
-msgstr ""
-"书库徽章（进度、页数等）的缩放比例。\n"
-"默认大小为100%。"
+#: engines/sui_book_grid.lua:1737
+msgid "Scale for the percentage read text.\n100% is the default size."
+msgstr "已读百分比文本的缩放比例。\n默认大小为100%。"
 
-#: desktop_modules/module_recent.lua:532 desktop_modules/module_tbr.lua:740
-msgid ""
-"Scale for the percentage read text.\n"
-"100% is the default size."
-msgstr ""
-"已读百分比文本的缩放比例。\n"
-"默认大小为100%。"
+#: engines/sui_book_grid.lua:1949
+msgid "Scale for this module's corner badges (progress, pages, series, new book)."
+msgstr "此模块角落徽章（进度、页数、系列、新书）的缩放。"
 
-#: desktop_modules/module_coverdeck.lua:1091
+#: modules/module_coverdeck.lua:1154
 msgid "Scale for this module."
 msgstr "此模块的缩放比例。"
 
-#: desktop_modules/module_quote.lua:1308
-#: desktop_modules/module_collections.lua:660
-#: desktop_modules/module_action_list.lua:563
-#: desktop_modules/module_recent.lua:504 desktop_modules/module_tbr.lua:536
-#: desktop_modules/module_reading_stats.lua:575
-#: desktop_modules/module_reading_goals.lua:817
-#: desktop_modules/module_clock.lua:790
-#: desktop_modules/module_new_books.lua:328
-#: desktop_modules/module_currently.lua:1000
-#: desktop_modules/module_quick_actions.lua:548
-msgid ""
-"Scale for this module.\n"
-"100% is the default size."
-msgstr ""
-"此模块的比例。\n"
-"默认大小为100%。"
+#: modules/module_quote.lua:1360
+#: modules/module_action_list.lua:571
+#: modules/module_reading_stats.lua:680
+#: modules/module_reading_goals.lua:802
+#: modules/module_clock.lua:953
+#: modules/module_currently.lua:1325
+#: modules/module_quick_actions.lua:661
+#: engines/sui_book_grid.lua:1729
+msgid "Scale for this module.\n100% is the default size."
+msgstr "此模块的比例。\n默认大小为100%。"
 
-#: desktop_modules/module_coverdeck.lua:1107
-msgid ""
-"Scale for title and statistics text.\n"
-"100% is the default size."
-msgstr ""
-"标题和统计文本的缩放比例。\n"
-"默认大小为100%。"
+#: modules/module_coverdeck.lua:1170
+msgid "Scale for title and statistics text.\n100% is the default size."
+msgstr "标题和统计文本的缩放比例。\n默认大小为100%。"
 
-#: sui_menu.lua:2409
-msgid ""
-"Scales all modules and labels together.\n"
-"100% is the default size."
-msgstr ""
-"同时缩放所有模块和标签。\n"
-"默认大小为100%。"
+#: screens/sui_menu.lua:2459
+msgid "Scales all modules and labels together.\n100% is the default size."
+msgstr "同时缩放所有模块和标签。\n默认大小为100%。"
 
-#: sui_menu.lua:2447
-msgid ""
-"Scales the section label text above each module.\n"
-"100% is the default size."
-msgstr ""
-"每个模块上方的分区标签文本的缩放比例。\n"
-"默认大小为100%。"
+#: screens/sui_menu.lua:2497
+msgid "Scales the section label text above each module.\n100% is the default size."
+msgstr "每个模块上方的分区标签文本的缩放比例。\n默认大小为100%。"
 
-#: sui_menu.lua:3459
+#: screens/sui_menu.lua:3533
 msgid "Scan Subfolders for Covers"
 msgstr "扫描子文件夹中的封面"
 
-#: sui_titlebar.lua:104
+#: screens/sui_settings_window.lua:439
+#: screens/sui_settings_window.lua:1110
+msgid "Screen name"
+msgstr "屏幕名称"
+
+#: screens/sui_titlebar.lua:104
 msgid "Search"
 msgstr "搜索"
 
-#: sui_style.lua:94
+#: features/sui_style.lua:94
 msgid "Search Button"
 msgstr "搜索按钮"
 
-#: sui_style.lua:2083
+#: features/sui_style.lua:2096
 msgid "Secondary / Dim Text"
 msgstr "次要/暗淡文本"
 
-#: sui_window.lua:1776 sui_window.lua:2609
+#: engines/sui_window.lua:1912
+#: engines/sui_window.lua:2803
 msgid "Select"
 msgstr "选择"
 
-#: sui_menu.lua:3929 sui_presets.lua:721 sui_presets.lua:729
-#: sui_presets.lua:734
+#: features/sui_presets.lua:669
+#: features/sui_presets.lua:677
+#: features/sui_presets.lua:682
+#: screens/sui_menu.lua:3959
 msgid "Select Preset"
 msgstr "选择预设"
 
-#: sui_menu.lua:2205
+#: screens/sui_menu.lua:2255
 msgid "Select Wallpaper"
 msgstr "选择壁纸"
 
-#: desktop_modules/module_collections.lua:791
+#: modules/module_collections.lua:1201
 msgid "Select at least 2 collections to arrange."
 msgstr "请至少选择 2 个收藏夹以便排序。"
 
-#: sui_style.lua:2084
+#: features/sui_style.lua:2097
 msgid "Separator Line"
 msgstr "分隔线"
 
-#: sui_style.lua:2048
+#: features/sui_style.lua:2061
 msgid "Sepia Classic"
 msgstr "经典棕褐色"
 
-#: sui_stats_windows.lua:2837 desktop_modules/module_clock.lua:62
+#: modules/module_clock.lua:63
+#: screens/sui_stats_windows.lua:2842
 msgid "September"
 msgstr "9月"
 
-#: sui_quickactions.lua:863 sui_config.lua:133 sui_browsemeta.lua:78
+#: modules/module_currently.lua:283
+#: features/sui_quickactions.lua:897
+#: infra/sui_config.lua:134
+#: features/library/sui_library_browse.lua:59
 msgid "Series"
 msgstr "系列"
 
-#: sui_menu.lua:2991
+#: engines/sui_book_grid.lua:1987
+#: engines/sui_book_grid.lua:2003
+msgid "Series Badge"
+msgstr "系列徽章"
+
+#: engines/sui_book_grid.lua:1998
+msgid "Series Badge Color"
+msgstr "系列徽章颜色"
+
+#: screens/sui_menu.lua:3065
 msgid "Series Index"
 msgstr "系列序号"
 
-#: sui_menu.lua:647 sui_menu.lua:908
+#: screens/sui_menu.lua:661
+#: screens/sui_menu.lua:922
 msgid "Set"
 msgstr "设置"
 
-#: desktop_modules/module_reading_goals.lua:959
-#: desktop_modules/module_reading_goals.lua:974
-#: desktop_modules/module_reading_goals.lua:989
+#: modules/module_reading_goals.lua:944
+#: modules/module_reading_goals.lua:959
+#: modules/module_reading_goals.lua:974
 msgid "Set Goal"
 msgstr "设置目标"
 
-#: sui_foldercovers.lua:924 sui_foldercovers.lua:1237 sui_browsemeta.lua:1386
+#: modules/module_collections.lua:1103
+msgid "Set collection cover"
+msgstr "设置收藏夹封面"
+
+#: features/library/sui_foldercovers.lua:684
+#: features/library/sui_library_browse.lua:811
+#: features/library/sui_series_grouping.lua:357
 msgid "Set folder cover"
 msgstr "设置文件夹封面"
 
-#: sui_onboarding.lua:168
+#: screens/sui_onboarding.lua:168
 msgid "Set your reading goal"
 msgstr "设置你的阅读目标"
 
-#: sui_quickactions.lua:832 sui_config.lua:130
+#: features/sui_quickactions.lua:866
+#: infra/sui_config.lua:131
 msgid "Settings"
 msgstr "设置"
 
-#: sui_settings_window.lua:236 sui_settings_window.lua:241
+#: screens/sui_settings_window.lua:258
+#: screens/sui_settings_window.lua:263
 msgid "Settings not found."
 msgstr "未找到设置。"
 
-#: sui_menu.lua:1078 sui_menu.lua:1370 sui_menu.lua:2619
-#: sui_quicksettings_bar.lua:1388
+#: screens/sui_menu.lua:1095
+#: screens/sui_menu.lua:1393
+#: screens/sui_menu.lua:2669
+#: screens/sui_quicksettings_bar.lua:1388
 msgid "Settings on Long Tap"
 msgstr "长按打开设置"
 
-#: desktop_modules/module_clock.lua:198 desktop_modules/module_clock.lua:248
+#: modules/module_clock.lua:239
 msgid "Seven"
 msgstr "七"
 
-#: desktop_modules/module_clock.lua:208 desktop_modules/module_clock.lua:251
+#: modules/module_clock.lua:242
 msgid "Seventeen"
 msgstr "十七"
 
-#: desktop_modules/module_clock.lua:821
+#: modules/module_clock.lua:987
 msgid "Show Battery"
 msgstr "显示电池"
 
-#: desktop_modules/module_clock.lua:809
+#: modules/module_clock.lua:975
 msgid "Show Clock"
 msgstr "显示时钟"
 
-#: desktop_modules/module_clock.lua:815
+#: modules/module_clock.lua:981
 msgid "Show Date"
 msgstr "显示日期"
 
-#: desktop_modules/module_action_list.lua:578
+#: modules/module_collections.lua:1269
+#: modules/module_collections.lua:1290
+msgid "Show Hidden Collection"
+msgstr "显示隐藏收藏夹"
+
+#: modules/module_action_list.lua:588
 msgid "Show Icon"
 msgstr "显示图标"
 
-#: sui_menu.lua:595
+#: screens/sui_menu.lua:609
 msgid "Show Page Count in Title Bar"
 msgstr "在标题栏显示页数"
 
-#: sui_menu.lua:2500
-msgid ""
-"Show a brief \"Closing book…\" notice when closing a book, preventing "
-"accidental double-taps while e-ink refreshes."
-msgstr ""
-"关闭书籍时显示短暂的「正在关闭书籍…」提示，防止在电子墨水屏刷新期间发生意外双"
-"击。"
+#: screens/sui_menu.lua:2550
+msgid "Show a brief \"Closing book…\" notice when closing a book, preventing accidental double-taps while e-ink refreshes."
+msgstr "关闭书籍时显示短暂的「正在关闭书籍…」提示，防止在电子墨水屏刷新期间发生意外双击。"
 
-#: sui_menu.lua:2596
-msgid ""
-"Show a brief \"Loading statistics…\" notice when opening a statistics "
-"window, preventing accidental double-taps while e-ink refreshes."
-msgstr ""
-"打开统计窗口时，显示短暂的「正在加载统计数据…」提示，以防止电子墨水屏刷新期间"
-"发生误触。"
+#: screens/sui_menu.lua:2646
+msgid "Show a brief \"Loading statistics…\" notice when opening a statistics window, preventing accidental double-taps while e-ink refreshes."
+msgstr "打开统计窗口时，显示短暂的「正在加载统计数据…」提示，以防止电子墨水屏刷新期间发生误触。"
 
-#: desktop_modules/module_recent.lua:590
-#: desktop_modules/module_coverdeck.lua:1443
+#: modules/module_library.lua:346
+#: modules/module_recent.lua:50
+#: modules/module_coverdeck.lua:1513
 msgid "Show finished books"
 msgstr "展示已完成书籍"
 
-#: sui_menu.lua:2557
+#: screens/sui_menu.lua:2607
 msgid "Show on Close"
 msgstr "关闭时显示"
 
-#: sui_menu.lua:2546
+#: screens/sui_menu.lua:2596
 msgid "Show on Open"
 msgstr "打开时显示"
 
-#: sui_config.lua:956
+#: infra/sui_config.lua:1195
 msgid "Show section label"
 msgstr "显示分区标签"
 
-#: sui_menu.lua:2272
+#: screens/sui_menu.lua:2322
 msgid "Show wallpaper on all screens"
 msgstr "在所有屏幕显示壁纸"
 
-#: desktop_modules/module_coll_row.lua:144
+#: screens/sui_menu.lua:614
+msgid "Shows \"Page X of Y\" in the title bar subtitle when browsing the library, history or collections.\nNavpager enables this automatically.\nNot available when Navpager is active."
+msgstr "在浏览书库、历史或收藏时，在标题栏副标题中显示「第 X 页，共 Y 页」。\n启用导航分页器时自动开启。\n启用导航分页器时不可用。"
+
+#: screens/sui_menu.lua:510
+msgid "Shows a row of dots at the bottom of the homescreen.\nThe active page dot is filled; the others are dimmed.\nAlways active when Navpager is selected."
+msgstr "在主屏幕底部显示一行点。\n活动页面的点是填充的；其他是暗淡的。\n选择导航页时始终启用。"
+
+#: modules/module_feat_coll.lua:173
+#: modules/module_tbr.lua:273
 msgid "Shuffle"
 msgstr "随机"
 
-#: sui_menu.lua:600
-msgid ""
-"Shows \"Page X of Y\" in the title bar subtitle when browsing the library, "
-"history or collections.\n"
-"Navpager enables this automatically.\n"
-"Not available when Navpager is active."
-msgstr ""
-"在浏览书库、历史或收藏时，在标题栏副标题中显示「第 X 页，共 Y 页」。\n"
-"启用导航分页器时自动开启。\n"
-"启用导航分页器时不可用。"
+#: modules/module_library.lua:274
+msgid "Shuffle now"
+msgstr "立即随机播放"
 
-#: sui_menu.lua:496
-msgid ""
-"Shows a row of dots at the bottom of the homescreen.\n"
-"The active page dot is filled; the others are dimmed.\n"
-"Always active when Navpager is selected."
-msgstr ""
-"在主屏幕底部显示一行点。\n"
-"活动页面的点是填充的；其他是暗淡的。\n"
-"选择导航页时始终启用。"
-
-#: desktop_modules/module_currently.lua:1500
+#: modules/module_currently.lua:1869
 msgid "Simple"
 msgstr "简洁"
 
-#: sui_menu.lua:4483 sui_menu.lua:4488 main.lua:2291 main.lua:2304 _meta.lua:6
+#: main.lua:2535
+#: main.lua:2548
+#: _meta.lua:5
+#: screens/sui_menu.lua:4532
+#: screens/sui_menu.lua:4540
+#: screens/sui_menu.lua:4629
 msgid "Simple UI"
 msgstr "Simple UI"
 
-#: sui_updater.lua:428
-msgid ""
-"Simple UI %s installed.\n"
-"\n"
-"Restart KOReader to apply the update?"
-msgstr ""
-"Simple UI %s 已安装。\n"
-"\n"
-"是否重启 KOReader 以使更新生效？"
+#: infra/sui_updater.lua:455
+msgid "Simple UI %s installed.\n\nRestart KOReader to apply the update?"
+msgstr "Simple UI %s 已安装。\n\n是否重启 KOReader 以使更新生效？"
 
-#: sui_updater.lua:475
-msgid ""
-"Simple UI %s is available!\n"
-"You have %s."
-msgstr ""
-"Simple UI %s 可用！\n"
-"您当前版本为 %s。"
+#: infra/sui_updater.lua:502
+msgid "Simple UI %s is available!\nYou have %s."
+msgstr "Simple UI %s 可用！\n您当前版本为 %s。"
 
-#: sui_settings_window.lua:850
+#: screens/sui_settings_window.lua:1019
 msgid "Simple UI Settings"
 msgstr "Simple UI 设置"
 
-#: sui_onboarding.lua:133
-msgid ""
-"Simple UI is designed to be simple and flexible. Here are a few tips to get "
-"the most out of it."
+#: screens/sui_onboarding.lua:133
+msgid "Simple UI is designed to be simple and flexible. Here are a few tips to get the most out of it."
 msgstr "Simple UI 的设计兼具简洁与灵活，以下是充分发挥其功能的一些小技巧。"
 
-#: sui_updater.lua:469
+#: infra/sui_updater.lua:496
 msgid "Simple UI is up to date (%s)."
 msgstr "Simple UI 已是最新版本（%s）。"
 
-#: sui_menu.lua:4505
-msgid ""
-"Simple UI will be %s after restart.\n"
-"\n"
-"Restart now?"
-msgstr ""
-"重启后 Simple UI 将变为 %s。\n"
-"\n"
-"是否立即重启？"
+#: screens/sui_menu.lua:4557
+msgid "Simple UI will be %s after restart.\n\nRestart now?"
+msgstr "重启后 Simple UI 将变为 %s。\n\n是否立即重启？"
 
-#: main.lua:869
+#: main.lua:892
 msgid "Simple UI: Go to Homescreen"
 msgstr "Simple UI：前往主屏幕"
 
-#: main.lua:875
+#: main.lua:898
 msgid "Simple UI: Go to Library"
 msgstr "Simple UI：前往书库"
 
-#: main.lua:893
+#: main.lua:922
+msgid "Simple UI: Navigation Bar"
+msgstr "Simple UI：导航栏"
+
+#: main.lua:916
 msgid "Simple UI: Recent"
 msgstr "Simple UI：最近"
 
-#: main.lua:887
+#: main.lua:910
 msgid "Simple UI: Settings"
 msgstr "Simple UI：设置"
 
-#: main.lua:881
+#: main.lua:904
 msgid "Simple UI: Toggle Homescreen / Library"
 msgstr "Simple UI：切换主屏幕/书库"
 
-#: sui_menu.lua:2791
+#: modules/module_collections.lua:1354
+#: screens/sui_menu.lua:2865
 msgid "Single Cover"
 msgstr "单封面"
 
-#: desktop_modules/module_clock.lua:197 desktop_modules/module_clock.lua:247
+#: modules/module_clock.lua:238
 msgid "Six"
 msgstr "六"
 
-#: desktop_modules/module_clock.lua:207 desktop_modules/module_clock.lua:251
+#: modules/module_clock.lua:242
 msgid "Sixteen"
 msgstr "十六"
 
-#: sui_menu.lua:1022 sui_menu.lua:2835 sui_quicksettings_bar.lua:1295
-#: sui_quicksettings_bar.lua:1296 sui_window.lua:2101 sui_window.lua:2108
-#: desktop_modules/module_quick_actions.lua:560
-#: desktop_modules/module_quick_actions.lua:561
+#: modules/module_action_list.lua:565
+#: modules/module_coverdeck.lua:1503
+#: modules/module_currently.lua:1828
+#: modules/module_quick_actions.lua:673
+#: modules/module_quick_actions.lua:674
+#: engines/sui_book_grid.lua:1810
+#: engines/sui_window.lua:2287
+#: engines/sui_window.lua:2294
+#: screens/sui_menu.lua:1036
+#: screens/sui_menu.lua:2909
+#: screens/sui_quicksettings_bar.lua:1295
+#: screens/sui_quicksettings_bar.lua:1296
 msgid "Size"
 msgstr "大小"
 
-#: sui_menu.lua:1338
-msgid ""
-"Size of the tab icons.\n"
-"100% is the default size."
-msgstr ""
-"标签图标的大小。\n"
-"默认大小为100%。"
+#: screens/sui_menu.lua:1358
+msgid "Size of the tab icons.\n100% is the default size."
+msgstr "标签图标的大小。\n默认大小为100%。"
 
-#: sui_menu.lua:1348
-msgid ""
-"Size of the tab label text.\n"
-"100% is the default size."
-msgstr ""
-"标签文本的大小。\n"
-"默认大小为100%。"
+#: screens/sui_menu.lua:1368
+msgid "Size of the tab label text.\n100% is the default size."
+msgstr "标签文本的大小。\n默认大小为100%。"
 
-#: desktop_modules/module_reading_stats.lua:718
-msgid ""
-"Size of the text inside the stat cards.\n"
-"Does not affect card size or padding.\n"
-"100% is the default size."
-msgstr ""
-"统计卡片内文字的大小。\n"
-"不影响卡片大小或内边距。\n"
-"默认大小为100%。"
+#: modules/module_reading_stats.lua:823
+msgid "Size of the text inside the stat cards.\nDoes not affect card size or padding.\n100% is the default size."
+msgstr "统计卡片内文字的大小。\n不影响卡片大小或内边距。\n默认大小为100%。"
 
-#: sui_quickactions.lua:502
+#: features/sui_quickactions.lua:533
 msgid "Sleep"
 msgstr "休眠"
 
-#: sui_menu.lua:568
+#: screens/sui_menu.lua:582
 msgid "Small"
 msgstr "小"
 
-#: sui_menu.lua:3232 sui_menu.lua:3236 sui_quicksettings_bar.lua:1365
-#: desktop_modules/module_quick_actions.lua:622
+#: modules/module_quick_actions.lua:737
+#: screens/sui_menu.lua:3306
+#: screens/sui_menu.lua:3310
+#: screens/sui_quicksettings_bar.lua:1365
 msgid "Solid"
 msgstr "纯色"
 
-#: desktop_modules/module_collections.lua:920
-#: desktop_modules/module_recent.lua:552 desktop_modules/module_tbr.lua:766
-#: desktop_modules/module_reading_goals.lua:1080
-#: desktop_modules/module_new_books.lua:369
-#: desktop_modules/module_currently.lua:1488
+#: modules/module_reading_goals.lua:1068
+#: modules/module_currently.lua:1852
+#: engines/sui_book_grid.lua:1834
 msgid "Solid Background"
 msgstr "纯色背景"
 
-#: desktop_modules/module_coll_row.lua:126
+#: modules/module_library.lua:240
+#: modules/module_collections.lua:1328
+#: modules/module_feat_coll.lua:177
+#: modules/module_tbr.lua:283
 msgid "Sort"
 msgstr "排序"
 
-#: desktop_modules/module_quote.lua:1334
-#: desktop_modules/module_coverdeck.lua:1173
+#: modules/module_quote.lua:1386
+#: modules/module_coverdeck.lua:1252
 msgid "Source"
 msgstr "来源"
 
-#: sui_menu.lua:1358
-msgid ""
-"Space below the bottom navigation bar.\n"
-"100% is the default spacing."
-msgstr ""
-"底部导航栏下方的间距。\n"
-"默认间距为100%。"
+#: screens/sui_menu.lua:1378
+msgid "Space below the bottom navigation bar.\n100% is the default spacing."
+msgstr "底部导航栏下方的间距。\n默认间距为100%。"
 
-#: desktop_modules/module_spacer.lua:56 desktop_modules/module_spacer.lua:109
+#: modules/module_spacer.lua:56
+#: modules/module_spacer.lua:109
 msgid "Spacer"
 msgstr "间隔元件"
 
-#: desktop_modules/module_spacer.lua:87 desktop_modules/module_spacer.lua:88
+#: modules/module_spacer.lua:87
+#: modules/module_spacer.lua:88
 msgid "Spacer Size"
 msgstr "间隔元件大小"
 
-#: sui_onboarding.lua:271
+#: modules/module_clock.lua:1057
+msgid "Spacing"
+msgstr "间距"
+
+#: screens/sui_onboarding.lua:271
 msgid "Start using Simple UI"
 msgstr "开始使用 Simple UI"
 
-#: sui_patches.lua:870 sui_patches.lua:872
+#: infra/sui_patches.lua:1137
+#: infra/sui_patches.lua:1139
 msgid "Start with"
 msgstr "启动时"
 
-#: sui_menu.lua:2362
+#: screens/sui_menu.lua:2412
 msgid "Start with Home Screen"
 msgstr "启动时显示主屏幕"
 
-#: sui_onboarding.lua:62
+#: screens/sui_onboarding.lua:62
 msgid "Start with a ready-made layout. You can change everything later."
 msgstr "从预设布局开始，后续均可自由调整。"
 
-#: desktop_modules/module_coverdeck.lua:93
-#: desktop_modules/module_coverdeck.lua:1245
-#: desktop_modules/module_coverdeck.lua:1292
-#: desktop_modules/module_coverdeck.lua:1358
+#: modules/module_coverdeck.lua:178
+#: modules/module_coverdeck.lua:1334
+#: modules/module_coverdeck.lua:1365
+#: modules/module_coverdeck.lua:1432
 msgid "Statistics"
 msgstr "统计"
 
-#: sui_menu.lua:2595
+#: screens/sui_menu.lua:2645
 msgid "Statistics Loading Notice"
 msgstr "统计数据加载提示"
 
-#: sui_stats_windows.lua:163
+#: screens/sui_stats_windows.lua:163
 msgid "Statistics database library not available."
 msgstr "统计数据库模块不可用。"
 
-#: sui_quickactions.lua:816
+#: features/sui_quickactions.lua:850
 msgid "Statistics plugin not available."
 msgstr "统计插件不可用。"
 
-#: sui_quickactions.lua:801 sui_config.lua:128
-#: desktop_modules/module_currently.lua:1194
-#: desktop_modules/module_currently.lua:1276
-#: desktop_modules/module_currently.lua:1337
+#: modules/module_currently.lua:1547
+#: modules/module_currently.lua:1629
+#: modules/module_currently.lua:1690
+#: features/sui_quickactions.lua:835
+#: infra/sui_config.lua:129
 msgid "Stats"
 msgstr "统计"
 
-#: desktop_modules/module_currently.lua:1522
+#: modules/module_currently.lua:1876
 msgid "Stats layout"
 msgstr "统计布局"
 
-#: desktop_modules/module_reading_stats.lua:882
-#: desktop_modules/module_reading_goals.lua:1113
-#: desktop_modules/module_coverdeck.lua:1476
-#: desktop_modules/module_currently.lua:1571
+#: modules/module_reading_stats.lua:992
+#: modules/module_reading_goals.lua:1109
+#: modules/module_coverdeck.lua:1551
+#: modules/module_currently.lua:1925
 msgid "Stats updated successfully."
 msgstr "统计数据已成功更新。"
 
-#: sui_menu.lua:2686
+#: screens/sui_menu.lua:2760
 msgid "Status Bar"
 msgstr "状态栏"
 
-#: sui_menu.lua:1029
+#: screens/sui_menu.lua:1043
 msgid "Status Bar Size"
 msgstr "状态栏大小"
 
-#: sui_menu.lua:842
-msgid ""
-"Status Bar will be %s after restart.\n"
-"\n"
-"Restart now?"
-msgstr ""
-"重启后状态栏将变为 %s。\n"
-"\n"
-"是否立即重启？"
+#: screens/sui_menu.lua:856
+msgid "Status Bar will be %s after restart.\n\nRestart now?"
+msgstr "重启后状态栏将变为 %s。\n\n是否立即重启？"
 
-#: sui_style.lua:2079
+#: features/sui_style.lua:2092
 msgid "Status Bar — Background"
 msgstr "状态栏 — 背景"
 
-#: sui_style.lua:2082
+#: features/sui_style.lua:2095
 msgid "Status Bar — Text"
 msgstr "状态栏 — 文本"
 
-#: sui_settings_window.lua:259
-msgid "Status, title, navigation and pagination"
-msgstr "状态栏、标题栏、导航栏和分页栏"
+#: modules/module_reading_stats.lua:134
+msgid "Status — Abandoned"
+msgstr "状态 — 已放弃"
 
-#: sui_stats_windows.lua:3518 desktop_modules/module_reading_stats.lua:94
+#: modules/module_reading_stats.lua:133
+msgid "Status — Reading"
+msgstr "状态 — 阅读中"
+
+#: modules/module_reading_stats.lua:132
+msgid "Status — Unread"
+msgstr "状态 — 未读"
+
+#: screens/sui_settings_window.lua:290
+msgid "Status, title, navigation and pagination"
+msgstr "状态栏、标题栏、导航栏与分页栏"
+
+#: modules/module_reading_stats.lua:124
+#: screens/sui_stats_windows.lua:3525
 msgid "Streak"
 msgstr "连续阅读"
 
-#: desktop_modules/module_reading_stats.lua:827
+#: modules/module_reading_stats.lua:932
 msgid "Streak Mode"
 msgstr "连续模式"
 
-#: sui_menu.lua:2290
+#: screens/sui_menu.lua:2340
 msgid "Stretch to fill screen"
 msgstr "拉伸以填满屏幕"
 
-#: sui_menu.lua:4534 sui_settings_window.lua:272 sui_settings_window.lua:854
-#: desktop_modules/module_reading_stats.lua:728
+#: modules/module_reading_stats.lua:833
+#: screens/sui_menu.lua:4586
+#: screens/sui_settings_window.lua:303
+#: screens/sui_settings_window.lua:1024
 msgid "Style"
 msgstr "样式"
 
-#: sui_menu.lua:1765 sui_menu.lua:1768
+#: screens/sui_menu.lua:1815
+#: screens/sui_menu.lua:1818
 msgid "Sub-page Buttons"
 msgstr "子页面按钮"
 
-#: sui_stats_windows.lua:2825
+#: screens/sui_stats_windows.lua:2830
 msgid "Sun"
 msgstr "星期日"
 
-#: desktop_modules/module_clock.lua:56
+#: modules/module_clock.lua:57
 msgid "Sunday"
 msgstr "星期日"
 
-#: sui_menu.lua:1059
+#: screens/sui_menu.lua:1076
 msgid "Swipe Indicator"
 msgstr "滑动指示器"
 
-#: sui_quickactions.lua:1668 sui_quickactions.lua:1671
-#: sui_quickactions.lua:2341 sui_quickactions.lua:2437
+#: features/sui_quickactions.lua:1826
+#: features/sui_quickactions.lua:1829
+#: features/sui_quickactions.lua:2517
+#: features/sui_quickactions.lua:2613
 msgid "System Actions"
 msgstr "系统操作"
 
-#: sui_menu.lua:3571 sui_menu.lua:3579 sui_style.lua:1392
+#: features/sui_style.lua:1392
+#: screens/sui_menu.lua:3645
+#: screens/sui_menu.lua:3653
 msgid "System Icons"
 msgstr "系统图标"
 
-#: sui_quickactions.lua:2762
+#: features/sui_quickactions.lua:2987
 msgid "System action error: %s"
 msgstr "系统操作错误：%s"
 
-#: sui_stats_windows.lua:2741
+#: screens/sui_stats_windows.lua:2746
 msgid "THIS MONTH"
 msgstr "本月"
 
-#: sui_stats_windows.lua:2740
+#: screens/sui_stats_windows.lua:2745
 msgid "THIS WEEK"
 msgstr "本周"
 
-#: sui_stats_windows.lua:2736
+#: screens/sui_stats_windows.lua:2741
 msgid "TODAY'S SUMMARY"
 msgstr "今日摘要"
 
-#: sui_style.lua:1387
+#: features/sui_style.lua:1387
 msgid "Tab Bar"
 msgstr "标签栏"
 
-#: sui_menu.lua:1253
+#: screens/sui_menu.lua:1270
 msgid "Tab Style"
 msgstr "标签样式"
 
-#: sui_style.lua:1343
+#: features/sui_style.lua:1343
 msgid "Tab bar icons must be PNG or SVG."
 msgstr "标签栏图标必须为 PNG 或 SVG 格式。"
 
-#: sui_window.lua:2065
+#: engines/sui_window.lua:2251
 msgid "Tab order"
 msgstr "标签顺序"
 
-#: sui_style.lua:270
+#: features/sui_style.lua:270
 msgid "Tab: Back to File Browser"
 msgstr "标签：返回文件浏览器"
 
-#: sui_style.lua:249
+#: features/sui_style.lua:249
 msgid "Tab: File Browser Settings"
 msgstr "标签：文件浏览器设置"
 
-#: sui_style.lua:221
+#: features/sui_style.lua:221
 msgid "Tab: Menu"
 msgstr "标签：菜单"
 
-#: sui_style.lua:256
+#: features/sui_style.lua:256
 msgid "Tab: Reader Navigation"
 msgstr "标签：导航"
 
-#: sui_style.lua:263
+#: features/sui_style.lua:263
 msgid "Tab: Reader Typeset"
 msgstr "标签：排版"
 
-#: sui_style.lua:242
+#: features/sui_style.lua:242
 msgid "Tab: Search"
 msgstr "标签：搜索"
 
-#: sui_style.lua:228
+#: features/sui_style.lua:228
 msgid "Tab: Settings"
 msgstr "标签：设置"
 
-#: sui_style.lua:277
+#: features/sui_style.lua:277
 msgid "Tab: SimpleUI Quick Settings"
 msgstr "标签：快速设置"
 
-#: sui_style.lua:235
+#: features/sui_style.lua:235
 msgid "Tab: Tools"
 msgstr "标签：工具"
 
-#: sui_menu.lua:1132 sui_menu.lua:1184
+#: screens/sui_menu.lua:1149
+#: screens/sui_menu.lua:1201
 msgid "Tabs"
 msgstr "标签"
 
-#: sui_menu.lua:1126
+#: screens/sui_menu.lua:1143
 msgid "Tabs  (%d/%d — %d left)"
 msgstr "标签页（%d/%d — 剩余 %d 个）"
 
-#: sui_menu.lua:1124
+#: screens/sui_menu.lua:1141
 msgid "Tabs  (%d/%d — at limit)"
 msgstr "标签（%d/%d — 已达限制）"
 
-#: sui_quickactions.lua:881 sui_config.lua:135 sui_browsemeta.lua:79
+#: features/sui_quickactions.lua:915
+#: infra/sui_config.lua:136
+#: features/library/sui_library_browse.lua:60
 msgid "Tags"
 msgstr "标签"
 
-#: desktop_modules/module_clock.lua:201 desktop_modules/module_clock.lua:249
+#: screens/sui_settings_window.lua:401
+msgid "Tap \"Create Screen\" below to add one."
+msgstr "点击下方的“创建屏幕”以添加一个。"
+
+#: modules/module_clock.lua:240
 msgid "Ten"
 msgstr "十"
 
-#: sui_menu.lua:201
+#: engines/sui_book_grid.lua:1896
+#: screens/sui_menu.lua:209
 msgid "Text"
 msgstr "文字"
 
-#: sui_menu.lua:3332 desktop_modules/module_collections.lua:671
-#: desktop_modules/module_collections.lua:672
-#: desktop_modules/module_action_list.lua:569
-#: desktop_modules/module_action_list.lua:570
-#: desktop_modules/module_recent.lua:530 desktop_modules/module_recent.lua:531
-#: desktop_modules/module_tbr.lua:738 desktop_modules/module_tbr.lua:739
-#: desktop_modules/module_reading_stats.lua:714
-#: desktop_modules/module_reading_stats.lua:717
-#: desktop_modules/module_new_books.lua:352
-#: desktop_modules/module_new_books.lua:353
-#: desktop_modules/module_currently.lua:1024
-#: desktop_modules/module_currently.lua:1025
+#: modules/module_action_list.lua:577
+#: modules/module_action_list.lua:578
+#: modules/module_reading_stats.lua:819
+#: modules/module_reading_stats.lua:822
+#: modules/module_currently.lua:1349
+#: modules/module_currently.lua:1350
+#: engines/sui_book_grid.lua:1735
+#: engines/sui_book_grid.lua:1736
+#: screens/sui_menu.lua:3406
 msgid "Text Size"
 msgstr "文字大小"
 
-#: desktop_modules/module_reading_stats.lua:715
+#: modules/module_reading_stats.lua:820
 msgid "Text Size — %d%%"
 msgstr "文字大小 — %d%%"
 
-#: sui_menu.lua:203
+#: screens/sui_menu.lua:211
 msgid "Text only"
 msgstr "仅文字"
 
-#: desktop_modules/module_coverdeck.lua:1105
-#: desktop_modules/module_coverdeck.lua:1106
+#: modules/module_coverdeck.lua:1168
+#: modules/module_coverdeck.lua:1169
 msgid "Text size"
 msgstr "文字大小"
 
-#: sui_quicksettings_bar.lua:1183
-msgid ""
-"The Quick Settings Bar will be %s after restart.\n"
-"\n"
-"Restart now?"
-msgstr ""
-"重启后快捷设置栏将变为 %s。\n"
-"\n"
-"是否立即重启？"
+#: screens/sui_quicksettings_bar.lua:1183
+msgid "The Quick Settings Bar will be %s after restart.\n\nRestart now?"
+msgstr "重启后快捷设置栏将变为 %s。\n\n是否立即重启？"
 
-#: sui_menu.lua:2570
-msgid ""
-"The cover shown right as a book opens normally comes from the library's "
-"cached thumbnail, which can look soft on higher-resolution screens. When on, "
-"SimpleUI instead reads the cover straight from the book file for that moment "
-"(also covers books never opened before, which otherwise show no cover at "
-"all) — at the cost of a brief extra pause while opening, since the file has "
-"to be read twice. Cover on close is unaffected either way: it already reads "
-"the full-quality cover from the open book."
-msgstr ""
-"书籍打开时显示的封面，一般来自书库的缓存缩略图，在高分辨率屏幕上可能发虚。启"
-"用此选项后，插件会直接从书籍文件中读取封面，即便是从未打开过的书也能显示"
-"封面（否则将无封面显示）。代价是打开书籍时会多一次短暂停顿，因为文件需要被读"
-"取两次。关闭时的封面不受影响：其始终从已打开的书籍中读取完整质量封面。"
+#: screens/sui_menu.lua:2620
+msgid "The cover shown right as a book opens normally comes from the library's cached thumbnail, which can look soft on higher-resolution screens. When on, SimpleUI instead reads the cover straight from the book file for that moment (also covers books never opened before, which otherwise show no cover at all) — at the cost of a brief extra pause while opening, since the file has to be read twice. Cover on close is unaffected either way: it already reads the full-quality cover from the open book."
+msgstr "书籍打开时显示的封面，一般来自书库的缓存缩略图，在高分辨率屏幕上可能发虚。启用此选项后，插件会直接从书籍文件中读取封面，即便是从未打开过的书也能显示封面（否则将无封面显示）。代价是打开书籍时会多一次短暂停顿，因为文件需要被读取两次。关闭时的封面不受影响：其始终从已打开的书籍中读取完整质量封面。"
 
-#: sui_patches.lua:1016
+#: main.lua:1399
+#: screens/sui_bottombar.lua:1870
+msgid "The navigation bar is already available on this screen."
+msgstr "此屏幕已提供导航栏。"
+
+#: infra/sui_patches.lua:1283
 msgid "The «To Be Read» collection cannot be renamed."
 msgstr "「待读」收藏夹无法重命名。"
 
-#: sui_menu.lua:4356
+#: screens/sui_menu.lua:4386
 msgid "Theme Colors"
 msgstr "主题颜色"
 
-#: desktop_modules/module_clock.lua:204 desktop_modules/module_clock.lua:250
+#: modules/module_clock.lua:241
 msgid "Thirteen"
 msgstr "十三"
 
-#: desktop_modules/module_clock.lua:216 desktop_modules/module_clock.lua:255
+#: modules/module_clock.lua:246
 msgid "Thirty"
 msgstr "三十"
 
-#: sui_quickactions.lua:2921 sui_quickactions.lua:3007
-msgid ""
-"This group is empty.\n"
-"Add actions to it from Settings → Quick Actions."
-msgstr ""
-"该分组为空。\n"
-"请在「快捷操作」中添加操作。"
+#: features/sui_quickactions.lua:3185
+#: features/sui_quickactions.lua:3271
+msgid "This group is empty.\nAdd actions to it from Settings → Quick Actions."
+msgstr "该分组为空。\n请在「快捷操作」中添加操作。"
 
-#: desktop_modules/module_reading_stats.lua:91
+#: modules/module_reading_stats.lua:121
 msgid "This month — Pages"
 msgstr "本月 — 页数"
 
-#: desktop_modules/module_reading_stats.lua:90
+#: modules/module_reading_stats.lua:120
 msgid "This month — Time"
 msgstr "本月 — 时间"
 
-#: sui_presets.lua:837 sui_presets.lua:910 sui_presets.lua:996
+#: features/sui_presets.lua:785
+#: features/sui_presets.lua:858
+#: features/sui_presets.lua:944
 msgid "This name is reserved by a built-in preset."
 msgstr "此名称已被内置预设保留使用。"
 
-#: desktop_modules/module_reading_stats.lua:87
+#: modules/module_reading_stats.lua:117
 msgid "This week — Pages"
 msgstr "本周 — 页数"
 
-#: desktop_modules/module_reading_stats.lua:86
+#: modules/module_reading_stats.lua:116
 msgid "This week — Time"
 msgstr "本周 — 时间"
 
-#: sui_menu.lua:4422
-msgid ""
-"This will delete all Simple UI settings and restart KOReader.\n"
-"Are you sure?"
-msgstr ""
-"这将删除所有 Simple UI 设置并重启 KOReader。\n"
-"确定要继续吗？"
+#: screens/sui_menu.lua:4452
+msgid "This will delete all Simple UI settings and restart KOReader.\nAre you sure?"
+msgstr "这将删除所有 Simple UI 设置并重启 KOReader。\n确定要继续吗？"
 
-#: desktop_modules/module_clock.lua:194 desktop_modules/module_clock.lua:246
+#: modules/module_clock.lua:237
 msgid "Three"
 msgstr "三"
 
-#: sui_stats_windows.lua:2825
+#: screens/sui_stats_windows.lua:2830
 msgid "Thu"
 msgstr "星期四"
 
-#: desktop_modules/module_clock.lua:57
+#: modules/module_clock.lua:58
 msgid "Thursday"
 msgstr "星期四"
 
-#: desktop_modules/module_coverdeck.lua:80
-#: desktop_modules/module_currently.lua:251
+#: modules/module_coverdeck.lua:165
+#: modules/module_currently.lua:288
 msgid "Time read"
 msgstr "已读时间"
 
-#: desktop_modules/module_coverdeck.lua:81
-#: desktop_modules/module_currently.lua:252
+#: modules/module_coverdeck.lua:166
+#: modules/module_currently.lua:289
 msgid "Time remaining"
 msgstr "剩余时间"
 
-#: sui_titlebar.lua:106 desktop_modules/module_coverdeck.lua:90
-#: desktop_modules/module_currently.lua:246
+#: modules/module_coverdeck.lua:175
+#: modules/module_currently.lua:281
+#: screens/sui_titlebar.lua:106
 msgid "Title"
 msgstr "标题"
 
-#: desktop_modules/module_coll_row.lua:139
+#: modules/module_library.lua:212
+#: modules/module_feat_coll.lua:168
+#: modules/module_tbr.lua:268
 msgid "Title (A–Z)"
 msgstr "标题（A–Z）"
 
-#: desktop_modules/module_coll_row.lua:140
+#: modules/module_library.lua:213
+#: modules/module_feat_coll.lua:169
+#: modules/module_tbr.lua:269
 msgid "Title (Z–A)"
 msgstr "标题（Z–A）"
 
-#: sui_menu.lua:2688 sui_style.lua:1382
+#: features/sui_style.lua:1382
+#: screens/sui_menu.lua:2762
 msgid "Title Bar"
 msgstr "标题栏"
 
-#: sui_menu.lua:1747
-msgid ""
-"Title Bar will be %s after restart.\n"
-"\n"
-"Restart now?"
-msgstr ""
-"重启后标题栏将变为 %s。\n"
-"\n"
-"是否立即重启？"
+#: screens/sui_menu.lua:1797
+msgid "Title Bar will be %s after restart.\n\nRestart now?"
+msgstr "重启后标题栏将变为 %s。\n\n是否立即重启？"
 
-#: sui_menu.lua:3394
+#: screens/sui_menu.lua:3468
 msgid "Title and Author"
 msgstr "标题与作者"
 
-#: sui_menu.lua:3345
+#: screens/sui_menu.lua:3419
 msgid "Title and Author Below Covers"
 msgstr "封面下方显示标题和作者"
 
-#: sui_menu.lua:3406
-msgid ""
-"Title and author strip enabled.\n"
-"\n"
-"Restart now?"
-msgstr ""
-"标题与作者栏已启用。\n"
-"\n"
-"是否立即重启？"
+#: screens/sui_menu.lua:3480
+msgid "Title and author strip enabled.\n\nRestart now?"
+msgstr "标题与作者栏已启用。\n\n是否立即重启？"
 
-#: sui_menu.lua:3372
+#: screens/sui_menu.lua:3446
 msgid "Title only"
 msgstr "仅标题"
 
-#: sui_menu.lua:3361
-msgid ""
-"Title strip disabled.\n"
-"\n"
-"Restart now?"
-msgstr ""
-"标题栏已禁用。\n"
-"\n"
-"是否立即重启？"
+#: screens/sui_menu.lua:3435
+msgid "Title strip disabled.\n\nRestart now?"
+msgstr "标题栏已禁用。\n\n是否立即重启？"
 
-#: sui_menu.lua:3384
-msgid ""
-"Title strip enabled.\n"
-"\n"
-"Restart now?"
-msgstr ""
-"标题栏已启用。\n"
-"\n"
-"是否立即重启？"
+#: screens/sui_menu.lua:3458
+msgid "Title strip enabled.\n\nRestart now?"
+msgstr "标题栏已启用。\n\n是否立即重启？"
 
-#: desktop_modules/module_tbr.lua:257 desktop_modules/module_tbr.lua:258
-#: desktop_modules/module_tbr.lua:273 desktop_modules/module_tbr.lua:309
-#: desktop_modules/module_tbr.lua:755 desktop_modules/module_coverdeck.lua:1165
-#: desktop_modules/module_coverdeck.lua:1187
+#: modules/module_tbr.lua:507
+#: modules/module_tbr.lua:552
+#: modules/module_tbr.lua:553
+#: modules/module_coverdeck.lua:1244
 msgid "To Be Read"
 msgstr "待读"
 
-#: desktop_modules/module_tbr.lua:617
+#: modules/module_tbr.lua:363
 msgid "To Be Read Books"
 msgstr "待读书籍"
 
-#: sui_patches.lua:1058
-msgid "To Be Read list is full (max. 5 books)."
-msgstr "待读列表已满（最多 5 本书）。"
-
-#: desktop_modules/module_reading_goals.lua:652
-#: desktop_modules/module_reading_goals.lua:654
-#: desktop_modules/module_reading_goals.lua:708
-#: desktop_modules/module_reading_goals.lua:711
+#: modules/module_reading_goals.lua:636
+#: modules/module_reading_goals.lua:638
+#: modules/module_reading_goals.lua:692
+#: modules/module_reading_goals.lua:695
 msgid "Today"
 msgstr "今天"
 
-#: desktop_modules/module_reading_stats.lua:85
+#: modules/module_reading_stats.lua:115
 msgid "Today — Pages"
 msgstr "今天 — 页数"
 
-#: desktop_modules/module_reading_stats.lua:84
+#: modules/module_reading_stats.lua:114
 msgid "Today — Time"
 msgstr "今天 — 时间"
 
-#: sui_menu.lua:2866 sui_menu.lua:2873 sui_menu.lua:2877 sui_menu.lua:3277
-#: sui_menu.lua:3284 desktop_modules/module_collections.lua:942
+#: modules/module_collections.lua:1408
+#: screens/sui_menu.lua:2940
+#: screens/sui_menu.lua:2947
+#: screens/sui_menu.lua:2951
+#: screens/sui_menu.lua:3351
+#: screens/sui_menu.lua:3358
 msgid "Top"
 msgstr "顶部"
 
-#: sui_topbar.lua:515
+#: screens/sui_topbar.lua:515
 msgid "Top Bar"
 msgstr "顶部栏"
 
-#: sui_homescreen.lua:1868
+#: engines/sui_screen_engine.lua:2115
 msgid "Top Margin"
 msgstr "顶部边距"
 
-#: sui_stats_windows.lua:948 sui_stats_windows.lua:3673
+#: screens/sui_stats_windows.lua:953
+#: screens/sui_stats_windows.lua:3680
 msgid "Total"
 msgstr "总计"
 
-#: sui_stats_windows.lua:2432 sui_stats_windows.lua:2448
+#: screens/sui_stats_windows.lua:2437
+#: screens/sui_stats_windows.lua:2453
 msgid "Total time"
 msgstr "总时长"
 
-#: sui_menu.lua:3232 sui_menu.lua:3249 sui_quicksettings_bar.lua:1355
-#: desktop_modules/module_quick_actions.lua:612
+#: modules/module_quick_actions.lua:727
+#: screens/sui_menu.lua:3306
+#: screens/sui_menu.lua:3323
+#: screens/sui_quicksettings_bar.lua:1355
 msgid "Transparent"
 msgstr "透明"
 
-#: sui_menu.lua:2252
+#: screens/sui_menu.lua:2302
 msgid "Transparent navigation bar"
 msgstr "透明导航栏"
 
-#: sui_menu.lua:2234
+#: screens/sui_menu.lua:2284
 msgid "Transparent status bar"
 msgstr "透明状态栏"
 
-#: sui_stats_windows.lua:2825
+#: screens/sui_stats_windows.lua:2830
 msgid "Tue"
 msgstr "星期二"
 
-#: desktop_modules/module_clock.lua:56
+#: modules/module_clock.lua:57
 msgid "Tuesday"
 msgstr "星期二"
 
-#: desktop_modules/module_clock.lua:203 desktop_modules/module_clock.lua:249
+#: modules/module_clock.lua:240
 msgid "Twelve"
 msgstr "十二"
 
-#: desktop_modules/module_clock.lua:215 desktop_modules/module_clock.lua:255
+#: modules/module_clock.lua:246
 msgid "Twenty"
 msgstr "二十"
 
-#: desktop_modules/module_clock.lua:193 desktop_modules/module_clock.lua:246
+#: modules/module_clock.lua:237
 msgid "Two"
 msgstr "二"
 
-#: sui_menu.lua:3054 sui_menu.lua:3121
+#: screens/sui_menu.lua:3128
+#: screens/sui_menu.lua:3195
 msgid "Type"
 msgstr "类型"
 
-#: sui_menu.lua:4252 sui_menu.lua:4255
+#: screens/sui_menu.lua:4282
+#: screens/sui_menu.lua:4285
 msgid "UI Font"
 msgstr "UI 字体"
 
-#: sui_menu.lua:4259
+#: screens/sui_menu.lua:4289
 msgid "UI Font  (default)"
 msgstr "UI 字体（默认）"
 
-#: sui_menu.lua:4261
+#: screens/sui_menu.lua:4291
 msgid "UI Font  [%s]"
 msgstr "UI 字体 [%s]"
 
-#: sui_menu.lua:3421
+#: screens/sui_menu.lua:3495
 msgid "Uniformize Covers (2:3)"
 msgstr "统一封面比例（2:3）"
 
-#: sui_stats_windows.lua:863
+#: modules/module_coverdeck.lua:123
+msgid "Unknown Author"
+msgstr "未知作者"
+
+#: screens/sui_stats_windows.lua:868
 msgid "Unknown error."
 msgstr "未知错误。"
 
-#: sui_style.lua:2398
+#: features/sui_style.lua:2411
 msgid "Unsupported format (use a folder or a .zip file)"
 msgstr "不支持的格式（请使用文件夹或 .zip 文件）"
 
-#: sui_quickactions.lua:92 sui_quickactions.lua:1625 sui_style.lua:1128
-#: sui_style.lua:1336
-msgid ""
-"Unsupported icon format.\n"
-"Please use a PNG or SVG file."
-msgstr ""
-"不支持的图标格式。\n"
-"请使用 PNG 或 SVG 文件。"
+#: features/sui_quickactions.lua:93
+#: features/sui_quickactions.lua:1770
+#: features/sui_style.lua:1128
+#: features/sui_style.lua:1336
+msgid "Unsupported icon format.\nPlease use a PNG or SVG file."
+msgstr "不支持的图标格式。\n请使用 PNG 或 SVG 文件。"
 
-#: sui_window.lua:1784 sui_window.lua:2621
+#: engines/sui_window.lua:1920
+#: engines/sui_window.lua:2815
 msgid "Update"
 msgstr "更新"
 
-#: desktop_modules/module_reading_stats.lua:858
-#: desktop_modules/module_reading_goals.lua:1089
-#: desktop_modules/module_coverdeck.lua:1452
-#: desktop_modules/module_currently.lua:1547
+#: modules/module_reading_stats.lua:963
+#: modules/module_reading_goals.lua:1079
+#: modules/module_coverdeck.lua:1522
+#: modules/module_currently.lua:1895
 msgid "Update Stats Now"
 msgstr "立即更新统计"
 
-#: sui_updater.lua:448
+#: infra/sui_updater.lua:475
 msgid "Update cancelled."
 msgstr "更新已取消。"
 
-#: sui_updater.lua:649
+#: infra/sui_updater.lua:676
 msgid "Update check cancelled."
 msgstr "更新检查已取消。"
 
-#: sui_menu.lua:4007 sui_presets.lua:883
+#: features/sui_presets.lua:831
+#: screens/sui_menu.lua:4037
 msgid "Update with current settings"
 msgstr "使用当前设置更新"
 
-#: sui_menu.lua:4407
+#: screens/sui_menu.lua:4437
 msgid "Updater module not found."
 msgstr "未找到更新模块。"
 
-#: sui_stats_windows.lua:3129
+#: screens/sui_stats_windows.lua:3134
 msgid "Use freeze"
 msgstr "使用冻结"
 
-#: sui_quickactions.lua:1821
+#: features/sui_quickactions.lua:1989
 msgid "Use this Nerd Font icon?"
 msgstr "使用此 Nerd Font 图标吗？"
 
-#: sui_menu.lua:518
-msgid ""
-"Uses the standard KOReader pagination bar on the homescreen.\n"
-"Not available when Navpager is active."
-msgstr ""
-"在主屏幕上使用 KOReader 标准分页栏。\n"
-"启用导航分页器时不可用。"
+#: screens/sui_menu.lua:532
+msgid "Uses the standard KOReader pagination bar on the homescreen.\nNot available when Navpager is active."
+msgstr "在主屏幕上使用 KOReader 标准分页栏。\n启用导航分页器时不可用。"
 
-#: sui_settings_window.lua:299
+#: screens/sui_settings_window.lua:325
 msgid "Version, author and updates"
 msgstr "版本、作者与更新"
 
-#: sui_menu.lua:4379
+#: screens/sui_menu.lua:4409
 msgid "Version: %s"
 msgstr "版本：%s"
 
-#: sui_homescreen.lua:1871
-msgid ""
-"Vertical space above this module.\n"
-"100% is the default spacing."
-msgstr ""
-"此模块上方的垂直间距。\n"
-"默认间距为100%。"
+#: engines/sui_screen_engine.lua:2118
+msgid "Vertical space above this module.\n100% is the default spacing."
+msgstr "此模块上方的垂直间距。\n默认间距为100%。"
 
-#: desktop_modules/module_clock.lua:888
-msgid ""
-"Vertical space between the clock and the date.\n"
-"100% is the default spacing."
-msgstr ""
-"时钟和日期之间的垂直间距。\n"
-"默认间距为100%。"
+#: modules/module_clock.lua:1069
+msgid "Vertical space between the clock and the date.\n100% is the default spacing."
+msgstr "时钟和日期之间的垂直间距。\n默认间距为100%。"
 
-#: desktop_modules/module_clock.lua:914
-msgid ""
-"Vertical space between the date (or clock) and the battery.\n"
-"100% is the default spacing."
-msgstr ""
-"日期（或时钟）与电池之间的垂直间距。\n"
-"默认间距为100%。"
+#: modules/module_clock.lua:1095
+msgid "Vertical space between the date (or clock) and the battery.\n100% is the default spacing."
+msgstr "日期（或时钟）与电池之间的垂直间距。\n默认间距为100%。"
 
-#: sui_menu.lua:2943 sui_menu.lua:2997 sui_menu.lua:3229
+#: modules/module_clock.lua:972
+#: screens/sui_menu.lua:3017
+#: screens/sui_menu.lua:3071
+#: screens/sui_menu.lua:3303
 msgid "Visibility"
 msgstr "可见"
 
-#: sui_menu.lua:2939 sui_menu.lua:2945 sui_menu.lua:2949 sui_menu.lua:2993
-#: sui_menu.lua:2999 sui_menu.lua:3003
+#: screens/sui_menu.lua:3013
+#: screens/sui_menu.lua:3019
+#: screens/sui_menu.lua:3023
+#: screens/sui_menu.lua:3067
+#: screens/sui_menu.lua:3073
+#: screens/sui_menu.lua:3077
 msgid "Visible"
 msgstr "可见"
 
-#: sui_stats_windows.lua:2738 sui_stats_windows.lua:3390
+#: screens/sui_stats_windows.lua:2743
+#: screens/sui_stats_windows.lua:3395
 msgid "WEEK STREAK"
 msgstr "连续周数"
 
-#: desktop_modules/module_clock.lua:234 desktop_modules/module_clock.lua:259
+#: modules/module_clock.lua:250
 msgid "WORD_CLOCK_TENS_SEP"
 msgstr "零"
 
-#: sui_menu.lua:2657 sui_settings_window.lua:318 sui_settings_window.lua:862
+#: screens/sui_menu.lua:2731
+#: screens/sui_settings_window.lua:355
+#: screens/sui_settings_window.lua:361
 msgid "Wallpaper"
 msgstr "壁纸"
 
-#: sui_style.lua:2006
+#: features/sui_style.lua:2019
 msgid "Warm Paper"
 msgstr "暖纸色"
 
-#: sui_quicksettings_bar.lua:500 sui_quicksettings_bar.lua:521
-#: sui_quicksettings_bar.lua:532
+#: screens/sui_quicksettings_bar.lua:500
+#: screens/sui_quicksettings_bar.lua:521
+#: screens/sui_quicksettings_bar.lua:532
 msgid "Warmth"
 msgstr "色温"
 
-#: sui_quicksettings_bar.lua:1281
+#: screens/sui_quicksettings_bar.lua:1281
 msgid "Warmth Slider"
 msgstr "色温滑块"
 
-#: sui_menu.lua:2608
+#: screens/sui_menu.lua:2658
 msgid "Warn when modules on a page exceed the available screen height."
 msgstr "当页面上的模块超出屏幕高度时发出警告。"
 
-#: sui_stats_windows.lua:2825
+#: screens/sui_stats_windows.lua:2830
 msgid "Wed"
 msgstr "星期三"
 
-#: desktop_modules/module_clock.lua:56
+#: modules/module_clock.lua:57
 msgid "Wednesday"
 msgstr "星期三"
 
-#: sui_onboarding.lua:233 sui_onboarding.lua:234
+#: screens/sui_onboarding.lua:233
+#: screens/sui_onboarding.lua:234
 msgid "Welcome to Simple UI"
 msgstr "欢迎使用 Simple UI"
 
-#: sui_updater.lua:476
+#: infra/sui_updater.lua:503
 msgid "What's new:"
 msgstr "更新内容："
 
-#: sui_menu.lua:2633
-msgid ""
-"When a finished book is deleted from the device, keep it counted in the "
-"Books Read statistics on the Home Screen.\n"
-"\n"
-"Books changed back to Reading or Abandoned are automatically removed from "
-"this list."
-msgstr ""
-"已读完的书籍从设备中删除后，仍保留在主屏幕「已读书籍」统计中。\n"
-"\n"
-"若将书籍状态改回「阅读中」或「放弃」，则会自动从该列表中移除。"
+#: screens/sui_menu.lua:2683
+msgid "When a finished book is deleted from the device, keep it counted in the Books Read statistics on the Home Screen.\n\nBooks changed back to Reading or Abandoned are automatically removed from this list."
+msgstr "已读完的书籍从设备中删除后，仍保留在主屏幕「已读书籍」统计中。\n\n若将书籍状态改回「阅读中」或「放弃」，则会自动从该列表中移除。"
 
-#: sui_menu.lua:2488
-msgid ""
-"When closing a book from the Home Screen, go back to the folder where the "
-"book is located instead of the Library home folder."
+#: screens/sui_menu.lua:2538
+msgid "When closing a book from the Home Screen, go back to the folder where the book is located instead of the Library home folder."
 msgstr "从主屏幕关闭书籍时，返回该书所在的文件夹，而不是书库主文件夹。"
 
-#: sui_menu.lua:2620
-msgid ""
-"When enabled, long-pressing a module on the home screen opens its settings "
-"menu.\n"
-"Disable this to prevent settings from appearing on long tap."
-msgstr ""
-"启用后，长按主屏幕上的模块会打开其设置菜单。\n"
-"禁用此项可防止长按时出现设置菜单。"
+#: screens/sui_menu.lua:2670
+msgid "When enabled, long-pressing a module on the home screen opens its settings menu.\nDisable this to prevent settings from appearing on long tap."
+msgstr "启用后，长按主屏幕上的模块会打开其设置菜单。\n禁用此项可防止长按时出现设置菜单。"
 
-#: sui_quicksettings_bar.lua:1389
-msgid ""
-"When enabled, long-pressing the Quick Settings Bar opens its settings menu.\n"
-"Disable this to prevent the settings menu from appearing on long tap."
-msgstr ""
-"启用后，长按快捷设置栏会打开其设置菜单。\n"
-"禁用此项可防止长按时出现设置菜单。"
+#: screens/sui_quicksettings_bar.lua:1389
+msgid "When enabled, long-pressing the Quick Settings Bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
+msgstr "启用后，长按快捷设置栏会打开其设置菜单。\n禁用此项可防止长按时出现设置菜单。"
 
-#: sui_menu.lua:1371
-msgid ""
-"When enabled, long-pressing the bottom bar opens its settings menu.\n"
-"Disable this to prevent the settings menu from appearing on long tap."
-msgstr ""
-"启用后，长按底部栏会打开其设置菜单。\n"
-"禁用此项可防止长按时出现设置菜单。"
+#: screens/sui_menu.lua:1394
+msgid "When enabled, long-pressing the navigation bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
+msgstr "启用后，长按导航栏会打开其设置菜单。\n禁用此项可防止长按时出现设置菜单。"
 
-#: sui_menu.lua:1079
-msgid ""
-"When enabled, long-pressing the top bar opens its settings menu.\n"
-"Disable this to prevent the settings menu from appearing on long tap."
-msgstr ""
-"启用后，长按顶部栏会打开其设置菜单。\n"
-"禁用此项可防止长按时出现设置菜单。"
+#: screens/sui_menu.lua:1096
+msgid "When enabled, long-pressing the top bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
+msgstr "启用后，长按顶部栏会打开其设置菜单。\n禁用此项可防止长按时出现设置菜单。"
 
-#: sui_menu.lua:2374
-msgid ""
-"When waking the device from sleep/suspend, always return to the Home Screen "
-"— even if a book was open when it went to sleep."
+#: screens/sui_menu.lua:2424
+msgid "When waking the device from sleep/suspend, always return to the Home Screen — even if a book was open when it went to sleep."
 msgstr "设备从休眠唤醒时始终返回主屏幕，即使休眠前正在阅读书籍。"
 
-#: sui_quickactions.lua:767 sui_config.lua:125
+#: features/sui_quickactions.lua:801
+#: infra/sui_config.lua:126
 msgid "Wi-Fi"
 msgstr "Wi-Fi"
 
-#: sui_quickactions.lua:229
+#: features/sui_quickactions.lua:244
 msgid "Wi-Fi off"
 msgstr "Wi-Fi 关闭"
 
-#: sui_config.lua:167
+#: infra/sui_config.lua:168
 msgid "WiFi"
 msgstr "Wi-Fi"
 
-#: sui_quickactions.lua:216
+#: features/sui_quickactions.lua:231
 msgid "WiFi not available on this device."
 msgstr "该设备不支持 Wi-Fi。"
 
-#: sui_quickactions.lua:1965
+#: features/sui_quickactions.lua:2133
 msgid "Wikipedia Lookup"
 msgstr "维基百科查询"
 
-#: desktop_modules/module_currently.lua:1510
+#: modules/module_currently.lua:1871
 msgid "With percentage"
 msgstr "带百分比"
 
-#: desktop_modules/module_clock.lua:831 desktop_modules/module_clock.lua:842
+#: modules/module_clock.lua:1000
+#: modules/module_clock.lua:1013
 msgid "Word"
 msgstr "单词"
 
-#: sui_stats_windows.lua:1222
+#: screens/sui_stats_windows.lua:1227
 msgid "Yes"
 msgstr "确定"
 
-#: sui_stats_windows.lua:3118
+#: screens/sui_stats_windows.lua:3123
 msgid "Yesterday is already covered by a freeze."
 msgstr "昨天已被冻结覆盖。"
 
-#: sui_stats_windows.lua:3116
+#: screens/sui_stats_windows.lua:3121
 msgid "You already read yesterday — there's nothing to freeze."
 msgstr "昨天的内容你已经读过了，无需冻结。"
 
-#: sui_stats_windows.lua:3109
+#: screens/sui_stats_windows.lua:3114
 msgid "You don't have any freezes available yet."
 msgstr "您当前没有可用的冻结次数。"
 
-#: sui_stats_windows.lua:3127
-msgid ""
-"You have %d freeze(s) available.\n"
-"Use one to cover %s?"
-msgstr ""
-"您还有 %d 次冻结可用。\n"
-"是否使用一次来覆盖 %s？"
+#: screens/sui_stats_windows.lua:3132
+msgid "You have %d freeze(s) available.\nUse one to cover %s?"
+msgstr "您还有 %d 次冻结可用。\n是否使用一次来覆盖 %s？"
 
-#: desktop_modules/module_quote.lua:952
+#: modules/module_quote.lua:1003
 msgid "Your highlights"
 msgstr "您的高亮标注"
 
-#: sui_stats_windows.lua:417
+#: modules/module_reading_stats.lua:134
+msgid "abandoned"
+msgstr "已放弃"
+
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1434
 msgid "apr"
 msgstr "4月"
 
-#: sui_stats_windows.lua:1433
+#: screens/sui_stats_windows.lua:1438
 msgid "april"
 msgstr "4月"
 
-#: sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:1435
 msgid "aug"
 msgstr "8月"
 
-#: sui_stats_windows.lua:1434
+#: screens/sui_stats_windows.lua:1439
 msgid "august"
 msgstr "8月"
 
-#: sui_stats_windows.lua:2306 desktop_modules/module_reading_stats.lua:93
+#: modules/module_reading_stats.lua:123
+#: screens/sui_stats_windows.lua:2311
 msgid "books finished"
 msgstr "已读完书籍"
 
-#: desktop_modules/module_reading_stats.lua:88
+#: modules/module_reading_stats.lua:118
 msgid "daily avg (7 days)"
 msgstr "日均（7天）"
 
-#: desktop_modules/module_reading_stats.lua:95
+#: modules/module_reading_stats.lua:125
 msgid "day streak"
 msgstr "天连续阅读"
 
-#: desktop_modules/module_reading_stats.lua:95
+#: modules/module_reading_stats.lua:125
 msgid "days streak"
 msgstr "天连续阅读"
 
-#: sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:1435
 msgid "dec"
 msgstr "12月"
 
-#: sui_stats_windows.lua:1434
+#: screens/sui_stats_windows.lua:1439
 msgid "december"
 msgstr "12月"
 
-#: sui_quickactions.lua:1617 sui_quickactions.lua:2575
+#: features/sui_quickactions.lua:1762
+#: features/sui_quickactions.lua:2794
 msgid "default"
 msgstr "默认"
 
-#: sui_menu.lua:842 sui_menu.lua:1108 sui_menu.lua:1748 sui_menu.lua:4505
-#: sui_quicksettings_bar.lua:1184
+#: screens/sui_menu.lua:856
+#: screens/sui_menu.lua:1125
+#: screens/sui_menu.lua:1798
+#: screens/sui_menu.lua:4557
+#: screens/sui_quicksettings_bar.lua:1184
 msgid "disabled"
 msgstr "已禁用"
 
-#: sui_style.lua:2101
+#: features/sui_style.lua:2114
 msgid "e.g. #F5F0E8  or #1C1C1E  (empty = reset)"
 msgstr "例如：#F5F0E8 或 #1C1C1E（留空表示重置）"
 
-#: sui_menu.lua:842 sui_menu.lua:1108 sui_menu.lua:1748 sui_menu.lua:4505
-#: sui_quicksettings_bar.lua:1184
+#: screens/sui_menu.lua:856
+#: screens/sui_menu.lua:1125
+#: screens/sui_menu.lua:1798
+#: screens/sui_menu.lua:4557
+#: screens/sui_quicksettings_bar.lua:1184
 msgid "enabled"
 msgstr "已启用"
 
-#: sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1434
 msgid "feb"
 msgstr "2月"
 
-#: sui_stats_windows.lua:1433
+#: screens/sui_stats_windows.lua:1438
 msgid "february"
 msgstr "2月"
 
-#: sui_style.lua:2344
+#: features/sui_style.lua:2357
 msgid "ffi/archiver not available in this KOReader version"
 msgstr "此 KOReader 版本不支持 ffi/archiver 模块"
 
-#: sui_quickactions.lua:1841
+#: features/sui_quickactions.lua:2009
 msgid "hex code, e.g. E001"
 msgstr "十六进制代码，例如 E001"
 
-#: sui_stats_windows.lua:1965 sui_stats_windows.lua:2304
+#: screens/sui_stats_windows.lua:1970
+#: screens/sui_stats_windows.lua:2309
 msgid "hours read"
 msgstr "已读小时数"
 
-#: sui_stats_windows.lua:417
+#: modules/module_reading_stats.lua:133
+msgid "in progress"
+msgstr "进行中"
+
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1434
 msgid "jan"
 msgstr "1月"
 
-#: sui_stats_windows.lua:1433
+#: screens/sui_stats_windows.lua:1438
 msgid "january"
 msgstr "1月"
 
-#: sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:1435
 msgid "jul"
 msgstr "7月"
 
-#: sui_stats_windows.lua:1434
+#: screens/sui_stats_windows.lua:1439
 msgid "july"
 msgstr "7月"
 
-#: sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1434
 msgid "jun"
 msgstr "6月"
 
-#: sui_stats_windows.lua:1433
+#: screens/sui_stats_windows.lua:1438
 msgid "june"
 msgstr "6月"
 
-#: sui_updater.lua:663
+#: infra/sui_updater.lua:690
 msgid "latest"
 msgstr "最新版"
 
-#: sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1434
 msgid "mar"
 msgstr "3月"
 
-#: sui_stats_windows.lua:1433
+#: screens/sui_stats_windows.lua:1438
 msgid "march"
 msgstr "3月"
 
-#: sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1434
+#: screens/sui_stats_windows.lua:1438
 msgid "may"
 msgstr "5月"
 
-#: desktop_modules/module_reading_stats.lua:95
+#: modules/module_reading_stats.lua:125
 msgid "no streak"
 msgstr "无连续阅读"
 
-#: sui_quickactions.lua:1396 sui_quickactions.lua:2672
-#: sui_quickactions.lua:2691
+#: features/sui_quickactions.lua:1499
+#: features/sui_quickactions.lua:2895
+#: features/sui_quickactions.lua:2914
 msgid "not configured"
 msgstr "未配置"
 
-#: sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:1435
 msgid "nov"
 msgstr "11月"
 
-#: sui_stats_windows.lua:1434
+#: screens/sui_stats_windows.lua:1439
 msgid "november"
 msgstr "11月"
 
-#: sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:1435
 msgid "oct"
 msgstr "10月"
 
-#: sui_stats_windows.lua:1434
+#: screens/sui_stats_windows.lua:1439
 msgid "october"
 msgstr "10月"
 
-#: desktop_modules/module_reading_stats.lua:90
+#: modules/module_reading_stats.lua:120
 msgid "of reading this month"
 msgstr "本月阅读量"
 
-#: desktop_modules/module_reading_stats.lua:86
+#: modules/module_reading_stats.lua:116
 msgid "of reading this week"
 msgstr "本周阅读量"
 
-#: desktop_modules/module_reading_stats.lua:84
+#: modules/module_reading_stats.lua:114
 msgid "of reading today"
 msgstr "今天阅读时长"
 
-#: desktop_modules/module_reading_stats.lua:92
+#: modules/module_reading_stats.lua:122
 msgid "of reading, all time"
 msgstr "总计阅读时长"
 
-#: sui_style.lua:2387
+#: features/sui_style.lua:2400
 msgid "pack_path not provided"
 msgstr "未提供 pack_path 参数"
 
-#: sui_stats_windows.lua:2305 sui_stats_windows.lua:2627
+#: screens/sui_stats_windows.lua:2310
+#: screens/sui_stats_windows.lua:2632
 msgid "pages read"
 msgstr "已读页数"
 
-#: desktop_modules/module_reading_stats.lua:91
+#: modules/module_reading_stats.lua:121
 msgid "pages read this month"
 msgstr "本月已读页数"
 
-#: desktop_modules/module_reading_stats.lua:87
+#: modules/module_reading_stats.lua:117
 msgid "pages read this week"
 msgstr "本周已读页数"
 
-#: desktop_modules/module_reading_stats.lua:85
+#: modules/module_reading_stats.lua:115
 msgid "pages read today"
 msgstr "今天阅读页数"
 
-#: desktop_modules/module_reading_stats.lua:89
+#: modules/module_reading_stats.lua:119
 msgid "pages/day (7 days)"
 msgstr "页/天（7天）"
 
-#: sui_stats_windows.lua:2625
+#: screens/sui_stats_windows.lua:2630
 msgid "reading time"
 msgstr "阅读时长"
 
-#: sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:1435
 msgid "sep"
 msgstr "9月"
 
-#: sui_stats_windows.lua:1434
+#: screens/sui_stats_windows.lua:1439
 msgid "september"
 msgstr "9月"
 
-#: sui_updater.lua:665
+#: modules/module_reading_stats.lua:132
+msgid "unread"
+msgstr "未读"
+
+#: infra/sui_updater.lua:692
 msgid "⬆ Update available: %s"
 msgstr "⬆ 有可用更新：%s"
 
-#: sui_menu.lua:337 sui_menu.lua:1929
-#: desktop_modules/module_collections.lua:992
-#: desktop_modules/module_action_list.lua:459
-#: desktop_modules/module_reading_stats.lua:816
-#: desktop_modules/module_quick_actions.lua:377
+#: modules/module_action_list.lua:464
+#: modules/module_reading_stats.lua:921
+#: modules/module_quick_actions.lua:484
+#: screens/sui_menu.lua:351
+#: screens/sui_menu.lua:1979
 msgid "  (%d left)"
 msgid_plural "  (%d left)"
-msgstr[0] "  （剩余 %s）"
-msgstr[1] "  （剩余 %s）"
+msgstr[0] "  （剩余 %d）"
+msgstr[1] "  （剩余 %d）"
 
-#: desktop_modules/module_reading_goals.lua:847
+#: modules/module_reading_goals.lua:832
 msgid "  Set Goal  (%d book in %s)"
 msgid_plural "  Set Goal  (%d books in %s)"
 msgstr[0] "  设置目标（读 %d 本书在 %s 年）"
 msgstr[1] "  设置目标（读 %d 本书在 %s 年）"
 
-#: desktop_modules/module_reading_goals.lua:472
+#: modules/module_reading_goals.lua:472
 msgid "%d book"
 msgid_plural "%d books"
 msgstr[0] "%d 本书"
 msgstr[1] "%d 本书"
 
-#: desktop_modules/module_reading_goals.lua:952
+#: modules/module_reading_goals.lua:937
 msgid "%d book in %s"
 msgid_plural "%d books in %s"
-msgstr[0] "%d 本书在 %s 年"
-msgstr[1] "%d 本书在 %s 年"
+msgstr[0] "读 %d 本书在 %s 年"
+msgstr[1] "读 %d 本书在 %s 年"
 
-#: sui_stats_windows.lua:1291
+#: screens/sui_stats_windows.lua:1296
 msgid "%d book read in %s"
 msgid_plural "%d books read in %s"
 msgstr[0] "已读 %d 本书在 %s 年"
 msgstr[1] "已读 %d 本书在 %s 年"
 
-#: sui_stats_windows.lua:2170 sui_stats_windows.lua:2172
+#: screens/sui_stats_windows.lua:2175
+#: screens/sui_stats_windows.lua:2177
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d 天"
 msgstr[1] "%d 天"
 
-#: desktop_modules/module_coverdeck.lua:841
-#: desktop_modules/module_currently.lua:653
-#: desktop_modules/module_currently.lua:654
-#: desktop_modules/module_currently.lua:732
+#: modules/module_coverdeck.lua:918
+#: modules/module_currently.lua:755
+#: modules/module_currently.lua:756
+#: modules/module_currently.lua:834
 msgid "%d day of reading"
 msgid_plural "%d days of reading"
 msgstr[0] "阅读 %d 天"
 msgstr[1] "阅读 %d 天"
 
-#: sui_stats_windows.lua:3436
+#: screens/sui_stats_windows.lua:3441
 msgid "%d freeze available"
 msgid_plural "%d freezes available"
 msgstr[0] "%d 次冻结可用"
 msgstr[1] "%d 次冻结可用"
 
-#: desktop_modules/module_reading_goals.lua:1038
+#: modules/module_reading_goals.lua:1023
 msgid "%d in %s"
 msgid_plural "%d in %s"
 msgstr[0] "%d 本在 %s 年"
 msgstr[1] "%d 本在 %s 年"
 
-#: sui_quickactions.lua:1388 sui_quickactions.lua:2664
-#: sui_quickactions.lua:2685
+#: features/sui_quickactions.lua:1491
+#: features/sui_quickactions.lua:2887
+#: features/sui_quickactions.lua:2908
 msgid "%d item"
 msgid_plural "%d items"
 msgstr[0] "%d 个项目"
 msgstr[1] "%d 个项目"
 
-#: sui_stats_windows.lua:2190 sui_stats_windows.lua:2192
+#: screens/sui_stats_windows.lua:2195
+#: screens/sui_stats_windows.lua:2197
 msgid "%d week"
 msgid_plural "%d weeks"
 msgstr[0] "%d 周"
 msgstr[1] "%d 周"
 
-#: desktop_modules/module_reading_goals.lua:470
+#: modules/module_reading_goals.lua:470
 msgid "%d/%d book"
 msgid_plural "%d/%d books"
 msgstr[0] "%d/%d 本书"
 msgstr[1] "%d/%d 本书"
 
-#: desktop_modules/module_collections.lua:355
-#: desktop_modules/module_reading_stats.lua:313
-#: desktop_modules/module_quick_actions.lua:493
+#: modules/module_collections.lua:1593
+msgid "(%d collection)"
+msgid_plural "(%d collections)"
+msgstr[0] "（%d 个收藏夹）"
+msgstr[1] "（%d 个收藏夹）"
+
+#: modules/module_reading_stats.lua:380
+#: modules/module_quick_actions.lua:600
 msgid "(%d/%d — %d left)"
 msgid_plural "(%d/%d — %d left)"
 msgstr[0] "（%d/%d — 剩余 %d）"
 msgstr[1] "（%d/%d — 剩余 %d）"
 
-#: sui_quickactions.lua:2192
+#: features/sui_quickactions.lua:2368
 msgid "Group (%d item)"
 msgid_plural "Group (%d items)"
 msgstr[0] "分组（%d 个项目）"
 msgstr[1] "分组（%d 个项目）"
 
-#: desktop_modules/module_reading_goals.lua:1029
+#: modules/module_reading_goals.lua:1014
 msgid "Manually Tracked Books  (%d in %s)"
 msgid_plural "Manually Tracked Books  (%d in %s)"
 msgstr[0] "手动导入的书籍（%d 本在 %s 年）"
 msgstr[1] "手动导入的书籍（%d 本在 %s 年）"
 
-#: sui_quicksettings_bar.lua:1158
+#: screens/sui_quicksettings_bar.lua:1158
 msgid "Maximum of %d slot reached. Remove one first."
 msgid_plural "Maximum of %d slots reached. Remove one first."
 msgstr[0] "最多 %d 个槽位。请先移除一个。"
 msgstr[1] "最多 %d 个槽位。请先移除一个。"
 
-#: sui_menu.lua:636 sui_menu.lua:902
-msgid ""
-"Text shown in the top bar.\n"
-"Maximum %d character."
-msgid_plural ""
-"Text shown in the top bar.\n"
-"Maximum %d characters."
-msgstr[0] ""
-"顶部栏中显示的文本。\n"
-"最多 %d 个字符。"
-msgstr[1] ""
-"顶部栏中显示的文本。\n"
-"最多 %d 个字符。"
+#: screens/sui_menu.lua:650
+#: screens/sui_menu.lua:916
+msgid "Text shown in the top bar.\nMaximum %d character."
+msgid_plural "Text shown in the top bar.\nMaximum %d characters."
+msgstr[0] "顶部栏中显示的文本。\n最多 %d 个字符。"
+msgstr[1] "顶部栏中显示的文本。\n最多 %d 个字符。"
 
-#: sui_menu.lua:1893 sui_menu.lua:2012
-#: desktop_modules/module_action_list.lua:396
-#: desktop_modules/module_action_list.lua:533
-#: desktop_modules/module_quick_actions.lua:319
-#: desktop_modules/module_quick_actions.lua:460
+#: modules/module_action_list.lua:401
+#: modules/module_action_list.lua:538
+#: modules/module_quick_actions.lua:426
+#: modules/module_quick_actions.lua:567
+#: screens/sui_menu.lua:1943
+#: screens/sui_menu.lua:2062
 msgid "The maximum of %d action per module has been reached. Remove one first."
-msgid_plural ""
-"The maximum of %d actions per module has been reached. Remove one first."
+msgid_plural "The maximum of %d actions per module has been reached. Remove one first."
 msgstr[0] "每个模块最多 %d 个操作。请先删除一个。"
 msgstr[1] "每个模块最多 %d 个操作。请先删除一个。"
 
-#: sui_quickactions.lua:1454 sui_quickactions.lua:2628
+#: features/sui_quickactions.lua:1563
+#: features/sui_quickactions.lua:2849
 msgid "The maximum of %d quick action has been reached. Delete one first."
-msgid_plural ""
-"The maximum of %d quick actions has been reached. Delete one first."
+msgid_plural "The maximum of %d quick actions has been reached. Delete one first."
 msgstr[0] "最多 %d 个快捷操作。请先删除一个。"
 msgstr[1] "最多 %d 个快捷操作。请先删除一个。"
 
-#: desktop_modules/module_reading_stats.lua:602
-#: desktop_modules/module_reading_stats.lua:684
+#: modules/module_reading_stats.lua:707
+#: modules/module_reading_stats.lua:789
 msgid "The maximum of %d stat per row has been reached. Remove one first."
-msgid_plural ""
-"The maximum of %d stats per row has been reached. Remove one first."
+msgid_plural "The maximum of %d stats per row has been reached. Remove one first."
 msgstr[0] "每行最多 %d 个统计项。请先移除一项。"
 msgstr[1] "每行最多 %d 个统计项。请先移除一项。"
 
-#: sui_menu.lua:370 sui_menu.lua:1223
+#: screens/sui_menu.lua:384
+#: screens/sui_menu.lua:1240
 msgid "The maximum of %d tab has been reached. Remove one first."
 msgid_plural "The maximum of %d tabs has been reached. Remove one first."
 msgstr[0] "最多 %d 个标签。请先删除一个。"
 msgstr[1] "最多 %d 个标签。请先删除一个。"
 
-#: sui_stats_windows.lua:1968
+#: screens/sui_stats_windows.lua:1973
 msgid "day read"
 msgid_plural "days read"
 msgstr[0] "已读天数"
 msgstr[1] "已读天数"
 
-#: sui_stats_windows.lua:1983
+#: screens/sui_stats_windows.lua:1988
 msgid "page read"
 msgid_plural "pages read"
 msgstr[0] "已读页数"

--- a/locale/zh_TW.po
+++ b/locale/zh_TW.po
@@ -1,1946 +1,4890 @@
 # Simple UI — KOReader plugin
-# Traditional Chinese translation
+# Translation template
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: simpleui\n"
-"PO-Revision-Date: 2026-04-05 12:00+0000\n"
+"POT-Creation-Date: 2026-08-17 08:26\n"
+"PO-Revision-Date: 2026-08-18 20:56\n"
+"Last-Translator: \n"
 "Language-Team: Chinese (Traditional)\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
-#: sui_menu.lua:347
-msgid "General"
-msgstr "一般"
+#: modules/module_reading_goals.lua:853
+msgid "  Set Goal  (%d hr/month)"
+msgstr "  設定目標（%d 小時/月）"
 
-#: sui_menu.lua:320
-msgid "    Size"
-msgstr "    大小"
-
-#: desktop_modules/module_reading_goals.lua:602
-msgid "  Physical Books  (%d in %s)"
-msgstr ""
-
-#: desktop_modules/module_reading_goals.lua:595
-msgid "  Set Goal  (%d books in %s)"
-msgstr ""
-
-#: desktop_modules/module_reading_goals.lua:617
+#: modules/module_reading_goals.lua:873
 msgid "  Set Goal  (%d min/day)"
-msgstr ""
+msgstr "  設定目標（%d 分鐘/天）"
 
-#: desktop_modules/module_reading_goals.lua:596
+#: modules/module_reading_goals.lua:833
 msgid "  Set Goal  (%s)"
-msgstr "  設定目標  (%s)"
+msgstr "  設定目標（%s）"
 
-#: desktop_modules/module_reading_goals.lua:616
+#: modules/module_reading_goals.lua:852
+#: modules/module_reading_goals.lua:872
 msgid "  Set Goal  (disabled)"
-msgstr "  設定目標  (已停用)"
+msgstr "  設定目標（已停用）"
 
-#: desktop_modules/module_reading_goals.lua:429
-msgid "%d books"
-msgstr "%d 本書"
+#: modules/module_coverdeck.lua:87
+msgid " et al."
+msgstr " 等"
 
-#: desktop_modules/module_currently.lua:336
-msgid "%d days of reading"
-msgstr "閱讀 %d 天"
+#: engines/sui_book_grid.lua:480
+#: features/library/sui_foldercovers.lua:1222
+msgid " p."
+msgstr " 頁"
 
-#: desktop_modules/module_recent.lua:123
+#: modules/module_feat_coll.lua:171
+#: modules/module_tbr.lua:271
+msgid "% Read (ascending)"
+msgstr "閱讀進度 %（遞增）"
+
+#: modules/module_feat_coll.lua:172
+#: modules/module_tbr.lua:272
+msgid "% Read (descending)"
+msgstr "閱讀進度 %（遞減）"
+
+#: engines/sui_book_grid.lua:1779
+#: engines/sui_book_grid.lua:1784
+msgid "%1 × %2"
+msgstr "%1 × %2"
+
+#: modules/module_reading_goals.lua:952
+msgid "%d hr/month"
+msgstr "%d 小時/月"
+
+#: modules/module_reading_goals.lua:967
+msgid "%d min/day"
+msgstr "%d 分鐘/天"
+
+#: engines/sui_book_grid.lua:865
 msgid "%d%%"
 msgstr "%d%%"
 
-#: desktop_modules/module_currently.lua:309
-#: desktop_modules/module_new_books.lua:141
-#: desktop_modules/module_recent.lua:157
+#: modules/module_coverdeck.lua:915
+#: modules/module_new_books.lua:139
+#: modules/module_currently.lua:729
+#: modules/module_currently.lua:738
+#: engines/sui_book_grid.lua:924
+#: engines/sui_book_grid.lua:935
 msgid "%d%% Read"
 msgstr "已讀 %d%%"
 
-#: desktop_modules/module_reading_goals.lua:428
-msgid "%d/%d books"
-msgstr "%d/%d 本書"
-
-#: desktop_modules/module_currently.lua:347
-#: desktop_modules/module_reading_goals.lua:445
-msgid "%s read"
-msgstr "已讀 %s"
-
-#: desktop_modules/module_currently.lua:370
-msgid "%s remaining"
-msgstr "剩餘 %s"
-
-#: desktop_modules/module_currently.lua:335
-msgid "1 day of reading"
-msgstr "閱讀 1 天"
-
-#: sui_menu.lua:1122
-msgid "Add at least 2 actions to arrange."
-msgstr ""
-
-#: desktop_modules/module_reading_stats.lua:546
-msgid "Add at least 2 stats to arrange."
-msgstr ""
-
-#: desktop_modules/module_reading_stats.lua:67
-msgid "All time — Books"
-msgstr "總計 — 書籍"
-
-#: desktop_modules/module_reading_stats.lua:66
-msgid "All time — Time"
-msgstr "總計 — 時間"
-
-#: desktop_modules/module_reading_goals.lua:585
-msgid "Annual Goal"
-msgstr "年度目標"
-
-#: sui_menu.lua:1024
-#: desktop_modules/module_reading_goals.lua:362
-msgid "Annual Reading Goal"
-msgstr "年度閱讀目標"
-
-#: sui_config.lua:1562
-#: sui_config.lua:1643
-#: sui_menu.lua:593
-#: sui_menu.lua:651
-#: sui_menu.lua:1364
-#: sui_menu.lua:1399
-msgid "Apply"
-msgstr "套用"
-
-#: desktop_modules/module_clock.lua:49
-msgid "April"
-msgstr "四月"
-
-#: sui_menu.lua:1120
-#: desktop_modules/module_reading_stats.lua:543
-msgid "Arrange"
-msgstr "排序"
-
-#: sui_menu.lua:1126
-msgid "Arrange %s"
-msgstr "排序 %s"
-
-#: sui_menu.lua:840
-#: sui_menu.lua:891
-#: sui_menu.lua:906
-msgid "Arrange Buttons"
-msgstr "排序按鈕"
-
-#: desktop_modules/module_collections.lua:535
-#: desktop_modules/module_collections.lua:548
-msgid "Arrange Collections"
-msgstr "排序收藏夾"
-
-#: sui_menu.lua:483
-#: sui_menu.lua:511
-msgid "Arrange Items"
-msgstr "排序項目"
-
-#: sui_menu.lua:1280
-#: sui_menu.lua:1296
-msgid "Arrange Modules"
-msgstr "排序模組"
-
-#: desktop_modules/module_reading_stats.lua:552
-msgid "Arrange Reading Stats"
-msgstr "排序閱讀統計"
-
-#: sui_menu.lua:193
-#: sui_menu.lua:203
-msgid "Arrange tabs"
-msgstr "排序分頁"
-
-#: desktop_modules/module_clock.lua:50
-msgid "August"
-msgstr "八月"
-
-#: sui_foldercovers.lua:405
-#: desktop_modules/module_collections.lua:497
-msgid "Auto (first book)"
-msgstr "自動（第一本書）"
-
-#: sui_titlebar.lua:54
-msgid "Back"
-msgstr "返回"
-
-#: desktop_modules/module_collections.lua:575
-msgid "Badge position: Bottom"
-msgstr "徽章位置：底部"
-
-#: desktop_modules/module_collections.lua:576
-msgid "Badge position: Top"
-msgstr "徽章位置：頂部"
-
-#: sui_config.lua:143
-msgid "Battery"
-msgstr "電池"
-
-#: sui_quickactions.lua:404
-msgid "Book Info"
-msgstr "書籍資訊"
-
-#: sui_bottombar.lua:886
-msgid "Bookmark browser"
-msgstr "書籤瀏覽器"
-
-#: sui_bottombar.lua:859
-msgid "Bookmark browser not available."
-msgstr "書籤瀏覽器不可用。"
-
-#: sui_config.lua:118
-msgid "Bookmarks"
-msgstr "書籤"
-
-#: desktop_modules/module_reading_goals.lua:363
-msgid "Books to read in %s:"
-msgstr "%s 年需要閱讀的書籍："
-
-#: sui_menu.lua:1545
-#: sui_menu.lua:1624
-#: sui_menu.lua:1680
-msgid "Bottom"
-msgstr "底部"
-
-#: sui_bottombar.lua:736
-#: sui_menu.lua:618
-msgid "Bottom Bar"
-msgstr "底部列"
-
-#: sui_menu.lua:644
-msgid "Bottom Bar Size"
-msgstr "底部列大小"
-
-#: sui_menu.lua
-msgid "A restart is required to apply the new bar size across all layouts.\n\nRestart now?"
-msgstr ""
-
-#: sui_menu.lua:626
-msgid "Bottom Bar will be %s after restart.\n\nRestart now?"
-msgstr ""
-
-#: sui_menu.lua:668
-#: sui_menu.lua:671
-msgid "Bottom Margin"
-msgstr "底部邊距"
-
-#: sui_menu.lua:669
-msgid "Bottom Margin — %d%%"
-msgstr "底部邊距 — %d%%"
-
-#: sui_homescreen.lua:701
-msgid "Top Margin  (%d%%)"
-msgstr ""
-
-#: sui_homescreen.lua:704
-msgid "Vertical space above this module.\n100% is the default spacing."
-msgstr ""
-
-#: sui_config.lua:120
-#: sui_config.lua:142
-msgid "Brightness"
-msgstr "亮度"
-
-#: sui_menu.lua:956
-msgid "Button Size"
-msgstr "按鈕大小"
-
-#: sui_bottombar.lua:911
-#: sui_bottombar.lua:1428
-#: sui_config.lua:1563
-#: sui_config.lua:1644
-#: sui_foldercovers.lua:431
-#: sui_menu.lua:594
-#: sui_menu.lua:652
-#: sui_menu.lua:1365
-#: sui_menu.lua:1400
-#: sui_quickactions.lua:188
-#: sui_quickactions.lua:279
-#: sui_quickactions.lua:387
-#: sui_quickactions.lua:565
-#: sui_quickactions.lua:636
-#: sui_quickactions.lua:664
-#: sui_quickactions.lua:692
-#: sui_quickactions.lua:708
-#: sui_quickactions.lua:820
-#: sui_quickactions.lua:961
-#: desktop_modules/module_collections.lua:523
-#: desktop_modules/module_quote.lua:892
-#: desktop_modules/module_reading_goals.lua:366
-#: desktop_modules/module_reading_goals.lua:383
-#: desktop_modules/module_reading_goals.lua:401
-msgid "Cancel"
-msgstr "取消"
-
-#: desktop_modules/module_reading_stats.lua:494
-msgid "Cards"
-msgstr "卡片"
-
-#: sui_menu.lua:498
-#: sui_menu.lua:1672
-msgid "Center"
-msgstr "置中"
-
-#: sui_quickactions.lua:869
-msgid "Change Icons"
-msgstr "變更圖示"
-
-#: sui_config.lua:140
-#: desktop_modules/module_clock.lua:211
-msgid "Clock"
-msgstr "時鐘"
-
-#: sui_titlebar.lua:59
-msgid "Close"
-msgstr "關閉"
-
-#: sui_quickactions.lua:312
-msgid "Codepoint out of valid Unicode range (0–10FFFF)."
-msgstr ""
-
-#: sui_quickactions.lua:702
-msgid "Collection"
-msgstr "收藏夾"
-
-#: desktop_modules/module_collections.lua:484
-#: desktop_modules/module_collections.lua:490
-msgid "Collection is empty."
-msgstr "收藏夾為空。"
-
-#: sui_quickactions.lua:1029
-msgid "Collection not available: %s"
-msgstr "收藏夾不可用：%s"
-
-#: sui_bottombar.lua:897
-#: sui_config.lua:114
-#: sui_quickactions.lua:406
-#: desktop_modules/module_collections.lua:290
-#: desktop_modules/module_collections.lua:291
-msgid "Collections"
-msgstr "收藏夾"
-
-#: sui_bottombar.lua:1121
-msgid "Collections not available."
-msgstr "收藏夾不可用。"
-
-#: sui_menu.lua:960
-#: desktop_modules/module_reading_goals.lua:573
-msgid "Compact"
-msgstr "精簡"
-
-#: sui_quickactions.lua:197
-msgid "Confirm"
-msgstr "確認"
-
-#: sui_config.lua:116
-msgid "Continue"
-msgstr "繼續"
-
-#: desktop_modules/module_collections.lua:527
-msgid "Cover for \"%s\""
-msgstr "\"%s\" 的封面"
-
-#: desktop_modules/module_collections.lua:564
-#: desktop_modules/module_collections.lua:566
-#: desktop_modules/module_currently.lua:447
-#: desktop_modules/module_currently.lua:449
-#: desktop_modules/module_new_books.lua:218
-#: desktop_modules/module_new_books.lua:220
-#: desktop_modules/module_recent.lua:239
-#: desktop_modules/module_recent.lua:241
-msgid "Cover size"
-msgstr "封面大小"
-
-#: sui_quickactions.lua:878
-msgid "Create Quick Action"
-msgstr "建立快捷操作"
-
-#: desktop_modules/module_currently.lua:232
-#: desktop_modules/module_currently.lua:233
-msgid "Currently Reading"
-msgstr "正在閱讀"
-
-#: sui_config.lua:637
-msgid "Custom"
-msgstr "自訂"
-
-#: desktop_modules/module_coverdeck.lua:325
-msgid "Cover Deck"
-msgstr "封面輪播"
-
-#: sui_config.lua:165
-#: sui_menu.lua:555
-msgid "Custom Text"
-msgstr "自訂文字"
-
-#: sui_menu.lua:547
-#: sui_menu.lua:549
-msgid "Edit Custom Text"
-msgstr "編輯自訂文字"
-
-#: sui_menu.lua:556
-msgid "Text shown in the top bar.\nMaximum %d characters."
-msgstr ""
-
-#: sui_menu.lua:933
-msgid "Custom Title Bar"
-msgstr "自訂標題列"
-
-#: sui_menu.lua:944
-msgid "Custom Title Bar will be %s after restart.\n\nRestart now?"
-msgstr ""
-
-#: desktop_modules/module_reading_goals.lua:606
-msgid "Daily Goal"
-msgstr "每日目標"
-
-#: desktop_modules/module_reading_goals.lua:398
-msgid "Daily Reading Goal"
-msgstr "每日閱讀目標"
-
-#: desktop_modules/module_reading_stats.lua:65
-msgid "Daily avg — Pages"
-msgstr "日均 — 頁數"
-
-#: desktop_modules/module_reading_stats.lua:64
-msgid "Daily avg — Time"
-msgstr "日均 — 時間"
-
-#: desktop_modules/module_clock.lua:51
-msgid "December"
-msgstr "十二月"
-
-#: sui_menu.lua:297
-#: sui_menu.lua:326
-#: sui_menu.lua:961
-#: sui_quickactions.lua:347
-#: desktop_modules/module_quick_actions.lua:266
-#: desktop_modules/module_quick_actions.lua:271
-#: desktop_modules/module_reading_goals.lua:565
-msgid "Default"
-msgstr "預設"
-
-#: sui_quickactions.lua:610
-#: sui_quickactions.lua:629
-msgid "Default (Folder)"
-msgstr "預設（資料夾）"
-
-#: sui_quickactions.lua:656
-msgid "Default (Plugin)"
-msgstr "預設（外掛）"
-
-#: sui_quickactions.lua:684
-msgid "Default (System)"
-msgstr "預設（系統）"
-
-#: desktop_modules/module_quote.lua:976
-msgid "Default Quotes"
-msgstr "預設名言"
-
-#: sui_quickactions.lua:955
-#: sui_quickactions.lua:960
-msgid "Delete"
-msgstr "刪除"
-
-#: sui_quickactions.lua:959
-msgid "Delete quick action \"%s\"?"
-msgstr ""
-
-#: sui_quickactions.lua:409
-msgid "Dictionary Lookup"
-msgstr "字典查詢"
-
-#: sui_menu.lua:1025
-msgid "Digital Goal  (%s)"
-msgstr "數位目標  (%s)"
-
-#: sui_menu.lua:1025
-msgid "Digital: %d books in %s"
-msgstr "數位：%s 年 %d 本書"
-
-#: sui_menu.lua:1384
-msgid "Disable \"Lock Scale\" first to set a custom label scale."
-msgstr ""
-
-#: sui_config.lua:1547
-msgid "Disable \"Lock Scale\" first to set a per-module scale."
-msgstr "請先停用「鎖定比例」以設定每個模組的比例。"
-
-#: sui_config.lua:144
-msgid "Disk Usage"
-msgstr "磁碟使用"
-
-#: sui_quickactions.lua:1014
-msgid "Dispatcher not available."
-msgstr "排程器不可用。"
-
-#: sui_quickactions.lua:945
-msgid "Edit"
-msgstr "編輯"
-
-#: sui_quickactions.lua:511
-msgid "Edit Quick Action"
-msgstr "編輯快捷操作"
-
-#: sui_menu.lua:1292
-msgid "Enable at least 2 modules to arrange."
-msgstr ""
-
-#: sui_quickactions.lua:271
-msgid "Enter the Unicode codepoint (hex) of a Nerd Fonts symbol.\nYou can look up codes with wakamaifondue.com using the file:\n  /koreader/fonts/nerdfonts/symbols.ttf\nLeave blank and press OK to remove a Nerd Font icon."
-msgstr "輸入 Nerd Fonts 符號的 Unicode 碼點（十六進位）。\n您可以使用 wakamaifondue.com 查詢代碼，使用檔案：\n  /koreader/fonts/nerdfonts/symbols.ttf\n留白並按確定可移除 Nerd Font 圖示。"
-
-#: sui_menu.lua:324
-msgid "Extra Small"
-msgstr "超小"
-
-#: sui_config.lua:117
-#: sui_quickactions.lua:405
-msgid "Favorites"
-msgstr "我的最愛"
-
-#: sui_bottombar.lua:1149
-msgid "Favorites not available."
-msgstr "我的最愛不可用。"
-
-#: desktop_modules/module_clock.lua:49
-msgid "February"
-msgstr "二月"
-
-#: sui_bottombar.lua:867
-msgid "Fetching bookmarks…"
-msgstr "正在取得書籤…"
-
-#: sui_quickactions.lua:407
-msgid "File Search"
-msgstr "檔案搜尋"
-
-#: desktop_modules/module_quick_actions.lua:266
-#: desktop_modules/module_quick_actions.lua:280
-#: desktop_modules/module_reading_stats.lua:504
-msgid "Flat"
-msgstr "扁平"
-
-#: sui_quickactions.lua:700
-msgid "Folder"
-msgstr "資料夾"
-
-#: sui_menu.lua:1578
-msgid "Folder Covers"
-msgstr "資料夾封面"
-
-#: sui_menu.lua:1640
-msgid "Folder Name"
-msgstr "資料夾名稱"
-
-#: sui_quickactions.lua:408
-msgid "Folder Shortcuts"
-msgstr "資料夾捷徑"
-
-#: sui_foldercovers.lua:436
-msgid "Folder cover"
-msgstr "資料夾封面"
-
-#: desktop_modules/module_clock.lua:46
-msgid "Friday"
-msgstr "星期五"
-
-#: sui_bottombar.lua:1253
-msgid "Frontlight not available on this device."
-msgstr "此裝置不支援前光。"
-
-#: sui_menu.lua:1358
-msgid "Global scale for all modules.\nIndividual overrides in Module Settings take precedence.\n100% is the default size."
-msgstr ""
-
-#: sui_menu.lua:645
-msgid "Height of the bottom navigation bar.\n100% is the default size."
-msgstr "底部導覽列的高度。\n100% 為預設大小。"
-
-#: sui_menu.lua:587
-msgid "Height of the top status bar.\n100% is the default size."
-msgstr ""
-
-#: sui_menu.lua:728
-#: sui_menu.lua:1605
-#: sui_menu.lua:1643
-msgid "Hidden"
-msgstr "隱藏"
-
-#: sui_menu.lua:1132
-msgid "Hide Text"
-msgstr "隱藏文字"
-
-#: sui_menu.lua:1702
-msgid "Hide selection underline"
-msgstr "隱藏選擇底線"
-
-#: sui_bottombar.lua:890
-#: sui_config.lua:115
-#: sui_quickactions.lua:403
-msgid "History"
-msgstr "歷史"
-
-#: sui_bottombar.lua:1125
-msgid "History not available."
-msgstr "歷史記錄不可用。"
-
-#: sui_config.lua:113
-msgid "Home"
-msgstr "首頁"
-
-#: sui_menu.lua:1449
-#: sui_menu.lua:1543
-#: sui_patches.lua:289
-#: sui_patches.lua:293
-#: sui_patches.lua:306
-msgid "Home Screen"
-msgstr "主畫面"
-
-#: sui_bottombar.lua:907
-msgid "Home folder"
-msgstr "主要資料夾"
-
-#: sui_bottombar.lua:909
-msgid "Home folder + subfolders"
-msgstr ""
-
-#: sui_homescreen.lua:446
-msgid "Homescreen"
-msgstr "主畫面"
-
-#: sui_bottombar.lua:1144
-msgid "Homescreen not available."
-msgstr "主畫面不可用。"
-
-#: sui_quickactions.lua:520
-#: sui_quickactions.lua:524
-msgid "Icon"
-msgstr "圖示"
-
-#: sui_menu.lua:690
-#: sui_menu.lua:693
-msgid "Icon Size"
-msgstr "圖示大小"
-
-#: sui_menu.lua:691
-msgid "Icon Size — %d%%"
-msgstr "圖示大小 — %d%%"
-
-#: sui_quickactions.lua:515
-msgid "Icon: Default"
-msgstr "圖示：預設"
-
-#: sui_menu.lua:101
-msgid "Icons"
-msgstr "圖示"
-
-#: sui_menu.lua:102
-msgid "Icons only"
-msgstr "僅圖示"
-
-#: sui_menu.lua:853
-msgid "Invalid arrangement.\nKeep items between the Left and Right separators."
-msgstr ""
-
-#: sui_menu.lua:525
-msgid "Invalid arrangement.\nKeep the Left, Center and Right separators in order."
-msgstr "排序無效。\n請按順序保持左側、置中、右側分隔符。"
-
-#: sui_quickactions.lua:318
-msgid "Invalid input. Please enter 1–6 hexadecimal digits (0–9, A–F)."
-msgstr ""
-
-#: desktop_modules/module_currently.lua:671
-#: sui_menu.lua:606
-msgid "Items"
-msgstr "項目"
-
-#: desktop_modules/module_clock.lua:49
-msgid "January"
-msgstr "一月"
-
-#: desktop_modules/module_clock.lua:50
-msgid "July"
-msgstr "七月"
-
-#: desktop_modules/module_clock.lua:50
-msgid "June"
-msgstr "六月"
-
-#: sui_menu.lua:1392
-msgid "Label Scale"
-msgstr "標籤比例"
-
-#: sui_menu.lua:710
-#: sui_menu.lua:713
-msgid "Label Size"
-msgstr "標籤大小"
-
-#: sui_menu.lua:711
-msgid "Label Size — %d%%"
-msgstr "標籤大小 — %d%%"
-
-#: sui_menu.lua:1377
-msgid "Labels"
-msgstr "標籤"
-
-#: sui_menu.lua:962
-msgid "Large"
-msgstr "大"
-
-#: sui_menu.lua:310
-#: sui_menu.lua:340
-#: sui_menu.lua:398
-#: sui_menu.lua:570
-#: sui_menu.lua:627
-#: sui_menu.lua:948
-#: sui_menu.lua:1524
-msgid "Later"
-msgstr "稍後"
-
-#: sui_menu.lua:492
-#: sui_menu.lua:823
-msgid "Left"
-msgstr "左側"
-
-#: sui_config.lua:112
-#: sui_config.lua:485
-#: sui_menu.lua:1564
-#: sui_titlebar.lua:568
-msgid "Library"
-msgstr "書庫"
-
-#: sui_menu.lua:966
-msgid "Library Buttons"
-msgstr "書庫按鈕"
-
-#: desktop_modules/module_reading_stats.lua:514
-msgid "List"
-msgstr "列表"
-
-#: sui_menu.lua:1338
-msgid "Lock Scale"
-msgstr "鎖定比例"
-
-#: desktop_modules/module_clock.lua:49
-msgid "March"
-msgstr "三月"
-
-#: sui_menu.lua:1095
-msgid "Maximum %d actions per module reached. Remove one first."
-msgstr ""
-
-#: sui_menu.lua:1152
-msgid "Maximum %d modules active. Disable one first."
-msgstr ""
-
-#: sui_quickactions.lua:883
-msgid "Maximum %d quick actions reached. Delete one first."
-msgstr ""
-
-#: desktop_modules/module_reading_stats.lua:481
-msgid "Maximum %d stats per row. Remove one first."
-msgstr ""
-
-#: sui_menu.lua:270
-msgid "Maximum %d tabs reached. Remove one first."
-msgstr ""
-
-#: desktop_modules/module_collections.lua:616
-msgid "Maximum 5 collections. Remove one first."
-msgstr "最多 5 個收藏夾。請先刪除一個。"
-
-#: desktop_modules/module_clock.lua:50
-msgid "May"
-msgstr "五月"
-
-#: sui_titlebar.lua:53
-#: sui_titlebar.lua:58
-msgid "Menu"
-msgstr "選單"
-
-#: sui_menu.lua:260
-msgid "Minimum 1 tab required in navpager mode."
-msgstr ""
-
-#: sui_menu.lua:261
-msgid "Minimum 2 tabs required. Select another tab first."
-msgstr ""
-
-#: desktop_modules/module_reading_goals.lua:399
-msgid "Minutes per day:"
-msgstr "每天分鐘數："
-
-#: sui_menu.lua:1355
-msgid "Module Scale"
-msgstr "模組比例"
-
-#: sui_menu.lua:1314
-msgid "Module Settings"
-msgstr "模組設定"
-
-#: sui_menu.lua:1326
-msgid "Module limit disabled. Enabling too many modules may slow down the homescreen significantly and modules may be clipped at the bottom of the page."
-msgstr ""
-
-#: sui_menu.lua:1349
-msgid "Modules"
-msgstr "模組"
-
-#: sui_menu.lua:1271
-msgid "Modules  (%d — no limit)"
-msgstr ""
-
-#: sui_menu.lua:1385
-msgid "Modules  (%d)"
-msgstr "模組  (%d)"
-
-#: sui_menu.lua:1275
-msgid "Modules  (%d/%d — %d left)"
-msgstr ""
-
-#: sui_menu.lua:1274
-msgid "Modules  (%d/%d — at limit)"
-msgstr ""
-
-#: desktop_modules/module_clock.lua:45
-msgid "Monday"
-msgstr "星期一"
-
-#: desktop_modules/module_quote.lua:996
-msgid "My Highlights"
-msgstr "我的劃線"
-
-#: sui_quickactions.lua:609
-#: sui_quickactions.lua:628
-#: sui_quickactions.lua:655
-#: sui_quickactions.lua:683
-msgid "Name"
-msgstr "名稱"
-
-#: sui_menu.lua:1547
-msgid "Navigation Bar"
-msgstr "導覽列"
-
-#: sui_menu.lua:375
-msgid "Navpager"
-msgstr "導覽頁"
-
-#: sui_menu.lua:397
-msgid "Navpager will be %s after restart.\n\nRestart now?"
-msgstr ""
-
-#: sui_quickactions.lua:268
-msgid "Nerd Font Icon"
-msgstr ""
-
-#: sui_quickactions.lua:358
-msgid "Nerd Font symbol…"
-msgstr ""
-
-#: sui_bottombar.lua:1213
-msgid "Network manager unavailable."
-msgstr "網路管理員不可用。"
-
-#: desktop_modules/module_new_books.lua:139
-msgid "New"
-msgstr "新"
-
-#: desktop_modules/module_new_books.lua:46
-#: desktop_modules/module_new_books.lua:47
-msgid "New Books"
-msgstr "新書"
-
-#: sui_quickactions.lua:511
-msgid "New Quick Action"
-msgstr "新增快捷操作"
-
-#: sui_quickactions.lua:840
-msgid "New name…"
-msgstr "新名稱…"
-
-#: sui_bottombar.lua:245
-msgid "Next"
-msgstr "下一頁"
-
-#: sui_menu.lua:1318
-msgid "No Module Limit  ⚠ not recommended"
-msgstr ""
-
-#: sui_bottombar.lua:1171
-msgid "No book in history."
-msgstr "歷史記錄中沒有書籍。"
-
-#: sui_foldercovers.lua:394
-msgid "No books found in this folder."
-msgstr "在此資料夾中未找到書籍。"
-
-#: sui_homescreen.lua:116
-msgid "No books opened yet"
-msgstr "尚未開啟任何書籍"
-
-#: desktop_modules/module_collections.lua:586
-msgid "No collections found."
-msgstr "未找到收藏夾。"
-
-#: desktop_modules/module_collections.lua:322
-msgid "No collections selected"
-msgstr "未選擇收藏夾"
-
-#: sui_quickactions.lua:1036
-msgid "No folder, collection or plugin configured.\nGo to Simple UI → Settings → Quick Actions to set one."
-msgstr ""
-
-#: desktop_modules/module_quote.lua:699
-msgid "No highlights found. Open a book and highlight some passages."
-msgstr "未找到劃線。請開啟一本書並劃選一些段落。"
-
-#: sui_quickactions.lua:371
-msgid "No icons found in:"
-msgstr "未在以下位置找到圖示："
-
-#: sui_quickactions.lua:645
-msgid "No plugins found."
-msgstr "未找到外掛。"
-
-#: desktop_modules/module_quote.lua:665
-msgid "No quotes found."
-msgstr "未找到名言。"
-
-#: desktop_modules/module_reading_stats.lua:367
-msgid "No stats selected"
-msgstr "未選擇統計項"
-
-#: sui_quickactions.lua:673
-msgid "No system actions found."
-msgstr "未找到系統操作。"
-
-#: desktop_modules/module_clock.lua:51
-msgid "November"
-msgstr "十一月"
-
-#: sui_menu.lua:1602
-msgid "Number of Books in Folder"
-msgstr "資料夾中的書籍數量"
-
-#: sui_menu.lua:1634
-msgid "Number of Pages"
-msgstr "頁數"
-
-#: sui_menu.lua:494
-msgid "Number of Pages in Title Bar Always"
-msgstr "標題列始終顯示頁數"
-
-#: sui_quickactions.lua:286
-msgid "OK"
-msgstr "確定"
-
-#: desktop_modules/module_clock.lua:51
-msgid "October"
-msgstr "十月"
-
-#: sui_menu.lua:296
-#: sui_menu.lua:356
-#: sui_menu.lua:374
-#: sui_menu.lua:561
-#: sui_menu.lua:618
-#: sui_menu.lua:787
-#: sui_menu.lua:933
-#: sui_menu.lua:1449
-#: sui_menu.lua:1506
-#: desktop_modules/module_clock.lua:378
-#: desktop_modules/module_clock.lua:386
-msgid "Off"
-msgstr "關閉"
-
-#: sui_menu.lua:296
-#: sui_menu.lua:356
-#: sui_menu.lua:374
-#: sui_menu.lua:561
-#: sui_menu.lua:618
-#: sui_menu.lua:787
-#: sui_menu.lua:933
-#: sui_menu.lua:1449
-#: sui_menu.lua:1506
-#: desktop_modules/module_clock.lua:378
-#: desktop_modules/module_clock.lua:386
-msgid "On"
-msgstr "開啟"
-
-#: desktop_modules/module_quote.lua:891
-msgid "Open"
-msgstr "開啟"
-
-#: sui_homescreen.lua:125
-msgid "Open a book to get started"
-msgstr "開啟一本書開始閱讀"
-
-#: sui_menu.lua:1598
-msgid "Overlays"
-msgstr "覆蓋層"
-
-#: sui_patches.lua:1125
-#: sui_patches.lua:1239
-msgid "Page %1 of %2"
-msgstr ""
-
-#: sui_menu.lua:356
-msgid "Page number in title bar"
-msgstr "標題列顯示頁碼"
-
-#: sui_menu.lua:1548
-msgid "Pagination Bar"
-msgstr "分頁列"
-
-#: sui_menu.lua:339
-msgid "Pagination bar size will change after restart.\n\nRestart now?"
-msgstr ""
-
-#: sui_menu.lua:309
-msgid "Pagination bar will be %s after restart.\n\nRestart now?"
-msgstr ""
-
-#: sui_titlebar.lua:57
-msgid "Path"
-msgstr "路徑"
-
-#: sui_quickactions.lua:592
-msgid "Path chooser not available."
-msgstr "路徑選擇器不可用。"
-
-#: desktop_modules/module_recent.lua:286
-msgid "Percentage overlay on cover"
-msgstr "封面上的百分比覆蓋層"
-
-#: desktop_modules/module_currently.lua:524
-msgid "Percentage read"
-msgstr "已讀百分比"
-
-#: desktop_modules/module_recent.lua:276
-msgid "Percentage text"
-msgstr "百分比文字"
-
-#: desktop_modules/module_reading_goals.lua:380
-msgid "Physical Books — %s"
-msgstr "實體書 — %s"
-
-#: desktop_modules/module_reading_goals.lua:381
-msgid "Physical books read this year:"
-msgstr "今年閱讀的實體書："
-
-#: sui_menu.lua:1031
-msgid "Physical: %d books in %s"
-msgstr "實體：%s 年 %d 本書"
-
-#: sui_quickactions.lua:704
-msgid "Plugin"
-msgstr "外掛"
-
-#: sui_quickactions.lua:1021
-msgid "Plugin error: %s"
-msgstr "外掛錯誤：%s"
-
-#: sui_quickactions.lua:1023
-msgid "Plugin not available: %s"
-msgstr "外掛不可用：%s"
-
-#: sui_config.lua:122
-msgid "Power"
-msgstr "電源"
-
-#: sui_bottombar.lua:245
-msgid "Prev"
-msgstr "上一頁"
-
-#: desktop_modules/module_recent.lua:266
-msgid "Progress bar"
-msgstr "進度列"
-
-#: desktop_modules/module_currently.lua:499
-msgid "Progress bar style"
-msgstr "進度列樣式"
-
-#: sui_menu.lua:1248
-#: sui_menu.lua:1555
-msgid "Quick Actions"
-msgstr "快捷操作"
-
-#: sui_menu.lua:1559
-msgid "Quick Actions  (%d/%d — %d left)"
-msgstr ""
-
-#: sui_menu.lua:1557
-msgid "Quick Actions  (%d/%d — at limit)"
-msgstr ""
-
-#: sui_menu.lua:1084
-#: desktop_modules/module_quick_actions.lua:197
-msgid "Quick Actions %d"
-msgstr "快捷操作 %d"
-
-#: sui_bottombar.lua:1420
-msgid "Quit"
-msgstr "離開"
-
-#: desktop_modules/module_quote.lua:767
-msgid "Quote of the Day"
-msgstr "每日名言"
-
-#: desktop_modules/module_quote.lua:1018
-msgid "Quotes + My Highlights"
-msgstr "名言 + 我的劃線"
-
-#: sui_config.lua:145
-msgid "RAM Usage"
-msgstr "記憶體使用"
-
-#: desktop_modules/module_reading_goals.lua:454
-#: desktop_modules/module_reading_goals.lua:455
-msgid "Reading Goals"
-msgstr "閱讀目標"
-
-#: desktop_modules/module_reading_stats.lua:308
-msgid "Reading Stats"
-msgstr "閱讀統計"
-
-#: desktop_modules/module_recent.lua:61
-#: desktop_modules/module_recent.lua:62
-msgid "Recent Books"
-msgstr "最近書籍"
-
-#: sui_quickactions.lua:815
-#: sui_quickactions.lua:873
-msgid "Rename"
-msgstr "重新命名"
-
-#: sui_menu.lua:378
-msgid "Replaces the pagination bar with Prev/Next arrows at the edges of the bottom bar.\nThe arrows dim when there is no previous or next page.\nWith navpager active, as few as 1 tab and at most 4 tabs can be configured."
-msgstr ""
-
-#: sui_menu.lua:1420
-#: sui_quickactions.lua:824
-msgid "Reset"
-msgstr "重設"
-
-#: sui_menu.lua:1419
-msgid "Reset all scales to default (100%)? This cannot be undone."
-msgstr ""
-
-#: sui_menu.lua:1414
-msgid "Reset to Default Scale"
-msgstr "重設為預設比例"
-
-#: sui_bottombar.lua:1412
-#: sui_menu.lua:310
-#: sui_menu.lua:340
-#: sui_menu.lua:398
-#: sui_menu.lua:570
-#: sui_menu.lua:627
-#: sui_menu.lua:947
-#: sui_menu.lua:1524
-msgid "Restart"
-msgstr "重新啟動"
-
-#: sui_menu.lua:504
-#: sui_menu.lua:831
-msgid "Right"
-msgstr "右側"
-
-#: desktop_modules/module_clock.lua:46
-msgid "Saturday"
-msgstr "星期六"
-
-#: sui_quickactions.lua:567
-#: sui_quickactions.lua:835
-#: desktop_modules/module_reading_goals.lua:366
-#: desktop_modules/module_reading_goals.lua:383
-#: desktop_modules/module_reading_goals.lua:401
-msgid "Save"
-msgstr "儲存"
-
-#: sui_menu.lua:1334
-#: desktop_modules/module_clock.lua:356
-#: desktop_modules/module_clock.lua:358
-#: desktop_modules/module_collections.lua:432
-#: desktop_modules/module_collections.lua:434
-#: desktop_modules/module_currently.lua:433
-#: desktop_modules/module_currently.lua:435
-#: desktop_modules/module_new_books.lua:204
-#: desktop_modules/module_new_books.lua:206
-#: desktop_modules/module_quick_actions.lua:245
-#: desktop_modules/module_quick_actions.lua:247
-#: desktop_modules/module_quote.lua:938
-#: desktop_modules/module_quote.lua:942
-#: desktop_modules/module_reading_goals.lua:546
-#: desktop_modules/module_reading_goals.lua:548
-#: desktop_modules/module_reading_stats.lua:452
-#: desktop_modules/module_reading_stats.lua:454
-#: desktop_modules/module_recent.lua:225
-#: desktop_modules/module_recent.lua:227
-msgid "Scale"
-msgstr "比例"
-
-#: desktop_modules/module_currently.lua:463
-msgid "Scale for all text elements (title, author, progress, time).\n100% is the default size."
-msgstr "所有文字元素的比例（標題、作者、進度、時間）。\n100% 為預設大小。"
-
-#: desktop_modules/module_quick_actions.lua:259
-msgid "Scale for the button label text.\n100% is the default size."
-msgstr "按鈕標籤文字的比例。\n100% 為預設大小。"
-
-#: desktop_modules/module_collections.lua:448
-msgid "Scale for the collection name text.\n100% is the default size."
-msgstr "收藏夾名稱文字的比例。\n100% 為預設大小。"
-
-#: desktop_modules/module_collections.lua:567
-msgid "Scale for the collection thumbnails only.\nThe label text follows the module scale.\n100% is the default size."
-msgstr "僅收藏夾縮圖的比例。\n標籤文字跟隨模組比例。\n100% 為預設大小。"
-
-#: desktop_modules/module_currently.lua:450
-msgid "Scale for the cover thumbnail only.\n100% is the default size."
-msgstr "僅封面縮圖的比例。\n100% 為預設大小。"
-
-#: desktop_modules/module_new_books.lua:221
-#: desktop_modules/module_recent.lua:242
-msgid "Scale for the cover thumbnails only.\nText and progress bar follow the module scale.\n100% is the default size."
-msgstr ""
-
-#: desktop_modules/module_new_books.lua:233
-msgid "Scale for the label text.\n100% is the default size."
-msgstr "標籤文字的比例。\n100% 為預設大小。"
-
-#: desktop_modules/module_recent.lua:256
-msgid "Scale for the percentage read text.\n100% is the default size."
-msgstr "已讀百分比文字的比例。\n100% 為預設大小。"
-
-#: desktop_modules/module_clock.lua:359
-#: desktop_modules/module_collections.lua:435
-#: desktop_modules/module_currently.lua:436
-#: desktop_modules/module_new_books.lua:207
-#: desktop_modules/module_quick_actions.lua:248
-#: desktop_modules/module_quote.lua:944
-#: desktop_modules/module_reading_goals.lua:549
-#: desktop_modules/module_reading_stats.lua:455
-#: desktop_modules/module_recent.lua:228
-msgid "Scale for this module.\n100% is the default size."
-msgstr "此模組的比例。\n100% 為預設大小。"
-
-#: sui_menu.lua:1357
-msgid "Scales all modules and labels together.\n100% is the default size."
-msgstr ""
-
-#: sui_menu.lua:1393
-msgid "Scales the section label text above each module.\n100% is the default size."
-msgstr ""
-
-#: sui_titlebar.lua:55
-msgid "Search"
-msgstr "搜尋"
-
-#: desktop_modules/module_collections.lua:540
-msgid "Select at least 2 collections to arrange."
-msgstr ""
-
-#: desktop_modules/module_clock.lua:51
-msgid "September"
-msgstr "九月"
-
-#: sui_foldercovers.lua:455
-msgid "Set folder cover…"
-msgstr "設定資料夾封面…"
-
-#: sui_menu.lua:1533
-msgid "Settings"
-msgstr "設定"
-
-#: desktop_modules/module_clock.lua:386
-msgid "Show Battery"
-msgstr "顯示電池"
-
-#: desktop_modules/module_clock.lua:378
-msgid "Show Date"
-msgstr "顯示日期"
-
-#: sui_menu.lua:364
-msgid "Shows \"Page X of Y\" in the title bar subtitle when browsing the library, history or collections.\nNavpager enables this automatically.\nNot available when Navpager is active."
-msgstr ""
-
-#: desktop_modules/module_currently.lua:502
-msgid "Simple"
-msgstr "簡潔"
-
-#: main.lua:381
-#: main.lua:394
-#: sui_menu.lua:1502
-#: sui_menu.lua:1506
-msgid "Simple UI"
-msgstr "Simple UI"
-
-#: main.lua:68
-msgid "Simple UI was updated (%s → %s).\n\nA restart is recommended to apply all changes cleanly."
-msgstr ""
-
-#: sui_menu.lua:1523
-msgid "Simple UI will be %s after restart.\n\nRestart now?"
-msgstr ""
-
-#: sui_menu.lua:580
-#: sui_menu.lua:638
-msgid "Size"
-msgstr "大小"
-
-#: sui_menu.lua:694
-msgid "Size of the tab icons.\n100% is the default size."
-msgstr "分頁圖示的大小。\n100% 為預設大小。"
-
-#: sui_menu.lua:714
-msgid "Size of the tab label text.\n100% is the default size."
-msgstr "分頁標籤文字的大小。\n100% 為預設大小。"
-
-#: desktop_modules/module_reading_stats.lua:534
-msgid "Size of the text inside the stat cards.\nDoes not affect card size or padding.\n100% is the default size."
-msgstr "統計卡片內文字的大小。\n不影響卡片大小或內邊距。\n100% 為預設大小。"
-
-#: sui_menu.lua:325
-msgid "Small"
-msgstr "小"
-
-#: desktop_modules/module_quote.lua:970
-msgid "Source"
-msgstr "來源"
-
-#: sui_menu.lua:672
-msgid "Space below the bottom navigation bar.\n100% is the default spacing."
-msgstr ""
-
-#: sui_patches.lua:306
-#: sui_patches.lua:308
-msgid "Start with"
-msgstr "啟動時"
-
-#: sui_menu.lua:1459
-msgid "Start with Home Screen"
-msgstr "啟動時顯示主畫面"
-
-#: sui_bottombar.lua:956
-#: sui_bottombar.lua:1184
-msgid "Statistics plugin not available."
-msgstr "統計外掛不可用。"
-
-#: sui_config.lua:121
-msgid "Stats"
-msgstr "統計"
-
-#: sui_menu.lua:1539
-msgid "Status Bar"
-msgstr "狀態列"
-
-#: desktop_modules/module_reading_stats.lua:68
-msgid "Streak"
-msgstr "連續閱讀"
-
-#: sui_menu.lua:971
-msgid "Sub-pages Buttons"
-msgstr "子頁面按鈕"
-
-#: desktop_modules/module_clock.lua:45
-msgid "Sunday"
-msgstr "星期日"
-
-#: sui_menu.lua:417
-msgid "Swipe Indicator"
-msgstr "滑動指示器"
-
-#: sui_menu.lua:427
-msgid "Hide Wi-Fi icon when off"
-msgstr ""
-
-#: sui_quickactions.lua:706
-msgid "System Actions"
-msgstr "系統操作"
-
-#: sui_quickactions.lua:1011
-msgid "System action error: %s"
-msgstr "系統操作錯誤：%s"
-
-#: sui_menu.lua:752
-msgid "Tabs  (%d/%d — %d left)"
-msgstr ""
-
-#: sui_menu.lua:750
-msgid "Tabs  (%d/%d — at limit)"
-msgstr ""
-
-#: sui_menu.lua:101
-msgid "Text"
-msgstr "文字"
-
-#: desktop_modules/module_collections.lua:446
-#: desktop_modules/module_collections.lua:447
-#: desktop_modules/module_currently.lua:461
-#: desktop_modules/module_currently.lua:462
-#: desktop_modules/module_new_books.lua:231
-#: desktop_modules/module_new_books.lua:232
-#: desktop_modules/module_quick_actions.lua:255
-#: desktop_modules/module_quick_actions.lua:258
-#: desktop_modules/module_reading_stats.lua:530
-#: desktop_modules/module_reading_stats.lua:533
-#: desktop_modules/module_recent.lua:254
-#: desktop_modules/module_recent.lua:255
-msgid "Text Size"
-msgstr "文字大小"
-
-#: desktop_modules/module_reading_stats.lua:531
-msgid "Text Size — %d%%"
-msgstr "文字大小 — %d%%"
-
-#: sui_menu.lua:103
-msgid "Text only"
-msgstr "僅文字"
-
-#: desktop_modules/module_clock.lua:46
-msgid "Thursday"
-msgstr "星期四"
-
-#: sui_titlebar.lua:56
-msgid "Title"
-msgstr "標題"
-
-#: sui_menu.lua:1540
-msgid "Title Bar"
-msgstr "標題列"
-
-#: desktop_modules/module_reading_goals.lua:491
-#: desktop_modules/module_reading_goals.lua:493
-#: desktop_modules/module_reading_goals.lua:515
-#: desktop_modules/module_reading_goals.lua:517
-msgid "Today"
-msgstr "今天"
-
-#: desktop_modules/module_reading_stats.lua:63
-msgid "Today — Pages"
-msgstr "今天 — 頁數"
-
-#: desktop_modules/module_reading_stats.lua:62
-msgid "Today — Time"
-msgstr "今天 — 時間"
-
-#: sui_menu.lua:1537
-#: sui_menu.lua:1616
-#: sui_menu.lua:1664
-msgid "Top"
-msgstr "頂部"
-
-#: sui_menu.lua:561
-#: sui_topbar.lua:473
-msgid "Top Bar"
-msgstr "頂部列"
-
-#: sui_menu.lua:586
-msgid "Top Bar Size"
-msgstr "頂部列大小"
-
-#: sui_menu.lua:569
-msgid "Top Bar will be %s after restart.\n\nRestart now?"
-msgstr ""
-
-#: sui_menu.lua:728
-msgid "Top separator"
-msgstr "頂部分隔符"
-
-#: sui_menu.lua:1653
-msgid "Transparent"
-msgstr "透明"
-
-#: desktop_modules/module_clock.lua:45
-msgid "Tuesday"
-msgstr "星期二"
-
-#: sui_menu.lua:741
-#: desktop_modules/module_quick_actions.lua:267
-#: desktop_modules/module_reading_goals.lua:563
-#: desktop_modules/module_reading_stats.lua:491
-msgid "Type"
-msgstr "類型"
-
-#: sui_menu.lua:1692
-msgid "Uniformize Covers (2:3)"
-msgstr "統一封面比例（2:3）"
-
-#: sui_menu.lua:728
-msgid "Visible"
-msgstr "可見"
-
-#: desktop_modules/module_clock.lua:45
-msgid "Wednesday"
-msgstr "星期三"
-
-#: sui_config.lua:119
-msgid "Wi-Fi"
-msgstr "Wi-Fi"
-
-#: sui_bottombar.lua:1221
-msgid "Wi-Fi off"
-msgstr "Wi-Fi 關閉"
-
-#: sui_config.lua:141
-msgid "WiFi"
-msgstr "WiFi"
-
-#: sui_bottombar.lua:1208
-msgid "WiFi not available on this device."
-msgstr ""
-
-#: sui_quickactions.lua:410
-msgid "Wikipedia Lookup"
-msgstr "維基百科查詢"
-
-#: desktop_modules/module_currently.lua:512
-msgid "With percentage"
-msgstr "帶百分比"
-
-#: desktop_modules/module_quote.lua:701
-msgid "Your highlights"
-msgstr "您的劃線"
-
-#: desktop_modules/module_reading_stats.lua:67
-msgid "books finished"
-msgstr "已完成書籍"
-
-#: desktop_modules/module_reading_stats.lua:64
-msgid "daily avg (7 days)"
-msgstr "日均（7 天）"
-
-#: desktop_modules/module_reading_stats.lua:69
-msgid "day streak"
-msgstr "天連續閱讀"
-
-#: desktop_modules/module_reading_stats.lua:69
-msgid "days streak"
-msgstr "天連續閱讀"
-
-#: desktop_modules/module_reading_stats.lua:68
-msgid "no streak"
-msgstr "無連續閱讀"
-
-#: sui_quickactions.lua:769
-msgid "default"
-msgstr "預設"
-
-#: sui_menu.lua:395
-#: sui_menu.lua:569
-#: sui_menu.lua:626
-#: sui_menu.lua:945
-#: sui_menu.lua:1523
-msgid "disabled"
-msgstr "已停用"
-
-#: sui_quickactions.lua:609
-msgid "e.g. Comics…"
-msgstr "例如：漫畫…"
-
-#: sui_quickactions.lua:655
-msgid "e.g. Rakuyomi…"
-msgstr ""
-
-#: sui_quickactions.lua:628
-msgid "e.g. Sci-Fi…"
-msgstr "例如：科幻…"
-
-#: sui_quickactions.lua:683
-msgid "e.g. Sleep, Refresh…"
-msgstr "例如：休眠、重新整理…"
-
-#: sui_menu.lua:395
-#: sui_menu.lua:569
-#: sui_menu.lua:626
-#: sui_menu.lua:945
-#: sui_menu.lua:1523
-msgid "enabled"
-msgstr "已啟用"
-
-#: sui_quickactions.lua:270
-msgid "hex code, e.g. E001"
-msgstr ""
-
-#: sui_menu.lua:307
-msgid "hidden"
-msgstr "隱藏"
-
-#: sui_quickactions.lua:921
-#: sui_quickactions.lua:937
-msgid "not configured"
-msgstr "未設定"
-
-#: desktop_modules/module_reading_stats.lua:62
-msgid "of reading today"
-msgstr "今天的閱讀"
-
-#: desktop_modules/module_reading_stats.lua:66
-msgid "of reading, all time"
-msgstr "總計閱讀"
-
-#: desktop_modules/module_reading_stats.lua:63
-msgid "pages read today"
-msgstr "今天閱讀的頁數"
-
-#: desktop_modules/module_reading_stats.lua:65
-msgid "pages/day (7 days)"
-msgstr "頁/天（7 天）"
-
-#: sui_menu.lua:307
-msgid "visible"
-msgstr "可見"
-
-#: desktop_modules/module_currently.lua:271
-msgid "Author"
-msgstr "作者"
-
-#: desktop_modules/module_currently.lua:274
-msgid "Days of reading"
-msgstr "閱讀天數"
-
-#: desktop_modules/module_currently.lua:275
-msgid "Time read"
-msgstr "已讀時間"
-
-#: desktop_modules/module_currently.lua:276
-msgid "Time remaining"
-msgstr "剩餘時間"
-
-#: desktop_modules/module_currently.lua
+#: screens/sui_stats_windows.lua:3450
+msgid "%d/%d days · %d/%d min to next freeze"
+msgstr "%d/%d 天 · 距下一次獲得凍結權還差 %d/%d 分鐘"
+
+#: modules/module_currently.lua:832
 msgid "%s left"
 msgstr "剩餘 %s"
 
-#: desktop_modules/module_currently.lua
-msgid "1 day"
-msgstr "1 天"
+#: modules/module_reading_goals.lua:488
+#: modules/module_reading_goals.lua:508
+#: modules/module_coverdeck.lua:920
+#: modules/module_currently.lua:772
+#: modules/module_currently.lua:773
+#: modules/module_currently.lua:830
+#: modules/module_currently.lua:841
+msgid "%s read"
+msgstr "已讀 %s"
 
-#: desktop_modules/module_currently.lua
-msgid "%d days"
-msgstr "%d 天"
+#: modules/module_coverdeck.lua:926
+#: modules/module_currently.lua:795
+#: modules/module_currently.lua:799
+msgid "%s remaining"
+msgstr "剩餘 %s"
 
-#: desktop_modules/module_currently.lua
-msgid "Stats layout"
-msgstr "統計佈局"
+#: modules/module_reading_stats.lua:379
+#: modules/module_quick_actions.lua:599
+msgid "(%d/%d — at limit)"
+msgstr "（%d/%d — 已達上限）"
 
-#: sui_menu.lua:356
-msgid "Pagination bar set to Default.\n\nRestart now?"
-msgstr ""
+#: modules/module_feat_coll.lua:95
+msgid "(collection not found)"
+msgstr "（未找到收藏）"
 
-#: sui_menu.lua:367
-msgid "Navpager enabled.\n\nRestart now?"
-msgstr ""
+#: modules/module_collections.lua:1364
+msgid "4-Cover Grid"
+msgstr "四封面網格"
 
-#: sui_menu.lua:377
-msgid "Pagination bar hidden.\n\nRestart now?"
-msgstr ""
+#: screens/sui_menu.lua:2876
+msgid "4-Cover Grid (Mosaic View Only)"
+msgstr "4 封面網格（僅圖書牆檢視）"
 
-#: sui_menu.lua:387
-msgid "Dot Pager"
-msgstr "點分頁器"
+#: screens/sui_stats_windows.lua:3125
+msgid "A freeze can only bridge a single missed day right after an active one — yesterday doesn't qualify."
+msgstr "凍結補簽只能補救連續閱讀日後錯過的第一天 — 昨天不符合補簽資格。"
 
-#: sui_menu.lua:395
-msgid "Shows a row of dots at the bottom of the homescreen.\nThe active page dot is filled; the others are dimmed.\nAlways active when Navpager is selected."
-msgstr "在主畫面底部顯示一行點。\n活動頁面的點是填充的；其他是暗淡的。\n選擇導覽頁時始終啟用。"
+#: features/sui_presets.lua:862
+#: features/sui_presets.lua:948
+#: screens/sui_menu.lua:4064
+#: screens/sui_menu.lua:4149
+msgid "A preset named \"%s\" already exists."
+msgstr "名為「%s」的預設檔已存在。"
 
-#: sui_menu.lua:417
-msgid "Uses the standard KOReader pagination bar on the homescreen.\nNot available when Navpager is active."
-msgstr ""
+#: features/sui_presets.lua:803
+#: screens/sui_menu.lua:4010
+msgid "A preset named \"%s\" already exists.\nOverwrite it?"
+msgstr "名為「%s」的預設檔已存在。\n要覆蓋它嗎？"
 
-#: sui_menu.lua:438
-msgid "Hides the pagination bar on the homescreen.\nNot available when Navpager is active."
-msgstr ""
+#: screens/sui_menu.lua:1063
+#: screens/sui_menu.lua:1343
+msgid "A restart is required to apply the new bar size across all layouts.\n\nRestart now?"
+msgstr "需要重新啟動才能在所有版面套用新的欄位尺寸。\n\n要立即重新啟動嗎？"
 
-#: sui_menu.lua:1566
-msgid "Modules per Page  (%d)"
-msgstr "每頁模組數  (%d)"
+#: screens/sui_menu.lua:4332
+msgid "A restart is required to apply the new text size everywhere.\n\nRestart now?"
+msgstr "需要重新啟動才能全面套用新的文字大小。\n\n要立即重新啟動嗎？"
 
-#: sui_menu.lua:1572
-msgid "Modules per Page"
-msgstr "每頁模組數"
+#: _meta.lua:6
+msgid "A simple UI for KOReader"
+msgstr "Simple UI 是 KOReader 的介面外掛，提供簡約美觀的介面。"
 
-#: sui_menu.lua:1573
-msgid "Maximum number of modules shown on each page.\nSwipe left/right on the Home Screen to turn pages."
-msgstr ""
+#: screens/sui_stats_windows.lua:2711
+msgid "ALL TIME"
+msgstr "所有時間"
 
-#: sui_menu.lua:1834
-msgid "Placeholder cover for bookless folders"
-msgstr "為空資料夾顯示佔位封面"
-
-#: sui_menu.lua:1849
-msgid "  Scan subfolders for cover"
-msgstr "  掃描子資料夾中的封面"
-
-#: sui_menu.lua
-msgid "Check for Updates"
-msgstr "檢查更新"
-
-#: sui_menu.lua
+#: screens/sui_menu.lua:4607
+#: screens/sui_settings_window.lua:324
+#: screens/sui_settings_window.lua:1025
 msgid "About"
 msgstr "關於"
 
-#: sui_menu.lua
-msgid "Version: %s"
-msgstr "版本：%s"
+#: features/sui_style.lua:2098
+msgid "Accent / Active Color"
+msgstr "強調/作用中顏色"
 
-#: sui_menu.lua
+#: features/sui_quickactions.lua:2356
+#: features/sui_quickactions.lua:2402
+msgid "Action"
+msgstr "動作"
+
+#: modules/module_action_list.lua:333
+msgid "Action List"
+msgstr "動作清單"
+
+#: features/sui_quickactions.lua:2606
+msgid "Action Type"
+msgstr "動作類型"
+
+#: features/sui_quickactions.lua:1091
+msgid "Action error: %s"
+msgstr "動作錯誤：%s"
+
+#: features/sui_quickactions.lua:2378
+msgid "Action name…"
+msgstr "動作名稱······"
+
+#: features/sui_quickactions.lua:1084
+msgid "Action not available: %s"
+msgstr "動作不可用：%s"
+
+#: screens/sui_quicksettings_bar.lua:1234
+#: screens/sui_quicksettings_bar.lua:1261
+msgid "Add Action"
+msgstr "新增動作"
+
+#: screens/sui_menu.lua:1605
+#: screens/sui_menu.lua:1643
+msgid "Add Button"
+msgstr "新增按鈕"
+
+#: modules/module_action_list.lua:518
+#: modules/module_action_list.lua:554
+#: modules/module_reading_stats.lua:773
+#: modules/module_reading_stats.lua:805
+#: modules/module_reading_goals.lua:898
+#: modules/module_reading_goals.lua:927
+#: modules/module_coverdeck.lua:1339
+#: modules/module_coverdeck.lua:1359
+#: modules/module_coverdeck.lua:1474
+#: modules/module_coverdeck.lua:1491
+#: modules/module_currently.lua:1560
+#: modules/module_currently.lua:1607
+#: modules/module_quick_actions.lua:547
+#: modules/module_quick_actions.lua:583
+#: engines/sui_screen_engine.lua:2146
+#: engines/sui_window.lua:848
+#: screens/sui_menu.lua:988
+#: screens/sui_menu.lua:1025
+#: screens/sui_menu.lua:1214
+#: screens/sui_menu.lua:1260
+#: screens/sui_menu.lua:2042
+#: screens/sui_menu.lua:2078
+#: screens/sui_quicksettings_bar.lua:1048
+#: screens/sui_settings_window.lua:1033
+msgid "Add Item"
+msgstr "新增項目"
+
+#: screens/sui_settings_window.lua:1030
+#: screens/sui_settings_window.lua:1170
+msgid "Add Module"
+msgstr "新增模組"
+
+#: screens/sui_settings_window.lua:1136
+msgid "Add Page"
+msgstr "新增頁面"
+
+#: modules/module_action_list.lua:429
+#: modules/module_quick_actions.lua:452
+#: screens/sui_menu.lua:1962
+#: screens/sui_quicksettings_bar.lua:1107
+msgid "Add at least 2 actions to arrange."
+msgstr "請至少新增 2 個動作以進行排序。"
+
+#: modules/module_feat_coll.lua:220
+#: modules/module_tbr.lua:328
+msgid "Add at least 2 books to arrange."
+msgstr "請至少新增 2 本書以進行排序。"
+
+#: modules/module_reading_stats.lua:722
+msgid "Add at least 2 stats to arrange."
+msgstr "請至少新增 2 項統計數據以進行排序。"
+
+#: modules/module_tbr.lua:532
+msgid "Add to To Be Read"
+msgstr "加入待讀清單"
+
+#: engines/sui_window.lua:2301
+msgid "Advanced"
+msgstr "進階"
+
+#: engines/sui_window.lua:2210
+msgid "Advanced option"
+msgstr "進階選項"
+
+#: modules/module_quote.lua:1559
+#: modules/module_action_list.lua:597
+#: modules/module_reading_stats.lua:878
+#: modules/module_clock.lua:1029
+#: modules/module_quick_actions.lua:759
+msgid "Alignment"
+msgstr "對齊方式"
+
+#: engines/sui_window.lua:3350
+#: screens/sui_settings_window.lua:808
+msgid "All items have already been added."
+msgstr "所有項目皆已新增。"
+
+#: screens/sui_settings_window.lua:786
+msgid "All modules have already been added."
+msgstr "所有模組皆已新增。"
+
+#: features/sui_quickactions.lua:3407
+msgid "All recent books are finished."
+msgstr "所有近期書籍皆已讀完。"
+
+#: modules/module_reading_stats.lua:123
+msgid "All time — Books"
+msgstr "累計 — 書籍"
+
+#: modules/module_reading_stats.lua:122
+msgid "All time — Time"
+msgstr "累計 — 時間"
+
+#: screens/sui_menu.lua:2553
+msgid "Always"
+msgstr "總是"
+
+#: modules/module_clock.lua:1001
+#: modules/module_clock.lua:1020
+msgid "Analogue"
+msgstr "模擬"
+
+#: modules/module_reading_goals.lua:820
+#: modules/module_reading_goals.lua:886
+#: modules/module_reading_goals.lua:923
+#: modules/module_reading_goals.lua:940
+msgid "Annual Goal"
+msgstr "年度目標"
+
+#: modules/module_reading_goals.lua:396
+msgid "Annual Reading Goal"
+msgstr "年度閱讀目標"
+
+#: modules/module_reading_goals.lua:1035
+#: modules/module_currently.lua:1838
+#: modules/module_quick_actions.lua:685
+#: engines/sui_book_grid.lua:1844
+#: screens/sui_menu.lua:1821
+#: screens/sui_menu.lua:1824
+msgid "Appearance"
+msgstr "外觀"
+
+#: modules/module_clock.lua:1075
+#: modules/module_clock.lua:1101
+#: features/sui_style.lua:2122
+#: infra/sui_config.lua:885
+#: infra/sui_config.lua:919
+#: infra/sui_config.lua:1034
+#: screens/sui_menu.lua:1050
+#: screens/sui_menu.lua:1330
+#: screens/sui_menu.lua:2394
+#: screens/sui_menu.lua:2466
+#: screens/sui_menu.lua:2503
+#: screens/sui_menu.lua:2924
+#: screens/sui_menu.lua:3285
+#: screens/sui_menu.lua:4326
+msgid "Apply"
+msgstr "套用"
+
+#: features/sui_style.lua:2172
+msgid "Apply Palette…"
+msgstr "套用調色盤······"
+
+#: modules/module_clock.lua:61
+#: screens/sui_stats_windows.lua:2840
+msgid "April"
+msgstr "四月"
+
+#: modules/module_feat_coll.lua:206
+#: modules/module_feat_coll.lua:281
+#: modules/module_feat_coll.lua:300
+#: modules/module_tbr.lua:316
+#: modules/module_tbr.lua:389
+#: modules/module_tbr.lua:412
+msgid "Arrange"
+msgstr "排序"
+
+#: modules/module_action_list.lua:449
+#: modules/module_quick_actions.lua:470
+#: screens/sui_menu.lua:1966
+msgid "Arrange %s"
+msgstr "排序 %s"
+
+#: screens/sui_menu.lua:1561
+#: screens/sui_menu.lua:1568
+#: screens/sui_menu.lua:1745
+#: screens/sui_menu.lua:1760
+msgid "Arrange Buttons"
+msgstr "排序按鈕"
+
+#: modules/module_feat_coll.lua:214
+#: modules/module_feat_coll.lua:249
+msgid "Arrange Collection"
+msgstr "排序收藏"
+
+#: modules/module_action_list.lua:420
+#: modules/module_coverdeck.lua:1414
+#: modules/module_coverdeck.lua:1420
+#: modules/module_currently.lua:1433
+#: modules/module_currently.lua:1476
+#: modules/module_quick_actions.lua:443
+#: engines/sui_screen_engine.lua:2145
+#: screens/sui_menu.lua:700
+#: screens/sui_menu.lua:771
+#: screens/sui_menu.lua:778
+#: screens/sui_menu.lua:1956
+#: screens/sui_topbar.lua:514
+#: screens/sui_bottombar.lua:889
+#: screens/sui_quicksettings_bar.lua:1047
+#: screens/sui_quicksettings_bar.lua:1098
+#: screens/sui_settings_window.lua:43
+#: screens/sui_settings_window.lua:1054
+msgid "Arrange Items"
+msgstr "排序項目"
+
+#: screens/sui_quicksettings_bar.lua:1123
+msgid "Arrange Quick Settings"
+msgstr "排序快速設定"
+
+#: modules/module_reading_stats.lua:733
+msgid "Arrange Reading Stats"
+msgstr "排序閱讀統計"
+
+#: modules/module_coverdeck.lua:1435
+msgid "Arrange Statistics"
+msgstr "排序統計"
+
+#: screens/sui_menu.lua:307
+#: screens/sui_menu.lua:325
+msgid "Arrange Tabs"
+msgstr "排序分頁"
+
+#: modules/module_tbr.lua:321
+#: modules/module_tbr.lua:359
+msgid "Arrange To Be Read List"
+msgstr "排序待讀清單"
+
+#: features/sui_presets.lua:137
+msgid "At a Glance"
+msgstr "概覽"
+
+#: modules/module_clock.lua:62
+#: screens/sui_stats_windows.lua:2841
+msgid "August"
+msgstr "八月"
+
+#: modules/module_coverdeck.lua:176
+#: modules/module_currently.lua:282
+msgid "Author"
+msgstr "作者"
+
+#: modules/module_library.lua:214
+#: modules/module_feat_coll.lua:170
+#: modules/module_tbr.lua:270
+msgid "Author (A–Z)"
+msgstr "作者（A–Z）"
+
+#: screens/sui_menu.lua:4414
 msgid "Author: %s"
 msgstr "作者：%s"
 
-#: sui_homescreen.lua:407
-#: desktop_modules/module_quote.lua:950
-msgid "Open this file?"
-msgstr "開啟這個檔案嗎？"
+#: features/sui_quickactions.lua:879
+#: infra/sui_config.lua:132
+#: features/library/sui_library_browse.lua:58
+msgid "Authors"
+msgstr "作者"
 
-#: sui_bottombar.lua:1638
-msgid "Sleep"
-msgstr "休眠"
+#: modules/module_collections.lua:1373
+#: screens/sui_menu.lua:2887
+msgid "Auto (Single ↔ 4-Cover Grid)"
+msgstr "自動（單封面 ↔ 4 封面網格）"
 
-#: sui_updater.lua:157
-msgid "Downloading Simple UI "
-msgstr ""
+#: modules/module_collections.lua:348
+#: features/library/sui_group_actions.lua:52
+msgid "Auto (first book)"
+msgstr "自動（第一本書）"
 
-#: sui_updater.lua:163
-msgid "Download error: "
-msgstr "下載錯誤："
+#: screens/sui_menu.lua:2351
+msgid "Auto-rotate"
+msgstr "自動旋轉"
 
-#: sui_updater.lua:174
-msgid "Extraction error: "
-msgstr "擷取錯誤："
+#: screens/sui_menu.lua:4419
+msgid "Automatic Update Check"
+msgstr "自動檢查更新"
 
-#: sui_updater.lua:180
-msgid "Simple UI %s successfully installed.\n\nRestart KOReader to apply the update?"
-msgstr ""
+#: screens/sui_stats_windows.lua:1215
+#: screens/sui_stats_windows.lua:2420
+#: screens/sui_stats_windows.lua:3913
+msgid "Average per day"
+msgstr "每日平均"
 
-#: sui_updater.lua:183
-msgid "Restart"
-msgstr "重新啟動"
+#: screens/sui_stats_windows.lua:1217
+#: screens/sui_stats_windows.lua:3915
+msgid "Average per page"
+msgstr "每頁平均"
 
-#: sui_updater.lua:184
-#: sui_updater.lua:237
-#: sui_updater.lua:258
+#: screens/sui_titlebar.lua:103
+#: screens/sui_titlebar.lua:109
+msgid "Back"
+msgstr "返回"
+
+#: features/sui_style.lua:100
+msgid "Back Button"
+msgstr "返回按鈕"
+
+#: modules/module_collections.lua:1395
+#: engines/sui_book_grid.lua:2013
+#: screens/sui_menu.lua:3189
+#: screens/sui_menu.lua:3198
+#: screens/sui_menu.lua:3204
+msgid "Badge"
+msgstr "標記"
+
+#: modules/module_collections.lua:1439
+#: modules/module_collections.lua:1442
+#: engines/sui_book_grid.lua:1946
+#: engines/sui_book_grid.lua:1948
+#: screens/sui_menu.lua:2917
+msgid "Badge Size"
+msgstr "標記尺寸"
+
+#: screens/sui_menu.lua:2905
+msgid "Badges"
+msgstr "標記"
+
+#: screens/sui_menu.lua:3122
+#: screens/sui_menu.lua:3131
+#: screens/sui_menu.lua:3137
+#: features/library/sui_foldercovers.lua:309
+msgid "Banner"
+msgstr "橫幅"
+
+#: engines/sui_book_grid.lua:1895
+msgid "Bar"
+msgstr "條形"
+
+#: engines/sui_book_grid.lua:1897
+msgid "Bar + Text"
+msgstr "條形 + 文字"
+
+#: screens/sui_menu.lua:566
+#: screens/sui_menu.lua:1316
+msgid "Bar Size"
+msgstr "欄位尺寸"
+
+#: screens/sui_menu.lua:1274
+msgid "Bar Style"
+msgstr "欄位樣式"
+
+#: modules/module_quick_actions.lua:711
+#: screens/sui_menu.lua:1301
+#: screens/sui_quicksettings_bar.lua:1338
+msgid "Bare"
+msgstr "無邊框"
+
+#: screens/sui_menu.lua:4569
+#: screens/sui_settings_window.lua:289
+#: screens/sui_settings_window.lua:1022
+msgid "Bars"
+msgstr "功能欄"
+
+#: infra/sui_config.lua:170
+msgid "Battery"
+msgstr "電量"
+
+#: modules/module_clock.lua:1086
+#: modules/module_clock.lua:1094
+msgid "Battery Spacing"
+msgstr "電量間距"
+
+#: screens/sui_menu.lua:2752
+#: screens/sui_settings_window.lua:373
+#: screens/sui_settings_window.lua:1035
+msgid "Behaviour"
+msgstr "行為"
+
+#: screens/sui_stats_windows.lua:2190
+#: screens/sui_stats_windows.lua:2210
+msgid "Best streak"
+msgstr "最佳連續"
+
+#: screens/sui_menu.lua:2592
+msgid "Book Cover Transition"
+msgstr "書籍封面過渡"
+
+#: features/sui_quickactions.lua:2127
+msgid "Book Info"
+msgstr "書籍資訊"
+
+#: infra/sui_config.lua:1104
+msgid "Book Menu"
+msgstr "圖書選單"
+
+#: screens/sui_stats_windows.lua:3966
+msgid "Book Statistics"
+msgstr "書籍統計"
+
+#: main.lua:1139
+msgid "Book statistics"
+msgstr "書籍統計"
+
+#: screens/sui_settings_window.lua:297
+msgid "Book-browser settings"
+msgstr "圖書瀏覽器設定"
+
+#: features/sui_quickactions.lua:453
+msgid "Bookmark browser"
+msgstr "書籤瀏覽器"
+
+#: features/sui_quickactions.lua:387
+msgid "Bookmark browser not available."
+msgstr "書籤瀏覽器不可用。"
+
+#: features/sui_quickactions.lua:776
+#: infra/sui_config.lua:125
+msgid "Bookmarks"
+msgstr "書籤"
+
+#: modules/module_library.lua:294
+#: modules/module_feat_coll.lua:257
+msgid "Books"
+msgstr "書籍"
+
+#: modules/module_reading_goals.lua:397
+msgid "Books to read in %s:"
+msgstr "%s 年預計閱讀書籍："
+
+#: modules/module_collections.lua:1416
+#: screens/sui_menu.lua:2940
+#: screens/sui_menu.lua:2947
+#: screens/sui_menu.lua:2962
+#: screens/sui_menu.lua:3353
+#: screens/sui_menu.lua:3372
+msgid "Bottom"
+msgstr "底部"
+
+#: screens/sui_menu.lua:1376
+#: screens/sui_menu.lua:1377
+msgid "Bottom Margin"
+msgstr "底邊距"
+
+#: screens/sui_menu.lua:2593
+msgid "Briefly show the book cover full-screen when opening or closing a book, masking the page-layout flash. Normally requires the book to already be indexed by the cover browser (its cover must have been seen at least once in a grid/list view) — see \"High-Quality Cover\" below to also cover un-indexed books."
+msgstr "開啟或關閉書籍時短暫全螢幕顯示封面，以遮罩版面刷新閃爍。通常需要書籍已被封面瀏覽器建立索引（封面需在網格/清單檢視中至少出現過一次）— 詳見下方的「高畫質封面」以包含未建立索引的書籍。"
+
+#: features/sui_quickactions.lua:817
+#: infra/sui_config.lua:127
+#: infra/sui_config.lua:169
+msgid "Brightness"
+msgstr "亮度"
+
+#: screens/sui_titlebar.lua:105
+msgid "Browse"
+msgstr "瀏覽"
+
+#: features/sui_style.lua:115
+msgid "Browse Button (author)"
+msgstr "瀏覽按鈕（作者）"
+
+#: features/sui_style.lua:109
+msgid "Browse Button (default)"
+msgstr "瀏覽按鈕（預設）"
+
+#: features/sui_style.lua:121
+msgid "Browse Button (series)"
+msgstr "瀏覽按鈕（系列）"
+
+#: features/sui_style.lua:127
+msgid "Browse Button (tags)"
+msgstr "瀏覽按鈕（標籤）"
+
+#: features/sui_style.lua:1383
+msgid "Browse Icons"
+msgstr "瀏覽圖示"
+
+#: features/library/sui_library_browse.lua:416
+msgid "Browse by"
+msgstr "瀏覽方式"
+
+#: features/sui_quickactions.lua:886
+#: features/sui_quickactions.lua:904
+#: features/sui_quickactions.lua:922
+msgid "Browse by Authors/Series/Tags not available."
+msgstr "依作者/系列/標籤瀏覽功能不可用。"
+
+#: screens/sui_titlebar.lua:1000
+msgid "Browse library"
+msgstr "瀏覽藏書"
+
+#: modules/module_quick_actions.lua:723
+#: screens/sui_quicksettings_bar.lua:1351
+msgid "Button Background"
+msgstr "按鈕背景"
+
+#: screens/sui_menu.lua:1832
+msgid "Button Size"
+msgstr "按鈕尺寸"
+
+#: modules/module_quick_actions.lua:688
+#: screens/sui_quicksettings_bar.lua:1315
+msgid "Button Type"
+msgstr "按鈕類型"
+
+#: screens/sui_titlebar.lua:1004
+msgid "By author"
+msgstr "依作者"
+
+#: screens/sui_menu.lua:2632
+msgid "By default the cover is stretched to fill the whole screen, which can distort it if its proportions don't match your screen's. When on, the cover keeps its original proportions instead, centered over a black background."
+msgstr "預設情況下封面會拉伸填滿整個螢幕，若比例不符可能會變形。開啟此選項後，封面將保持原始比例並於黑色背景中央顯示。"
+
+#: screens/sui_titlebar.lua:1005
+msgid "By series"
+msgstr "依系列"
+
+#: screens/sui_titlebar.lua:1006
+msgid "By tags"
+msgstr "依標籤"
+
+#: screens/sui_stats_windows.lua:3146
+msgid "CALENDAR"
+msgstr "行事曆"
+
+#: modules/module_quote.lua:1305
+#: modules/module_collections.lua:374
+#: modules/module_reading_goals.lua:383
+#: modules/module_clock.lua:1076
+#: modules/module_clock.lua:1102
+#: features/sui_quickactions.lua:478
+#: features/sui_quickactions.lua:1521
+#: features/sui_quickactions.lua:1867
+#: features/sui_quickactions.lua:1991
+#: features/sui_quickactions.lua:2013
+#: features/sui_quickactions.lua:2107
+#: features/sui_quickactions.lua:2393
+#: features/sui_quickactions.lua:2464
+#: features/sui_quickactions.lua:2490
+#: features/sui_quickactions.lua:2515
+#: features/sui_quickactions.lua:2593
+#: features/sui_quickactions.lua:2617
+#: features/sui_quickactions.lua:2941
+#: features/sui_quickactions.lua:3345
+#: features/sui_style.lua:1401
+#: features/sui_style.lua:2118
+#: features/sui_presets.lua:766
+#: features/sui_presets.lua:805
+#: features/sui_presets.lua:835
+#: features/sui_presets.lua:852
+#: features/sui_presets.lua:880
+#: features/sui_presets.lua:920
+#: features/sui_presets.lua:938
+#: features/sui_presets.lua:967
+#: infra/sui_config.lua:886
+#: infra/sui_config.lua:920
+#: infra/sui_config.lua:1035
+#: infra/sui_updater.lua:510
+#: infra/sui_updater.lua:527
+#: screens/sui_titlebar.lua:1007
+#: screens/sui_menu.lua:656
+#: screens/sui_menu.lua:921
+#: screens/sui_menu.lua:1051
+#: screens/sui_menu.lua:1331
+#: screens/sui_menu.lua:2395
+#: screens/sui_menu.lua:2467
+#: screens/sui_menu.lua:2504
+#: screens/sui_menu.lua:2925
+#: screens/sui_menu.lua:3286
+#: screens/sui_menu.lua:3978
+#: screens/sui_menu.lua:4012
+#: screens/sui_menu.lua:4041
+#: screens/sui_menu.lua:4058
+#: screens/sui_menu.lua:4084
+#: screens/sui_menu.lua:4125
+#: screens/sui_menu.lua:4143
+#: screens/sui_menu.lua:4170
+#: screens/sui_menu.lua:4327
+#: screens/sui_menu.lua:4454
+#: screens/sui_stats_windows.lua:650
+#: screens/sui_stats_windows.lua:776
+#: screens/sui_settings_window.lua:442
+#: screens/sui_settings_window.lua:1113
+#: features/library/sui_library_browse.lua:826
+#: features/library/sui_series_grouping.lua:377
+#: features/library/sui_group_actions.lua:75
+#: features/library/sui_group_actions.lua:109
 msgid "Cancel"
 msgstr "取消"
 
-#: sui_updater.lua:184
-msgid "Later"
-msgstr "稍後"
+#: modules/module_reading_stats.lua:836
+msgid "Cards"
+msgstr "卡片"
 
-#: sui_updater.lua:194
+#: modules/module_reading_stats.lua:846
+msgid "Cards - Transparent"
+msgstr "卡片 - 透明"
+
+#: modules/module_quote.lua:128
+#: modules/module_quote.lua:1569
+#: modules/module_action_list.lua:75
+#: modules/module_action_list.lua:607
+#: modules/module_reading_stats.lua:98
+#: modules/module_reading_stats.lua:892
+#: modules/module_clock.lua:146
+#: modules/module_clock.lua:1041
+#: screens/sui_menu.lua:716
+#: screens/sui_menu.lua:951
+#: screens/sui_menu.lua:3352
+#: screens/sui_menu.lua:3365
+msgid "Center"
+msgstr "置中"
+
+#: screens/sui_menu.lua:4430
+msgid "Check for Updates"
+msgstr "檢查更新"
+
+#: infra/sui_updater.lua:643
 msgid "Checking for updates…"
-msgstr "檢查更新中…"
+msgstr "正在檢查更新······"
 
-#: sui_updater.lua:200
-msgid "Error checking for updates: "
-msgstr "檢查更新時出錯："
+#: screens/sui_onboarding.lua:55
+msgid "Choose your initial layout"
+msgstr "選擇初始版面配置"
 
-#: sui_updater.lua:216
-msgid "Could not retrieve version information."
-msgstr "無法取得版本資訊"
+#: modules/module_clock.lua:700
+#: features/sui_presets.lua:150
+#: infra/sui_config.lua:167
+msgid "Clock"
+msgstr "時鐘"
 
-#: sui_updater.lua:222
-msgid "Simple UI is up to date (%s)."
-msgstr ""
+#: modules/module_clock.lua:997
+msgid "Clock Style"
+msgstr "時鐘樣式"
 
-#: sui_updater.lua:233
-msgid "Simple UI %s is available (you have %s).\n\nNo automatic update file was found.\n\nOpen the releases page on GitHub?"
-msgstr ""
+#: screens/sui_titlebar.lua:108
+msgid "Close"
+msgstr "關閉"
 
-#: sui_updater.lua:236
-msgid "Open in browser"
-msgstr "在瀏覽器中打開"
+#: screens/sui_menu.lua:2549
+msgid "Closing Book Notice"
+msgstr "關閉書籍提示"
 
-#: sui_updater.lua:254
-msgid "Simple UI %s is available!\nCurrent version: %s\n\nDownload and install now?"
-msgstr ""
+#: main.lua:1901
+msgid "Closing book…"
+msgstr "正在關閉書籍······"
 
-#: sui_updater.lua:257
+#: features/sui_quickactions.lua:2039
+msgid "Codepoint out of valid Unicode range (0–10FFFF)."
+msgstr "碼位超出有效的 Unicode 範圍（0–10FFFF）。"
+
+#: features/sui_quickactions.lua:2466
+#: features/sui_quickactions.lua:2609
+msgid "Collection"
+msgstr "收藏"
+
+#: modules/module_collections.lua:1503
+msgid "Collection Menu"
+msgstr "收藏選單"
+
+#: features/library/sui_group_actions.lua:138
+msgid "Collection \"%1\" created with %2 books."
+msgstr "已建立包含 %2 本書的收藏「%1」。"
+
+#: features/library/sui_group_actions.lua:122
+msgid "Collection already exists: %1"
+msgstr "收藏已存在：%1"
+
+#: modules/module_collections.lua:335
+#: modules/module_collections.lua:341
+msgid "Collection is empty."
+msgstr "收藏為空。"
+
+#: features/sui_quickactions.lua:3031
+msgid "Collection not available: %s"
+msgstr "收藏不可用：%s"
+
+#: modules/module_feat_coll.lua:127
+msgid "Collection: "
+msgstr "收藏："
+
+#: modules/module_feat_coll.lua:127
+msgid "Collection: (none)"
+msgstr "收藏：（無）"
+
+#: modules/module_collections.lua:1196
+#: modules/module_collections.lua:1216
+#: modules/module_collections.lua:1225
+#: modules/module_collections.lua:1244
+#: modules/module_collections.lua:1494
+#: modules/module_collections.lua:1495
+#: modules/module_coverdeck.lua:1264
+#: features/sui_quickactions.lua:464
+#: features/sui_quickactions.lua:661
+#: features/sui_quickactions.lua:2129
+#: infra/sui_config.lua:119
+msgid "Collections"
+msgstr "收藏"
+
+#: infra/sui_patches.lua:1385
+msgid "Collections (%1)"
+msgstr "收藏（%1）"
+
+#: features/sui_quickactions.lua:668
+msgid "Collections not available."
+msgstr "收藏不可用。"
+
+#: features/sui_style.lua:177
+msgid "Collections: Back Button"
+msgstr "收藏：返回按鈕"
+
+#: screens/sui_menu.lua:2985
+#: screens/sui_menu.lua:3039
+#: screens/sui_menu.lua:3093
+#: screens/sui_menu.lua:3160
+#: screens/sui_menu.lua:3227
+#: screens/sui_menu.lua:3381
+msgid "Color"
+msgstr "顏色"
+
+#: engines/sui_book_grid.lua:1790
+msgid "Columns"
+msgstr "列"
+
+#: modules/module_reading_goals.lua:1047
+#: modules/module_currently.lua:1880
+#: screens/sui_menu.lua:1835
+msgid "Compact"
+msgstr "緊湊"
+
+#: features/sui_quickactions.lua:1990
+msgid "Confirm"
+msgstr "確認"
+
+#: features/sui_quickactions.lua:694
+#: infra/sui_config.lua:122
+#: screens/sui_onboarding.lua:253
+#: screens/sui_onboarding.lua:259
+#: screens/sui_onboarding.lua:265
+msgid "Continue"
+msgstr "繼續"
+
+#: features/sui_style.lua:2047
+msgid "Cool Mist"
+msgstr "冷霧"
+
+#: engines/sui_book_grid.lua:1899
+msgid "Corner Badge"
+msgstr "角落徽章"
+
+#: features/sui_style.lua:2359
+msgid "Could not determine packs folder"
+msgstr "無法確定圖示包資料夾"
+
+#: screens/sui_stats_windows.lua:172
+msgid "Could not open statistics database."
+msgstr "無法開啟統計資料庫。"
+
+#: features/sui_style.lua:2361
+msgid "Could not open zip (invalid format or corrupted)"
+msgstr "無法開啟 ZIP 檔（格式無效或已損壞）"
+
+#: modules/module_coverdeck.lua:559
+#: features/sui_presets.lua:165
+#: features/sui_presets.lua:183
+msgid "Cover Deck"
+msgstr "封面卡牌"
+
+#: screens/sui_menu.lua:2857
+msgid "Cover Settings"
+msgstr "封面設定"
+
+#: engines/sui_book_grid.lua:1743
+#: engines/sui_book_grid.lua:1745
+msgid "Cover Size"
+msgstr "封面尺寸"
+
+#: modules/module_currently.lua:1363
+#: modules/module_currently.lua:1364
+msgid "Cover Spacing"
+msgstr "封面間距"
+
+#: modules/module_collections.lua:1350
+msgid "Cover Style"
+msgstr "封面樣式"
+
+#: modules/module_collections.lua:378
+msgid "Cover for \"%s\""
+msgstr "「%s」的封面"
+
+#: modules/module_coverdeck.lua:1160
+#: modules/module_coverdeck.lua:1161
+#: modules/module_currently.lua:1336
+#: modules/module_currently.lua:1337
+msgid "Cover size"
+msgstr "封面尺寸"
+
+#: modules/module_coverdeck.lua:174
+msgid "Covers"
+msgstr "封面"
+
+#: screens/sui_settings_window.lua:1118
+#: features/library/sui_group_actions.lua:114
+msgid "Create"
+msgstr "建立"
+
+#: features/sui_quickactions.lua:1557
+#: features/sui_quickactions.lua:2844
+msgid "Create Quick Action"
+msgstr "建立快速動作"
+
+#: screens/sui_settings_window.lua:1101
+msgid "Create Screen"
+msgstr "建立螢幕"
+
+#: features/library/sui_foldercovers.lua:726
+#: features/library/sui_library_browse.lua:819
+#: features/library/sui_series_grouping.lua:369
+msgid "Create collection"
+msgstr "建立收藏"
+
+#: screens/sui_settings_window.lua:1108
+msgid "Create screen"
+msgstr "建立螢幕"
+
+#: screens/sui_stats_windows.lua:2188
+#: screens/sui_stats_windows.lua:2208
+msgid "Current streak"
+msgstr "當前連續"
+
+#: modules/module_currently.lua:331
+#: modules/module_currently.lua:332
+#: modules/module_currently.lua:413
+#: modules/module_currently.lua:1841
+#: features/sui_presets.lua:138
+#: features/sui_presets.lua:150
+msgid "Currently Reading"
+msgstr "正在閱讀"
+
+#: infra/sui_config.lua:1836
+msgid "Custom"
+msgstr "自訂"
+
+#: features/sui_quickactions.lua:1836
+#: features/sui_quickactions.lua:1839
+msgid "Custom Actions"
+msgstr "自訂動作"
+
+#: modules/module_quote.lua:1456
+msgid "Custom File"
+msgstr "自訂檔案"
+
+#: modules/module_quote.lua:1505
+msgid "Custom File + My Highlights"
+msgstr "自訂檔案 + 我的劃線"
+
+#: features/sui_quickactions.lua:1450
+#: features/sui_quickactions.lua:1554
+msgid "Custom Quick Actions"
+msgstr "自定義快捷操作"
+
+#: infra/sui_custom_screens.lua:158
+msgid "Custom Screen"
+msgstr "自定義螢幕"
+
+#: features/sui_quickactions.lua:1846
+#: features/sui_quickactions.lua:1849
+msgid "Custom Screens"
+msgstr "自定義螢幕"
+
+#: screens/sui_settings_window.lua:393
+msgid "Custom Screens unavailable."
+msgstr "自定義螢幕不可用。"
+
+#: infra/sui_config.lua:173
+#: screens/sui_menu.lua:648
+#: screens/sui_menu.lua:914
+msgid "Custom Text"
+msgstr "自訂文字"
+
+#: screens/sui_onboarding.lua:172
+msgid "Custom wallpapers and icons"
+msgstr "自訂桌布與圖示"
+
+#: screens/sui_onboarding.lua:164
+msgid "Customize even more"
+msgstr "進一步自訂"
+
+#: screens/sui_stats_windows.lua:2742
+#: screens/sui_stats_windows.lua:3388
+msgid "DAY STREAK"
+msgstr "連續閱讀天數"
+
+#: modules/module_reading_goals.lua:860
+#: modules/module_reading_goals.lua:888
+#: modules/module_reading_goals.lua:925
+#: modules/module_reading_goals.lua:970
+msgid "Daily Goal"
+msgstr "每日目標"
+
+#: modules/module_reading_goals.lua:430
+msgid "Daily Reading Goal"
+msgstr "每日閱讀目標"
+
+#: modules/module_reading_stats.lua:119
+msgid "Daily avg — Pages"
+msgstr "每日平均 — 頁數"
+
+#: modules/module_reading_stats.lua:118
+msgid "Daily avg — Time"
+msgstr "每日平均 — 時間"
+
+#: modules/module_collections.lua:1425
+#: engines/sui_book_grid.lua:1870
+#: screens/sui_menu.lua:2987
+#: screens/sui_menu.lua:2992
+#: screens/sui_menu.lua:3041
+#: screens/sui_menu.lua:3046
+#: screens/sui_menu.lua:3095
+#: screens/sui_menu.lua:3100
+#: screens/sui_menu.lua:3162
+#: screens/sui_menu.lua:3167
+#: screens/sui_menu.lua:3229
+#: screens/sui_menu.lua:3234
+#: screens/sui_menu.lua:3383
+#: screens/sui_menu.lua:3395
+msgid "Dark"
+msgstr "深色"
+
+#: features/sui_style.lua:2033
+msgid "Dark Slate"
+msgstr "深石板灰"
+
+#: modules/module_clock.lua:1060
+#: modules/module_clock.lua:1068
+msgid "Date Spacing"
+msgstr "日期間距"
+
+#: modules/module_library.lua:215
+msgid "Date added (newest)"
+msgstr "新增日期（最新）"
+
+#: modules/module_library.lua:216
+msgid "Date added (oldest)"
+msgstr "新增日期（最早）"
+
+#: screens/sui_stats_windows.lua:728
+msgid "Date finished"
+msgstr "完讀日期"
+
+#: screens/sui_stats_windows.lua:721
+msgid "Date started"
+msgstr "開始日期"
+
+#: screens/sui_stats_windows.lua:955
+#: screens/sui_stats_windows.lua:3682
+msgid "Days"
+msgstr "天數"
+
+#: modules/module_coverdeck.lua:164
+#: modules/module_currently.lua:287
+msgid "Days of reading"
+msgstr "閱讀天數"
+
+#: modules/module_clock.lua:63
+#: screens/sui_stats_windows.lua:2842
+msgid "December"
+msgstr "十二月"
+
+#: modules/module_reading_goals.lua:1039
+#: modules/module_currently.lua:1387
+#: modules/module_currently.lua:1878
+#: features/sui_quickactions.lua:2068
+#: features/sui_quickactions.lua:2333
+#: screens/sui_titlebar.lua:1003
+#: screens/sui_menu.lua:465
+#: screens/sui_menu.lua:594
+#: screens/sui_menu.lua:1277
+#: screens/sui_menu.lua:1836
+msgid "Default"
+msgstr "預設"
+
+#: features/sui_quickactions.lua:2334
+msgid "Default (Folder)"
+msgstr "預設（資料夾）"
+
+#: features/sui_quickactions.lua:2335
+msgid "Default (Plugin)"
+msgstr "預設（外掛程式）"
+
+#: features/sui_quickactions.lua:2336
+msgid "Default (System)"
+msgstr "預設（系統）"
+
+#: modules/module_quote.lua:1392
+msgid "Default Quotes"
+msgstr "預設佳句"
+
+#: features/sui_style.lua:184
+msgid "Default: Folder"
+msgstr "預設：資料夾"
+
+#: features/sui_style.lua:202
+msgid "Default: Group"
+msgstr "預設：群組"
+
+#: features/sui_style.lua:190
+msgid "Default: Plugin"
+msgstr "預設：外掛程式"
+
+#: features/sui_style.lua:196
+msgid "Default: System"
+msgstr "預設：系統"
+
+#: engines/sui_window.lua:1926
+#: engines/sui_window.lua:2826
+#: features/sui_quickactions.lua:1520
+#: features/sui_quickactions.lua:2935
+#: features/sui_quickactions.lua:2940
+#: features/sui_presets.lua:876
+#: features/sui_presets.lua:879
+#: features/sui_presets.lua:919
+#: screens/sui_menu.lua:4080
+#: screens/sui_menu.lua:4083
+#: screens/sui_menu.lua:4124
+#: screens/sui_settings_window.lua:469
+#: screens/sui_settings_window.lua:514
+#: screens/sui_settings_window.lua:643
+#: features/library/sui_book_hold_dialog.lua:151
+msgid "Delete"
+msgstr "刪除"
+
+#: screens/sui_menu.lua:4453
+msgid "Delete Settings"
+msgstr "刪除設定"
+
+#: screens/sui_settings_window.lua:467
+msgid "Delete \"%s\"? This removes its layout, modules and Quick Action."
+msgstr "要刪除「%s」嗎？這將移除其佈局、模組和快捷操作。"
+
+#: features/sui_presets.lua:878
+#: features/sui_presets.lua:918
+#: screens/sui_menu.lua:4082
+#: screens/sui_menu.lua:4123
+msgid "Delete preset \"%s\"?"
+msgstr "要刪除預設檔「%s」嗎？"
+
+#: features/sui_quickactions.lua:1519
+#: features/sui_quickactions.lua:2939
+msgid "Delete quick action \"%s\"?"
+msgstr "要刪除快速動作「%s」嗎？"
+
+#: modules/module_currently.lua:284
+msgid "Description"
+msgstr "描述"
+
+#: features/sui_quickactions.lua:2132
+msgid "Dictionary Lookup"
+msgstr "查字典"
+
+#: modules/module_clock.lua:1002
+#: modules/module_clock.lua:1006
+msgid "Digital"
+msgstr "數位"
+
+#: screens/sui_menu.lua:2488
+msgid "Disable \"Lock Scale\" first to set a custom label scale."
+msgstr "請先停用「鎖定縮放」以設定自訂標籤縮放。"
+
+#: infra/sui_config.lua:870
+msgid "Disable \"Lock Scale\" first to set a per-module scale."
+msgstr "請先停用「鎖定縮放」以設定個別模組縮放。"
+
+#: infra/sui_config.lua:171
+msgid "Disk Usage"
+msgstr "磁碟使用量"
+
+#: features/sui_quickactions.lua:2990
+msgid "Dispatcher not available."
+msgstr "調度器不可用。"
+
+#: screens/sui_menu.lua:3553
+msgid "Display"
+msgstr "顯示"
+
+#: engines/sui_window.lua:67
+msgid "Do something"
+msgstr "執行操作"
+
+#: features/sui_quickactions.lua:2584
+msgid "Done"
+msgstr "完成"
+
+#: screens/sui_menu.lua:502
+msgid "Dot Pager"
+msgstr "圓點分頁器"
+
+#: infra/sui_updater.lua:526
 msgid "Download and install"
 msgstr "下載並安裝"
 
-#: desktop_modules/module_coverdeck.lua:750
-msgid "Above"
-msgstr "上方"
+#: infra/sui_updater.lua:525
+msgid "Download and install now?"
+msgstr "要立即下載並安裝嗎？"
 
-#: desktop_modules/module_tbr.lua:113
-msgid "Add at least 2 books to arrange."
-msgstr ""
+#: infra/sui_updater.lua:447
+msgid "Download error: "
+msgstr "下載錯誤："
 
-#: desktop_modules/module_tbr.lua:257
-msgid "Add to To Be Read"
-msgstr "加入待讀"
-
-#: desktop_modules/module_coverdeck.lua:787
-msgid "Arrange Statistics"
-msgstr "排序統計項"
-
-#: desktop_modules/module_tbr.lua:117
-msgid "Arrange To Be Read list"
-msgstr "排序待讀清單"
-
-#: desktop_modules/module_coverdeck.lua:758
-msgid "Below"
-msgstr "下方"
-
-#: sui_patches.lua:900
-msgid "Collections (%1)"
-msgstr "收藏夾（%1）"
-
-#: sui_updater.lua:323
+#: infra/sui_updater.lua:421
 msgid "Downloading Simple UI %s…"
-msgstr ""
+msgstr "正在下載 Simple UI %s······"
 
-#: sui_updater.lua:466
+#: modules/module_currently.lua:1390
+msgid "Dynamic"
+msgstr "動態"
+
+#: features/sui_quickactions.lua:2922
+msgid "Edit"
+msgstr "編輯"
+
+#: screens/sui_menu.lua:640
+#: screens/sui_menu.lua:642
+#: screens/sui_menu.lua:908
+msgid "Edit Custom Text"
+msgstr "編輯自訂文字"
+
+#: screens/sui_menu.lua:2196
+#: screens/sui_settings_window.lua:338
+msgid "Edit Home Screen Layout"
+msgstr "編輯主螢幕布局"
+
+#: features/sui_quickactions.lua:2251
+msgid "Edit Quick Action"
+msgstr "編輯快速動作"
+
+#: modules/module_clock.lua:239
+msgid "Eight"
+msgstr "八"
+
+#: modules/module_clock.lua:242
+msgid "Eighteen"
+msgstr "十八"
+
+#: modules/module_clock.lua:240
+msgid "Eleven"
+msgstr "十一"
+
+#: screens/sui_menu.lua:901
+msgid "Empty"
+msgstr "空白"
+
+#: features/sui_quickactions.lua:887
+#: features/sui_quickactions.lua:905
+#: features/sui_quickactions.lua:923
+msgid "Enable 'Browse by Author / Series / Tags' in the library menu first."
+msgstr "請先在書房選單中啟用「依作者/系列/標籤瀏覽」。"
+
+#: screens/sui_menu.lua:2808
+msgid "Enable Browse by Author / Series / Tags"
+msgstr "啟用依作者/系列/標籤瀏覽"
+
+#: screens/sui_menu.lua:2792
+msgid "Enable Library Custom Covers"
+msgstr "啟用書房自訂封面"
+
+#: screens/sui_menu.lua:1117
+msgid "Enable Navigation Bar"
+msgstr "啟用導覽欄"
+
+#: screens/sui_quicksettings_bar.lua:1172
+msgid "Enable Quick Settings Bar"
+msgstr "啟用快速設定欄"
+
+#: screens/sui_menu.lua:848
+msgid "Enable Status Bar"
+msgstr "啟用狀態欄"
+
+#: screens/sui_menu.lua:1786
+msgid "Enable Title Bar"
+msgstr "啟用標題欄"
+
+#: screens/sui_menu.lua:2244
+msgid "Enable Wallpaper"
+msgstr "啟用桌布"
+
+#: features/sui_style.lua:1782
+msgid "Enable custom UI font"
+msgstr "啟用自訂介面字型"
+
+#: features/sui_style.lua:2115
+msgid "Enter a hex color (#RRGGBB). On greyscale e-ink the perceived brightness is used."
+msgstr "輸入十六進位顏色碼（#RRGGBB）。在灰階電子墨水螢幕上將使用感知亮度。"
+
+#: features/sui_quickactions.lua:2010
+msgid "Enter the Unicode codepoint (hex) of a Nerd Fonts symbol.\nYou can look up codes with wakamaifondue.com using the file:\n  /koreader/fonts/nerdfonts/symbols.ttf\nLeave blank and press OK to remove a Nerd Font icon."
+msgstr "輸入 Nerd Fonts 符號的 Unicode 碼位（十六進位）。\n您可以使用以下檔案在 wakamaifondue.com 查詢代碼：\n  /koreader/fonts/nerdfonts/symbols.ttf\n留空並按下確定可移除 Nerd Font 圖示。"
+
+#: screens/sui_menu.lua:3843
+msgid "Error applying pack:"
+msgstr "套用圖示包時發生錯誤："
+
+#: infra/sui_updater.lua:648
 msgid "Error checking for updates."
-msgstr "檢查更新時出錯。"
+msgstr "檢查更新時發生錯誤。"
 
-#: sui_menu.lua:2042
+#: infra/sui_updater.lua:653
+msgid "Error checking for updates: "
+msgstr "檢查更新時發生錯誤："
+
+#: features/sui_presets.lua:1057
+#: screens/sui_menu.lua:4262
+msgid "Error exporting preset: "
+msgstr "匯出預設檔時發生錯誤："
+
+#: features/sui_style.lua:2408
+msgid "Error extracting zip: "
+msgstr "解壓縮 ZIP 時發生錯誤："
+
+#: features/sui_presets.lua:1025
+#: screens/sui_menu.lua:4229
+msgid "Error importing preset: "
+msgstr "匯入預設檔時發生錯誤："
+
+#: modules/module_reading_goals.lua:741
+msgid "Error in Reading Goals: check crash.log"
+msgstr "閱讀目標發生錯誤：請檢查 crash.log"
+
+#: screens/sui_menu.lua:3804
+msgid "Error installing pack:"
+msgstr "安裝圖示包時發生錯誤："
+
+#: screens/sui_stats_windows.lua:1226
+msgid "Exclude from goals"
+msgstr "排除於目標之外"
+
+#: screens/sui_stats_windows.lua:846
+#: screens/sui_stats_windows.lua:852
+msgid "Excluded"
+msgstr "已排除"
+
+#: features/sui_presets.lua:1041
+#: screens/sui_menu.lua:4245
+msgid "Export preset"
+msgstr "匯出預設檔"
+
+#: screens/sui_settings_window.lua:349
+#: screens/sui_settings_window.lua:1021
+msgid "Extra Custom Screens"
+msgstr "額外自定義螢幕"
+
+#: screens/sui_menu.lua:570
+msgid "Extra Small"
+msgstr "特小"
+
+#: infra/sui_updater.lua:448
+msgid "Extraction error: "
+msgstr "解壓縮錯誤："
+
+#: screens/sui_stats_windows.lua:3500
+msgid "FREEZES"
+msgstr "凍結權"
+
+#: screens/sui_menu.lua:4446
+msgid "Factory Reset"
+msgstr "恢復原廠設定"
+
+#: screens/sui_menu.lua:3262
+msgid "Fade Finished Books"
+msgstr "淡化完讀書籍"
+
+#: screens/sui_menu.lua:3278
+msgid "Fade Intensity"
+msgstr "淡化強度"
+
+#: screens/sui_menu.lua:3279
+msgid "Fades finished book covers towards white.\n50% is the default."
+msgstr "將已讀完書籍的封面朝白色淡化。\n預設值為50%。"
+
+#: screens/sui_menu.lua:2388
+msgid "Fades the wallpaper towards white to improve text readability.\n0% is the default (no lightening)."
+msgstr "將桌布朝白色淡化以提高文字可讀性。\n預設值為0%（不加亮）。"
+
+#: modules/module_coverdeck.lua:1246
+#: features/sui_quickactions.lua:763
+#: features/sui_quickactions.lua:2128
+#: infra/sui_config.lua:124
+msgid "Favorites"
+msgstr "我的最愛"
+
+#: features/sui_quickactions.lua:770
+msgid "Favorites not available."
+msgstr "我的最愛不可用。"
+
+#: modules/module_feat_coll.lua:373
+#: modules/module_feat_coll.lua:430
+msgid "Featured Collection"
+msgstr "精選收藏"
+
+#: modules/module_feat_coll.lua:87
+msgid "Featured Collection — tap to configure"
+msgstr "精選收藏 — 點選以組態"
+
+#: modules/module_clock.lua:61
+#: screens/sui_stats_windows.lua:2840
+msgid "February"
+msgstr "二月"
+
+#: features/sui_quickactions.lua:409
+msgid "Fetching bookmarks…"
+msgstr "正在抓取書籤······"
+
+#: modules/module_clock.lua:241
+msgid "Fifteen"
+msgstr "十五"
+
+#: modules/module_clock.lua:247
+msgid "Fifty"
+msgstr "五十"
+
+#: features/sui_quickactions.lua:751
+msgid "File Manager not available."
+msgstr "檔案管理器不可用。"
+
+#: features/sui_quickactions.lua:2130
+msgid "File Search"
+msgstr "檔案搜尋"
+
+#: features/sui_style.lua:2355
+msgid "File not found: "
+msgstr "未找到檔案："
+
+#: modules/module_library.lua:217
+msgid "File size (largest)"
+msgstr "檔案大小（最大）"
+
+#: modules/module_library.lua:218
+msgid "File size (smallest)"
+msgstr "檔案大小（最小）"
+
+#: screens/sui_menu.lua:3255
+msgid "Finished Books"
+msgstr "完讀書籍"
+
+#: modules/module_clock.lua:238
+msgid "Five"
+msgstr "五"
+
+#: modules/module_quote.lua:1584
+msgid "Fixed Height"
+msgstr "固定高度"
+
+#: modules/module_reading_stats.lua:856
+#: modules/module_quick_actions.lua:747
+#: screens/sui_menu.lua:4348
+#: screens/sui_quicksettings_bar.lua:1375
+msgid "Flat"
+msgstr "扁平"
+
+#: modules/module_library.lua:293
+msgid "Flat Library"
+msgstr "平面書庫"
+
+#: features/sui_quickactions.lua:2607
+msgid "Folder"
+msgstr "資料夾"
+
+#: screens/sui_menu.lua:2862
+msgid "Folder Cover Type"
+msgstr "資料夾封面類型"
+
+#: features/sui_style.lua:1386
+msgid "Folder Covers"
+msgstr "資料夾封面"
+
+#: features/sui_style.lua:209
+msgid "Folder Covers: Empty Folder"
+msgstr "資料夾封面：空資料夾"
+
+#: screens/sui_menu.lua:3299
+msgid "Folder Name"
+msgstr "資料夾名稱"
+
+#: screens/sui_menu.lua:3408
 msgid "Folder Name Text Size"
 msgstr "資料夾名稱文字大小"
 
-#: sui_foldercovers.lua:349
-#: sui_menu.lua:2015
-msgid "Group Books by Series"
-msgstr "按系列分組書籍"
+#: features/sui_quickactions.lua:2131
+msgid "Folder Shortcuts"
+msgstr "資料夾捷徑"
 
-#: sui_menu.lua:411
+#: features/library/sui_foldercovers.lua:647
+#: features/library/sui_library_browse.lua:366
+#: features/library/sui_series_grouping.lua:87
+#: features/library/sui_group_actions.lua:80
+msgid "Folder cover"
+msgstr "資料夾封面"
+
+#: engines/sui_book_grid.lua:1869
+msgid "Follow Library"
+msgstr "跟隨書庫"
+
+#: engines/sui_window.lua:2233
+#: engines/sui_window.lua:2238
+msgid "Font weight"
+msgstr "字型粗細"
+
+#: modules/module_clock.lua:247
+msgid "Forty"
+msgstr "四十"
+
+#: modules/module_clock.lua:238
+msgid "Four"
+msgstr "四"
+
+#: modules/module_clock.lua:241
+msgid "Fourteen"
+msgstr "十四"
+
+#: modules/module_reading_goals.lua:1059
+#: modules/module_currently.lua:1843
+#: engines/sui_book_grid.lua:1825
+msgid "Frame"
+msgstr "外框"
+
+#: screens/sui_menu.lua:1289
+#: screens/sui_menu.lua:4359
+msgid "Framed"
+msgstr "帶外框"
+
+#: modules/module_reading_stats.lua:935
+#: modules/module_reading_stats.lua:940
+msgid "Freezes"
+msgstr "凍結權"
+
+#: screens/sui_stats_windows.lua:3102
+msgid "Freezes can only cover a single missed day, and only right after an active one. Tap yesterday's cell to use one, when eligible."
+msgstr "凍結權只能補救連續閱讀日後錯過的第一天。符合條件時，點擊昨天的格子即可使用。"
+
+#: screens/sui_stats_windows.lua:2830
+msgid "Fri"
+msgstr "週五"
+
+#: modules/module_clock.lua:58
+msgid "Friday"
+msgstr "星期五"
+
+#: screens/sui_quicksettings_bar.lua:396
+#: screens/sui_quicksettings_bar.lua:418
+msgid "Frontlight"
+msgstr "前光"
+
+#: screens/sui_quicksettings_bar.lua:1270
+msgid "Frontlight Slider"
+msgstr "前光滑桿"
+
+#: features/sui_quickactions.lua:373
+msgid "Frontlight not available on this device."
+msgstr "此裝置不支援前光。"
+
+#: screens/sui_menu.lua:2566
+msgid "Gesture Only"
+msgstr "僅限手勢"
+
+#: screens/sui_menu.lua:4312
+#: screens/sui_menu.lua:4319
+msgid "Global Text Size"
+msgstr "全域文字大小"
+
+#: screens/sui_settings_window.lua:311
+msgid "Global custom actions & icons"
+msgstr "全域性自定義操作與圖示"
+
+#: screens/sui_menu.lua:4320
+msgid "Global scale applied to all of KOReader's interface text — menus, dialogs, titles, and Simple UI. It does not change the book's reading font size, which has its own setting.\n100% is the default size. Useful when a chosen UI font (see UI Font above) renders smaller or larger than usual."
+msgstr "套用到 KOReader 所有介面文字（選單、對話方塊、標題和 Simple UI）的全域縮放。這不會改變內文閱讀字型大小（內文有其獨立設定）。\n預設大小為100%。當選用的介面字型顯示過大或過小時非常實用。"
+
+#: screens/sui_menu.lua:2460
+msgid "Global scale for all modules.\nIndividual overrides in Module Settings take precedence.\n100% is the default size."
+msgstr "所有模組的全域縮放比例。\n模組設定中的個別覆蓋設定優先套用。\n預設大小為100%。"
+
+#: screens/sui_onboarding.lua:165
+msgid "Go to Settings > Home Screen to edit your layout whenever you want."
+msgstr "您可以隨時前往 設定 → 主螢幕 來修改版面配置。"
+
+#: modules/module_reading_goals.lua:817
+#: modules/module_reading_goals.lua:882
+#: modules/module_reading_goals.lua:896
+msgid "Goals"
+msgstr "目標"
+
+#: engines/sui_book_grid.lua:1777
+#: engines/sui_book_grid.lua:1788
+msgid "Grid size"
+msgstr "網格大小"
+
+#: features/sui_quickactions.lua:2262
+#: features/sui_quickactions.lua:2590
+msgid "Group"
+msgstr "群組"
+
+#: screens/sui_menu.lua:2844
+msgid "Group by Book Series"
+msgstr "依叢書系列分組"
+
+#: features/sui_quickactions.lua:2615
+msgid "Group of Quick Actions"
+msgstr "快速動作群組"
+
+#: features/sui_quickactions.lua:2597
+msgid "Group: select actions"
+msgstr "群組：選擇動作"
+
+#: modules/module_currently.lua:1398
+msgid "Grows or shrinks the cover so its height always matches the text column, keeping the cover's proportions.\nThe spacing between cover and text stays as set above.\nThe Cover size setting still applies on top of this, and the cover never shrinks below its 100% size."
+msgstr "根據文字欄高度自動放大或縮小封面，並保持封面比例。\n封面與文字之間的間距保持為上述設定。\n“封面大小”設定仍在此基礎上疊加生效，且封面永遠不會小於其 100% 大小。"
+
+#: screens/sui_menu.lua:1324
+msgid "Height of the bottom navigation bar.\n100% is the default size."
+msgstr "底部導覽欄的高度。\n預設大小為100%。"
+
+#: modules/module_spacer.lua:89
+msgid "Height of the spacer.\n100% is the default size."
+msgstr "間距區塊的高度。\n預設大小為100%。"
+
+#: screens/sui_menu.lua:1044
+msgid "Height of the top status bar.\n100% is the default size."
+msgstr "頂部狀態欄的高度。\n預設大小為100%。"
+
+#: modules/module_collections.lua:1398
+#: screens/sui_menu.lua:486
+#: screens/sui_menu.lua:545
+#: screens/sui_menu.lua:2939
+#: screens/sui_menu.lua:2946
+#: screens/sui_menu.lua:2973
+#: screens/sui_menu.lua:3013
+#: screens/sui_menu.lua:3019
+#: screens/sui_menu.lua:3030
+#: screens/sui_menu.lua:3067
+#: screens/sui_menu.lua:3073
+#: screens/sui_menu.lua:3084
+#: screens/sui_menu.lua:3305
+#: screens/sui_menu.lua:3336
+msgid "Hidden"
+msgstr "隱藏"
+
+#: modules/module_collections.lua:1387
+msgid "Hide Book Spine"
+msgstr "隱藏書脊"
+
+#: screens/sui_menu.lua:3510
+msgid "Hide Folder Book Spine"
+msgstr "隱藏資料夾書脊"
+
+#: modules/module_quick_actions.lua:494
+#: modules/module_quick_actions.lua:653
+#: screens/sui_menu.lua:1989
+#: screens/sui_quicksettings_bar.lua:1303
+msgid "Hide Label"
+msgstr "隱藏標籤"
+
+#: screens/sui_menu.lua:3504
+msgid "Hide Selection Underline"
+msgstr "隱藏選取底線"
+
+#: screens/sui_menu.lua:1086
+msgid "Hide Wi-Fi Icon When Off"
+msgstr "關閉時隱藏 Wi-Fi 圖示"
+
+#: screens/sui_menu.lua:553
+msgid "Hides the pagination bar on the homescreen.\nNot available when Navpager is active."
+msgstr "隱藏主螢幕上的分頁欄。\n當導覽分頁器啟用時不可用。"
+
+#: screens/sui_menu.lua:2619
+msgid "High-Quality Cover"
+msgstr "高畫質封面"
+
+#: screens/sui_stats_windows.lua:1220
+#: screens/sui_stats_windows.lua:3918
+msgid "Highlights"
+msgstr "劃線"
+
+#: features/sui_quickactions.lua:457
+#: features/sui_quickactions.lua:673
+#: features/sui_quickactions.lua:2126
+#: infra/sui_config.lua:120
+msgid "History"
+msgstr "歷史紀錄"
+
+#: features/sui_quickactions.lua:680
+msgid "History not available."
+msgstr "歷史紀錄不可用。"
+
+#: features/sui_quickactions.lua:624
+#: infra/sui_config.lua:118
+msgid "Home"
+msgstr "首頁"
+
+#: engines/sui_screen_engine.lua:1306
+#: infra/sui_patches.lua:1110
+#: infra/sui_patches.lua:1137
+#: screens/sui_menu.lua:4574
+#: screens/sui_settings_window.lua:282
+#: screens/sui_settings_window.lua:1020
+msgid "Home Screen"
+msgstr "主螢幕"
+
+#: screens/sui_settings_window.lua:1036
+msgid "Home Screen Presets"
+msgstr "主螢幕預設檔"
+
+#: screens/sui_menu.lua:499
+msgid "Home Screen Style"
+msgstr "主螢幕樣式"
+
+#: features/sui_style.lua:2090
+msgid "Home Screen — Background"
+msgstr "主螢幕 — 背景"
+
+#: features/sui_style.lua:2093
+msgid "Home Screen — Text"
+msgstr "主螢幕 — 文字"
+
+#: features/sui_quickactions.lua:474
+msgid "Home folder"
+msgstr "主資料夾"
+
+#: features/sui_quickactions.lua:476
+msgid "Home folder + subfolders"
+msgstr "主資料夾 + 子資料夾"
+
+#: features/sui_quickactions.lua:655
+msgid "Homescreen not available."
+msgstr "主螢幕不可用。"
+
+#: modules/module_currently.lua:1365
+msgid "Horizontal space between the cover and the text.\n100% is the default spacing."
+msgstr "封面與文字之間的水平間距。\n預設間距為100%。"
+
+#: modules/module_reading_goals.lua:419
+msgid "Hours per month:"
+msgstr "每月小時數："
+
+#: features/sui_quickactions.lua:2287
+#: features/sui_quickactions.lua:2291
+msgid "Icon"
+msgstr "圖示"
+
+#: screens/sui_menu.lua:3693
+msgid "Icon Packs"
+msgstr "圖示包"
+
+#: screens/sui_menu.lua:3860
+msgid "Icon Presets"
+msgstr "圖示預設檔"
+
+#: screens/sui_menu.lua:1356
+#: screens/sui_menu.lua:1357
+msgid "Icon Size"
+msgstr "圖示尺寸"
+
+#: features/sui_quickactions.lua:2283
+msgid "Icon: Default"
+msgstr "圖示：預設"
+
+#: screens/sui_menu.lua:209
+#: screens/sui_menu.lua:3639
+msgid "Icons"
+msgstr "圖示"
+
+#: screens/sui_menu.lua:210
+msgid "Icons only"
+msgstr "僅圖示"
+
+#: screens/sui_settings_window.lua:304
+msgid "Icons, fonts and appearance"
+msgstr "圖示、字型與外觀"
+
+#: screens/sui_onboarding.lua:169
+msgid "If you selected the Momentum Preset, long press the Reading Goal module to choose and set your reading goals."
+msgstr "若您選擇了「動量」預設檔，請長按閱讀目標模組以選擇並設定您的閱讀目標。"
+
+#: features/sui_presets.lua:998
+#: screens/sui_menu.lua:4201
+msgid "Import preset"
+msgstr "匯入預設檔"
+
+#: screens/sui_menu.lua:3767
+msgid "Install pack from ZIP"
+msgstr "從 ZIP 安裝圖示包"
+
+#: screens/sui_menu.lua:3271
+msgid "Intensity"
+msgstr "強度"
+
+#: screens/sui_menu.lua:1513
+msgid "Invalid arrangement.\nKeep items between the Left and Right separators."
+msgstr "排列無效。\n請將項目保持在左側與右側分隔符號之間。"
+
+#: screens/sui_menu.lua:741
+msgid "Invalid arrangement.\nKeep the Left, Center and Right separators in order."
+msgstr "排列無效。\n請保持左、中、右分隔符號的順序。"
+
+#: features/sui_presets.lua:366
+#: features/sui_presets.lua:546
+msgid "Invalid data"
+msgstr "無效的資料"
+
+#: features/sui_quickactions.lua:2045
+msgid "Invalid input. Please enter 1–6 hexadecimal digits (0–9, A–F)."
+msgstr "輸入無效。請輸入 1–6 位十六進位數字（0–9, A–F）。"
+
+#: features/sui_presets.lua:362
+#: features/sui_presets.lua:542
+msgid "Invalid preset file"
+msgstr "無效的預設檔"
+
+#: screens/sui_menu.lua:2362
+msgid "Invert in Night Mode"
+msgstr "夜間模式下反相"
+
+#: modules/module_reading_stats.lua:718
+#: modules/module_reading_stats.lua:739
+#: modules/module_reading_stats.lua:761
+#: modules/module_coverdeck.lua:1411
+#: modules/module_coverdeck.lua:1451
+#: modules/module_coverdeck.lua:1465
+#: modules/module_currently.lua:1531
+#: modules/module_currently.lua:1536
+#: modules/module_currently.lua:1559
+#: screens/sui_menu.lua:867
+#: screens/sui_menu.lua:872
+#: screens/sui_menu.lua:961
+#: screens/sui_menu.lua:1999
+#: screens/sui_menu.lua:2004
+#: screens/sui_menu.lua:2030
+msgid "Items"
+msgstr "項目"
+
+#: modules/module_clock.lua:61
+#: screens/sui_stats_windows.lua:2840
+msgid "January"
+msgstr "一月"
+
+#: modules/module_clock.lua:62
+#: screens/sui_stats_windows.lua:2841
+msgid "July"
+msgstr "七月"
+
+#: modules/module_clock.lua:62
+#: screens/sui_stats_windows.lua:2841
+msgid "June"
+msgstr "六月"
+
+#: modules/module_quick_actions.lua:762
+msgid "Justified"
+msgstr "兩端對齊"
+
+#: screens/sui_menu.lua:523
 msgid "KOReader"
 msgstr "KOReader"
 
-#: sui_updater.lua:419
-msgid "No automatic update file was found.\n\nOpen the releases page on GitHub?"
-msgstr ""
+#: screens/sui_stats_windows.lua:2744
+msgid "LAST 7 DAYS"
+msgstr "過去 7 天"
 
-#: sui_foldercovers.lua:368
+#: modules/module_quick_actions.lua:670
+#: screens/sui_quicksettings_bar.lua:1292
+msgid "Label"
+msgstr "標籤"
+
+#: screens/sui_menu.lua:2496
+msgid "Label Scale"
+msgstr "標籤縮放"
+
+#: screens/sui_menu.lua:1366
+#: screens/sui_menu.lua:1367
+msgid "Label Size"
+msgstr "標籤尺寸"
+
+#: screens/sui_menu.lua:2480
+msgid "Labels"
+msgstr "標籤"
+
+#: screens/sui_menu.lua:1837
+msgid "Large"
+msgstr "大"
+
+#: infra/sui_updater.lua:459
+#: screens/sui_menu.lua:450
+#: screens/sui_menu.lua:857
+#: screens/sui_menu.lua:1065
+#: screens/sui_menu.lua:1126
+#: screens/sui_menu.lua:1345
+#: screens/sui_menu.lua:1801
+#: screens/sui_menu.lua:3436
+#: screens/sui_menu.lua:3459
+#: screens/sui_menu.lua:3481
+#: screens/sui_menu.lua:4334
+#: screens/sui_menu.lua:4558
+#: screens/sui_quicksettings_bar.lua:1186
+msgid "Later"
+msgstr "稍後"
+
+#: modules/module_reading_goals.lua:1037
+#: modules/module_currently.lua:1384
+msgid "Layout"
+msgstr "版面配置"
+
+#: screens/sui_settings_window.lua:1027
+#: screens/sui_settings_window.lua:1028
+msgid "Layout Editor"
+msgstr "版面編輯器"
+
+#: screens/sui_settings_window.lua:283
+msgid "Layout, wallpaper, presets and behaviour"
+msgstr "佈局、桌布、預設與行為"
+
+#: modules/module_quote.lua:126
+#: modules/module_quote.lua:1563
+#: modules/module_action_list.lua:73
+#: modules/module_action_list.lua:601
+#: modules/module_reading_stats.lua:96
+#: modules/module_reading_stats.lua:882
+#: modules/module_clock.lua:144
+#: modules/module_clock.lua:1034
+#: modules/module_quick_actions.lua:772
+#: screens/sui_menu.lua:710
+#: screens/sui_menu.lua:947
+#: screens/sui_menu.lua:1478
+#: screens/sui_menu.lua:1689
+msgid "Left"
+msgstr "靠左"
+
+#: features/sui_quickactions.lua:597
+#: infra/sui_config.lua:117
+#: infra/sui_config.lua:376
+#: screens/sui_titlebar.lua:1089
+#: screens/sui_menu.lua:4578
+#: screens/sui_settings_window.lua:296
+#: screens/sui_settings_window.lua:1023
+msgid "Library"
+msgstr "藏書"
+
+#: screens/sui_menu.lua:1809
+#: screens/sui_menu.lua:1812
+msgid "Library Buttons"
+msgstr "藏書按鈕"
+
+#: features/sui_presets.lua:182
+msgid "Library View"
+msgstr "藏書檢視"
+
+#: modules/module_collections.lua:1432
+#: engines/sui_book_grid.lua:1871
+#: screens/sui_menu.lua:2987
+#: screens/sui_menu.lua:2999
+#: screens/sui_menu.lua:3041
+#: screens/sui_menu.lua:3053
+#: screens/sui_menu.lua:3095
+#: screens/sui_menu.lua:3107
+#: screens/sui_menu.lua:3162
+#: screens/sui_menu.lua:3174
+#: screens/sui_menu.lua:3229
+#: screens/sui_menu.lua:3241
+#: screens/sui_menu.lua:3383
+#: screens/sui_menu.lua:3388
+msgid "Light"
+msgstr "淺色"
+
+#: screens/sui_menu.lua:2374
+msgid "Lighten"
+msgstr "加亮"
+
+#: screens/sui_menu.lua:2387
+msgid "Lighten Wallpaper"
+msgstr "加亮桌布"
+
+#: modules/module_reading_stats.lua:866
+msgid "List"
+msgstr "清單"
+
+#: screens/sui_stats_windows.lua:2504
+msgid "Loading statistics…"
+msgstr "正在載入統計資料······"
+
+#: screens/sui_menu.lua:2439
+msgid "Lock Scale"
+msgstr "鎖定縮放"
+
+#: infra/sui_config.lua:1106
+msgid "Long Press"
+msgstr "長按"
+
+#: screens/sui_onboarding.lua:160
+msgid "Long press to customize"
+msgstr "長按以自訂"
+
+#: features/sui_presets.lua:345
+#: features/sui_presets.lua:357
+#: features/sui_presets.lua:525
+#: features/sui_presets.lua:537
+msgid "LuaSettings module unavailable"
+msgstr "LuaSettings 模組不可用"
+
+#: screens/sui_onboarding.lua:126
+msgid "Make it yours"
+msgstr "打造您的專屬風格"
+
+#: screens/sui_menu.lua:2706
+msgid "Makes the device's physical Home button always open the SimpleUI Home Screen — while reading and while browsing files — instead of KOReader's native Home behaviour."
+msgstr "讓裝置的實體 Home 鍵無論在閱讀或瀏覽檔案時，都一律開啟 Simple UI 主螢幕，而非 KOReader 原生的 Home 鍵行為。"
+
+#: features/sui_presets.lua:823
+#: features/sui_presets.lua:899
+#: features/sui_presets.lua:904
+#: screens/sui_menu.lua:4029
+#: screens/sui_menu.lua:4103
+#: screens/sui_menu.lua:4108
+msgid "Manage presets"
+msgstr "管理預設檔"
+
+#: modules/module_collections.lua:534
+msgid "Manual order"
+msgstr "手動排序"
+
+#: modules/module_reading_goals.lua:1027
+msgid "Manually Tracked Books"
+msgstr "手動追蹤的書籍"
+
+#: modules/module_reading_goals.lua:1015
+msgid "Manually Tracked Books  (%s)"
+msgstr "手動追蹤的書籍（%s）"
+
+#: modules/module_clock.lua:61
+#: screens/sui_stats_windows.lua:2840
+msgid "March"
+msgstr "三月"
+
+#: screens/sui_quicksettings_bar.lua:443
+#: screens/sui_quicksettings_bar.lua:549
+msgid "Max"
+msgstr "最大"
+
+#: screens/sui_quicksettings_bar.lua:1248
+msgid "Maximum slots reached."
+msgstr "已達最多欄位限制。"
+
+#: modules/module_clock.lua:62
+#: screens/sui_stats_windows.lua:2841
+msgid "May"
+msgstr "五月"
+
+#: screens/sui_titlebar.lua:102
+#: screens/sui_titlebar.lua:107
+msgid "Menu"
+msgstr "選單"
+
+#: features/sui_style.lua:88
+msgid "Menu Button"
+msgstr "選單按鈕"
+
+#: modules/module_clock.lua:295
+msgid "Midnight"
+msgstr "午夜"
+
+#: features/sui_presets.lua:149
+msgid "Mindful Reading"
+msgstr "專注閱讀"
+
+#: screens/sui_menu.lua:374
+msgid "Minimum 1 tab required in navpager mode."
+msgstr "導覽分頁器模式下至少需要 1 個分頁。"
+
+#: screens/sui_menu.lua:375
+msgid "Minimum 2 tabs required. Select another tab first."
+msgstr "至少需要 2 個分頁。請先選擇另一個分頁。"
+
+#: modules/module_reading_goals.lua:431
+msgid "Minutes per day:"
+msgstr "每日分鐘數："
+
+#: screens/sui_menu.lua:462
+msgid "Mode"
+msgstr "模式"
+
+#: screens/sui_menu.lua:2457
+msgid "Module Scale"
+msgstr "模組縮放"
+
+#: infra/sui_config.lua:1103
+#: screens/sui_menu.lua:2203
+msgid "Module Settings"
+msgstr "模組設定"
+
+#: screens/sui_menu.lua:3697
+msgid "Module unavailable"
+msgstr "模組不可用"
+
+#: screens/sui_menu.lua:2450
+#: screens/sui_menu.lua:2725
+msgid "Modules"
+msgstr "模組"
+
+#: screens/sui_menu.lua:2191
+msgid "Modules  (%d)"
+msgstr "模組（%d）"
+
+#: engines/sui_screen_engine.lua:2745
+msgid "Modules exceed the visible area.\nMove some to another page or adjust the scale."
+msgstr "模組已超出可見區域。\n請將部分模組移動至其他頁面或調整縮放比例。"
+
+#: features/sui_presets.lua:164
+msgid "Momentum"
+msgstr "動量"
+
+#: screens/sui_stats_windows.lua:2830
+msgid "Mon"
+msgstr "週一"
+
+#: modules/module_clock.lua:57
+msgid "Monday"
+msgstr "星期一"
+
+#: modules/module_reading_goals.lua:840
+#: modules/module_reading_goals.lua:887
+#: modules/module_reading_goals.lua:924
+#: modules/module_reading_goals.lua:955
+msgid "Monthly Goal"
+msgstr "每月目標"
+
+#: modules/module_reading_goals.lua:418
+msgid "Monthly Reading Goal"
+msgstr "每月閱讀目標"
+
+#: main.lua:1088
+msgid "More by %s (%d)"
+msgstr "%s 的更多作品（%d）"
+
+#: engines/sui_window.lua:2812
+msgid "Move down"
+msgstr "下移"
+
+#: engines/sui_window.lua:2806
+#: screens/sui_settings_window.lua:662
+#: screens/sui_settings_window.lua:698
+msgid "Move to page"
+msgstr "移動至頁面"
+
+#: engines/sui_window.lua:2809
+msgid "Move up"
+msgstr "上移"
+
+#: features/sui_quickactions.lua:22
+msgid "My Action"
+msgstr "我的動作"
+
+#: modules/module_quote.lua:1412
+msgid "My Highlights"
+msgstr "我的劃線"
+
+#: features/sui_presets.lua:713
+#: features/sui_presets.lua:718
+msgid "My Presets"
+msgstr "我的預設檔"
+
+#: features/sui_quickactions.lua:2378
+msgid "Name"
+msgstr "名稱"
+
+#: modules/module_collections.lua:535
+msgid "Name (A–Z)"
+msgstr "名稱（A–Z）"
+
+#: modules/module_collections.lua:536
+msgid "Name (Z–A)"
+msgstr "名稱（Z–A）"
+
+#: screens/sui_menu.lua:3123
+#: screens/sui_menu.lua:3132
+#: screens/sui_menu.lua:3144
+#: features/library/sui_foldercovers.lua:314
+msgid "Native"
+msgstr "原生"
+
+#: screens/sui_menu.lua:2761
+#: screens/sui_bottombar.lua:890
+msgid "Navigation Bar"
+msgstr "導覽欄"
+
+#: screens/sui_menu.lua:1323
+msgid "Navigation Bar Size"
+msgstr "導覽欄尺寸"
+
+#: screens/sui_menu.lua:1125
+msgid "Navigation Bar will be %s after restart.\n\nRestart now?"
+msgstr "重啟後導覽欄將改為 %s。\n\n要立即重新啟動嗎？"
+
+#: features/sui_style.lua:2091
+msgid "Navigation Bar — Background"
+msgstr "導航欄 — 背景"
+
+#: features/sui_style.lua:2094
+msgid "Navigation Bar — Text and Icons"
+msgstr "導航欄 — 文字與圖示"
+
+#: features/sui_style.lua:1385
+#: screens/sui_menu.lua:475
+msgid "Navpager"
+msgstr "導覽分頁器"
+
+#: screens/sui_menu.lua:482
+msgid "Navpager enabled.\n\nRestart now?"
+msgstr "導覽分頁器已啟用。\n\n要立即重新啟動嗎？"
+
+#: features/sui_style.lua:168
+msgid "Navpager: Next"
+msgstr "導覽分頁器：下一頁"
+
+#: features/sui_style.lua:162
+msgid "Navpager: Previous"
+msgstr "導覽分頁器：上一頁"
+
+#: features/sui_quickactions.lua:2007
+msgid "Nerd Font Icon"
+msgstr "Nerd Font 圖示"
+
+#: features/sui_quickactions.lua:2078
+msgid "Nerd Font symbol…"
+msgstr "Nerd Font 符號······"
+
+#: features/sui_quickactions.lua:236
+msgid "Network manager unavailable."
+msgstr "網路管理員不可用。"
+
+#: screens/sui_menu.lua:2577
+msgid "Never"
+msgstr "永不"
+
+#: modules/module_new_books.lua:138
+#: engines/sui_book_grid.lua:535
+#: features/library/sui_foldercovers.lua:1263
+#: features/library/sui_foldercovers.lua:1911
+#: features/library/sui_cover_widgets.lua:421
+msgid "New"
+msgstr "新"
+
+#: engines/sui_book_grid.lua:2026
+msgid "New Badge Color"
+msgstr "新徽章顏色"
+
+#: screens/sui_menu.lua:3186
+msgid "New Book"
+msgstr "新書"
+
+#: engines/sui_book_grid.lua:2018
+#: engines/sui_book_grid.lua:2031
+msgid "New Book Badge"
+msgstr "新書徽章"
+
+#: modules/module_new_books.lua:83
+#: modules/module_new_books.lua:84
+msgid "New Books"
+msgstr "新進書籍"
+
+#: features/sui_quickactions.lua:2251
+msgid "New Quick Action"
+msgstr "新增快速動作"
+
+#: features/library/sui_group_actions.lua:105
+msgid "New collection name"
+msgstr "新收藏名稱"
+
+#: screens/sui_bottombar.lua:569
+msgid "Next"
+msgstr "下一頁"
+
+#: features/sui_quickactions.lua:826
+#: infra/sui_config.lua:128
+msgid "Night Mode"
+msgstr "夜間模式"
+
+#: modules/module_clock.lua:239
+msgid "Nine"
+msgstr "九"
+
+#: modules/module_clock.lua:243
+msgid "Nineteen"
+msgstr "十九"
+
+#: screens/sui_stats_windows.lua:1227
+msgid "No"
+msgstr "否"
+
+#: modules/module_quote.lua:1469
+#: modules/module_quote.lua:1518
+msgid "No .lua files found in sui_quotes/"
+msgstr "在 sui_quotes/ 中未找到 .lua 檔案"
+
+#: screens/sui_menu.lua:3785
+msgid "No .zip files found.\nPlace .zip files in:\n%1"
+msgstr "未找到 .zip 檔案。\n請將 .zip 檔案放至：\n%1"
+
+#: screens/sui_quicksettings_bar.lua:1204
+#: screens/sui_quicksettings_bar.lua:1224
+msgid "No actions active yet."
+msgstr "尚無啟用的動作。"
+
+#: modules/module_action_list.lua:108
+#: modules/module_action_list.lua:135
+#: modules/module_quick_actions.lua:166
+#: features/sui_quickactions.lua:1556
+#: screens/sui_settings_window.lua:615
+msgid "No actions configured"
+msgstr "未設定任何動作"
+
+#: modules/module_action_list.lua:107
+#: modules/module_action_list.lua:134
+#: modules/module_quick_actions.lua:165
+msgid "No actions configured  —  long press to configure"
+msgstr "未設定任何動作 — 長按以設定"
+
+#: screens/sui_quicksettings_bar.lua:355
+msgid "No actions configured.\nGo to Bars → Quick Settings Bar."
+msgstr "未設定任何動作。\n請前往 功能欄 → 快速設定欄。"
+
+#: features/sui_quickactions.lua:706
+msgid "No book in history."
+msgstr "歷史紀錄中沒有書籍。"
+
+#: screens/sui_stats_windows.lua:791
+msgid "No books finished in %s"
+msgstr "%s 沒有讀完的書籍"
+
+#: features/library/sui_foldercovers.lua:651
+msgid "No books found in this folder."
+msgstr "此資料夾中未找到書籍。"
+
+#: features/library/sui_series_grouping.lua:91
+#: features/library/sui_series_grouping.lua:104
 msgid "No books found in this series."
-msgstr "未在此系列中找到書籍。"
+msgstr "此系列中未找到書籍。"
 
-#: desktop_modules/module_tbr.lua:246
+#: features/library/sui_library_browse.lua:370
+#: features/library/sui_library_browse.lua:392
+#: features/library/sui_group_actions.lua:38
+#: features/library/sui_group_actions.lua:96
+msgid "No books found."
+msgstr "未找到書籍。"
+
+#: modules/module_tbr.lua:367
+#: modules/module_tbr.lua:392
+#: modules/module_tbr.lua:467
 msgid "No books in To Be Read list."
-msgstr "待讀清單中暫無書籍。"
+msgstr "待讀清單中沒有書籍。"
 
-#: desktop_modules/module_tbr.lua:265
+#: modules/module_feat_coll.lua:260
+#: modules/module_feat_coll.lua:284
+#: modules/module_feat_coll.lua:353
+msgid "No books in this collection."
+msgstr "此收藏中沒有書籍。"
+
+#: engines/sui_screen_engine.lua:391
+msgid "No books opened yet"
+msgstr "尚未開啟任何書籍"
+
+#: modules/module_feat_coll.lua:410
+#: screens/sui_settings_window.lua:627
+msgid "No collection selected"
+msgstr "未選擇收藏"
+
+#: modules/module_feat_coll.lua:409
+msgid "No collection selected  —  long press to configure"
+msgstr "未選擇收藏 — 長按以設定"
+
+#: modules/module_coverdeck.lua:1216
+msgid "No collections found"
+msgstr "未找到收藏"
+
+#: modules/module_collections.lua:1456
+#: modules/module_feat_coll.lua:136
+msgid "No collections found."
+msgstr "未找到收藏。"
+
+#: modules/module_collections.lua:1541
+msgid "No collections selected"
+msgstr "未選擇收藏"
+
+#: modules/module_collections.lua:1540
+msgid "No collections selected  —  long press to configure"
+msgstr "未選擇收藏 — 長按以設定"
+
+#: modules/module_quote.lua:929
+msgid "No custom quotes found. Add a .lua file to the plugin's sui_quotes/ folder and select it in Settings."
+msgstr "未找到自訂佳句。請將 .lua 檔案新增至外掛程式的 sui_quotes/ 資料夾，並於設定中選取它。"
+
+#: screens/sui_settings_window.lua:400
+msgid "No custom screens yet."
+msgstr "暫無自定義螢幕。"
+
+#: infra/sui_updater.lua:508
+msgid "No download file found.\n\nOpen the releases page?"
+msgstr "未找到下載檔案。\n\n要開啟發行頁面嗎？"
+
+#: features/sui_presets.lua:337
+#: features/sui_presets.lua:517
+msgid "No export directory"
+msgstr "無匯出目錄"
+
+#: screens/sui_stats_windows.lua:159
+msgid "No filepath."
+msgstr "無檔案路徑。"
+
+#: features/sui_quickactions.lua:3068
+msgid "No folder, collection or plugin configured.\nGo to Simple UI → Settings → Quick Actions to set one."
+msgstr "未設定資料夾、收藏或外掛程式。\n請前往 Simple UI → 設定 → 快速動作 進行設定。"
+
+#: features/sui_style.lua:1797
+msgid "No fonts found."
+msgstr "未找到字型。"
+
+#: modules/module_quote.lua:1001
+msgid "No highlights found. Open a book and highlight some passages."
+msgstr "未找到劃線。請開啟書籍並劃線劃重點。"
+
+#: features/sui_quickactions.lua:2091
+msgid "No icons found in:"
+msgstr "未在此處找到圖示："
+
+#: engines/sui_window.lua:2506
+#: engines/sui_window.lua:3111
+msgid "No items available."
+msgstr "沒有可用項目。"
+
+#: modules/module_collections.lua:1228
+#: modules/module_collections.lua:1246
+#: modules/module_action_list.lua:483
+#: modules/module_action_list.lua:508
+#: modules/module_reading_stats.lua:742
+#: modules/module_reading_stats.lua:763
+#: modules/module_reading_goals.lua:890
+#: modules/module_reading_goals.lua:897
+#: modules/module_coverdeck.lua:1459
+#: modules/module_coverdeck.lua:1467
+#: modules/module_currently.lua:1553
+#: modules/module_currently.lua:1637
+#: modules/module_currently.lua:1769
+#: modules/module_currently.lua:1812
+#: modules/module_quick_actions.lua:512
+#: modules/module_quick_actions.lua:537
+#: engines/sui_window.lua:3021
+#: screens/sui_menu.lua:885
+#: screens/sui_menu.lua:963
+#: screens/sui_menu.lua:1152
+#: screens/sui_menu.lua:1203
+#: screens/sui_menu.lua:1598
+#: screens/sui_menu.lua:1705
+#: screens/sui_menu.lua:2007
+#: screens/sui_menu.lua:2032
+msgid "No items selected."
+msgstr "未選取任何項目。"
+
+#: screens/sui_settings_window.lua:534
+#: screens/sui_settings_window.lua:709
+msgid "No modules"
+msgstr "無模組"
+
+#: screens/sui_settings_window.lua:695
+msgid "No other pages available."
+msgstr "沒有其他可用頁面。"
+
+#: screens/sui_menu.lua:3821
+msgid "No packs found."
+msgstr "未找到圖示包。"
+
+#: features/sui_quickactions.lua:2473
+msgid "No plugins found."
+msgstr "未找到外掛程式。"
+
+#: features/sui_presets.lua:1005
+#: screens/sui_menu.lua:4209
+msgid "No preset files found.\nPlace .lua files in:\n%1"
+msgstr "未找到預設檔。\n請將 .lua 檔案放至：\n%1"
+
+#: features/sui_presets.lua:982
+#: screens/sui_menu.lua:4185
+msgid "No presets found."
+msgstr "未找到預設檔。"
+
+#: modules/module_quote.lua:963
+msgid "No quotes found."
+msgstr "未找到佳句。"
+
+#: features/sui_quickactions.lua:3389
+msgid "No recent books."
+msgstr "沒有近期書籍。"
+
+#: screens/sui_stats_windows.lua:168
+#: screens/sui_stats_windows.lua:203
+#: screens/sui_stats_windows.lua:3598
+msgid "No statistics found for this book."
+msgstr "未找到這本書的統計數據。"
+
+#: modules/module_coverdeck.lua:1336
+msgid "No statistics selected."
+msgstr "未選擇統計項目。"
+
+#: modules/module_reading_stats.lua:467
+msgid "No stats selected"
+msgstr "未選擇統計項目"
+
+#: modules/module_reading_stats.lua:466
+msgid "No stats selected  —  long press to configure"
+msgstr "未選擇統計項目 — 長按以設定"
+
+#: features/sui_quickactions.lua:2499
+msgid "No system actions found."
+msgstr "未找到系統動作。"
+
+#: screens/sui_menu.lua:2275
+msgid "No wallpapers found."
+msgstr "未找到桌布。"
+
+#: engines/sui_book_grid.lua:1894
+#: engines/sui_book_grid.lua:2012
+#: features/sui_quickactions.lua:2371
+#: screens/sui_menu.lua:3124
+#: screens/sui_menu.lua:3133
+#: screens/sui_menu.lua:3151
+#: screens/sui_menu.lua:3191
+#: screens/sui_menu.lua:3200
+#: screens/sui_menu.lua:3218
+#: features/library/sui_foldercovers.lua:319
+msgid "None"
+msgstr "無"
+
+#: modules/module_clock.lua:298
+msgid "Noon"
+msgstr "中午"
+
+#: modules/module_reading_goals.lua:938
+#: modules/module_reading_goals.lua:953
+#: modules/module_reading_goals.lua:968
+msgid "Not set"
+msgstr "未設定"
+
+#: screens/sui_stats_windows.lua:1221
+#: screens/sui_stats_windows.lua:3919
+msgid "Notes"
+msgstr "筆記"
+
+#: modules/module_clock.lua:63
+#: screens/sui_stats_windows.lua:2842
+msgid "November"
+msgstr "十一月"
+
+#: engines/sui_book_grid.lua:1761
+#: engines/sui_book_grid.lua:1762
+msgid "Number of Books"
+msgstr "圖書數量"
+
+#: screens/sui_menu.lua:2937
+msgid "Number of Books in Folder"
+msgstr "資料夾中的書籍數量"
+
+#: screens/sui_menu.lua:3011
+msgid "Number of Pages"
+msgstr "頁數"
+
+#: modules/module_clock.lua:316
+msgid "O'Clock"
+msgstr "點鐘"
+
+#: features/sui_quickactions.lua:2020
+msgid "OK"
+msgstr "確定"
+
+#: modules/module_clock.lua:63
+#: screens/sui_stats_windows.lua:2842
+msgid "October"
+msgstr "十月"
+
+#: engines/sui_book_grid.lua:1979
+#: engines/sui_book_grid.lua:2005
+#: features/sui_quickactions.lua:1655
+#: features/sui_quickactions.lua:2755
+#: screens/sui_menu.lua:1442
+#: screens/sui_menu.lua:1656
+#: screens/sui_menu.lua:3257
+#: screens/sui_menu.lua:3422
+#: screens/sui_menu.lua:4540
+msgid "Off"
+msgstr "關閉"
+
+#: modules/module_clock.lua:261
+msgid "Oh"
+msgstr "零"
+
+#: engines/sui_book_grid.lua:1979
+#: engines/sui_book_grid.lua:2005
+#: features/sui_quickactions.lua:1654
+#: features/sui_quickactions.lua:2754
+#: screens/sui_menu.lua:1442
+#: screens/sui_menu.lua:1656
+#: screens/sui_menu.lua:4540
+msgid "On"
+msgstr "開啟"
+
+#: modules/module_clock.lua:237
+msgid "One"
+msgstr "一"
+
+#: modules/module_quote.lua:1304
+#: engines/sui_screen_engine.lua:741
+#: features/sui_quickactions.lua:3344
+#: screens/sui_stats_windows.lua:775
+msgid "Open"
+msgstr "開啟"
+
+#: modules/module_collections.lua:1111
+msgid "Open Module Settings"
+msgstr "開啟模組設定"
+
+#: engines/sui_screen_engine.lua:400
+msgid "Open a book to get started"
+msgstr "開啟一本書即可開始"
+
+#: infra/sui_updater.lua:509
+msgid "Open in browser"
+msgstr "在瀏覽器中開啟"
+
+#: features/library/sui_book_hold_dialog.lua:517
+msgid "Open module settings"
+msgstr "開啟模組設定"
+
+#: modules/module_quote.lua:1303
+#: engines/sui_screen_engine.lua:740
+#: features/sui_quickactions.lua:3343
+#: screens/sui_stats_windows.lua:773
+msgid "Open this file?"
+msgstr "要開啟此檔案嗎？"
+
+#: features/library/sui_book_hold_dialog.lua:387
+msgid "Open with…"
+msgstr "開啟方式······"
+
+#: screens/sui_menu.lua:2657
+msgid "Overflow Warning"
+msgstr "溢出警告"
+
+#: screens/sui_menu.lua:2901
+msgid "Overlays"
+msgstr "重疊圖層"
+
+#: features/sui_presets.lua:804
+#: features/sui_presets.lua:834
+#: features/sui_presets.lua:966
+#: screens/sui_menu.lua:4011
+#: screens/sui_menu.lua:4040
+#: screens/sui_menu.lua:4169
+msgid "Overwrite"
+msgstr "覆蓋"
+
+#: features/sui_presets.lua:833
+#: features/sui_presets.lua:965
+msgid "Overwrite preset \"%s\" with the current homescreen settings?"
+msgstr "要以目前的主螢幕設定覆蓋預設檔「%s」嗎？"
+
+#: screens/sui_menu.lua:4039
+#: screens/sui_menu.lua:4168
+msgid "Overwrite preset \"%s\" with the current icon settings?"
+msgstr "要以目前的圖示設定覆蓋預設檔「%s」嗎？"
+
+#: screens/sui_menu.lua:3837
+msgid "Pack \"%s\" applied.\n%d icons replaced."
+msgstr "已套用圖示包「%s」。\n已替換 %d 個圖示。"
+
+#: screens/sui_menu.lua:3798
+msgid "Pack \"%s\" installed.\nYou can now apply it from the list."
+msgstr "已安裝圖示包「%s」。\n您現在可以從清單中套用它。"
+
+#: features/sui_style.lua:2413
+msgid "Pack folder not accessible: "
+msgstr "無法存取圖示包資料夾："
+
+#: engines/sui_screen_engine.lua:1970
+#: engines/sui_window.lua:1406
+#: infra/sui_patches.lua:2232
+#: infra/sui_patches.lua:2805
+msgid "Page %1 of %2"
+msgstr "第 %1 頁，共 %2 頁"
+
+#: screens/sui_settings_window.lua:508
+#: screens/sui_settings_window.lua:671
+#: screens/sui_settings_window.lua:1042
+msgid "Page %d"
+msgstr "第 %d 頁"
+
+#: screens/sui_settings_window.lua:507
+#: screens/sui_settings_window.lua:670
+#: screens/sui_settings_window.lua:1041
+msgid "Page 1 (Home)"
+msgstr "第 1 頁（首頁）"
+
+#: screens/sui_stats_windows.lua:957
+#: screens/sui_stats_windows.lua:3684
+msgid "Pages"
+msgstr "頁數"
+
+#: engines/sui_book_grid.lua:1961
+#: engines/sui_book_grid.lua:1977
+msgid "Pages Badge"
+msgstr "頁數徽章"
+
+#: engines/sui_book_grid.lua:1972
+msgid "Pages Badge Color"
+msgstr "頁數徽章顏色"
+
+#: screens/sui_stats_windows.lua:2422
+msgid "Pages per day"
+msgstr "每日頁數"
+
+#: screens/sui_stats_windows.lua:2439
+#: screens/sui_stats_windows.lua:2455
+msgid "Pages read"
+msgstr "已讀頁數"
+
+#: features/sui_style.lua:1384
+#: screens/sui_menu.lua:2763
+msgid "Pagination Bar"
+msgstr "分頁欄"
+
+#: screens/sui_menu.lua:492
+msgid "Pagination bar hidden.\n\nRestart now?"
+msgstr "分頁欄已隱藏。\n\n要立即重新啟動嗎？"
+
+#: screens/sui_menu.lua:471
+msgid "Pagination bar set to Default.\n\nRestart now?"
+msgstr "分頁欄已設為預設。\n\n要立即重新啟動嗎？"
+
+#: screens/sui_menu.lua:578
+#: screens/sui_menu.lua:590
+#: screens/sui_menu.lua:602
+msgid "Pagination bar size will change after restart.\n\nRestart now?"
+msgstr "分頁欄尺寸將在重啟後變更。\n\n要立即重新啟動嗎？"
+
+#: features/sui_style.lua:149
+msgid "Pagination: First Page"
+msgstr "分頁：第一頁"
+
+#: features/sui_style.lua:155
+msgid "Pagination: Last Page"
+msgstr "分頁：最後一頁"
+
+#: features/sui_style.lua:143
+msgid "Pagination: Next Page"
+msgstr "分頁：下一頁"
+
+#: features/sui_style.lua:137
+msgid "Pagination: Previous Page"
+msgstr "分頁：上一頁"
+
+#: features/sui_quickactions.lua:2427
+msgid "Path chooser not available."
+msgstr "路徑選擇器不可用。"
+
+#: features/sui_style.lua:2402
+msgid "Path does not exist: "
+msgstr "路徑不存在："
+
+#: modules/module_coverdeck.lua:163
+#: modules/module_currently.lua:286
+#: modules/module_currently.lua:1512
+msgid "Percentage read"
+msgstr "閱讀百分比"
+
+#: modules/module_reading_goals.lua:407
+msgid "Physical Books — %s"
+msgstr "實體書 — %s"
+
+#: modules/module_reading_goals.lua:408
+msgid "Physical books read this year:"
+msgstr "今年閱讀的實體書數量："
+
+#: modules/module_quote.lua:1494
+#: modules/module_quote.lua:1543
+msgid "Place .lua files in the plugin's sui_quotes/ folder"
+msgstr "請將 .lua 檔案放至外掛程式的 sui_quotes/ 資料夾"
+
+#: screens/sui_menu.lua:3822
+msgid "Place a folder or .zip in:"
+msgstr "請將資料夾或 .zip 放至："
+
+#: screens/sui_menu.lua:2277
+msgid "Place images in:"
+msgstr "請將圖片放至："
+
+#: screens/sui_onboarding.lua:173
+msgid "Place your files in koreader/settings/simpleui/sui_wallpapers or sui_icons."
+msgstr "請將您的檔案放至 koreader/settings/simpleui/sui_wallpapers 或 sui_icons。"
+
+#: screens/sui_menu.lua:3520
+msgid "Placeholder Cover for Bookless Folders"
+msgstr "無書籍資料夾的預設佔位封面"
+
+#: screens/sui_stats_windows.lua:670
+msgid "Please enter a date in YYYY-MM-DD format."
+msgstr "請輸入 YYYY-MM-DD 格式的日期。"
+
+#: features/sui_presets.lua:778
+#: screens/sui_menu.lua:3990
+msgid "Please enter a name for the preset."
+msgstr "請輸入預設檔的名稱。"
+
+#: features/sui_quickactions.lua:2398
+msgid "Please select an action."
+msgstr "請選擇一個動作。"
+
+#: features/sui_quickactions.lua:2492
+#: features/sui_quickactions.lua:2611
+msgid "Plugin"
+msgstr "外掛程式"
+
+#: features/sui_quickactions.lua:3014
+msgid "Plugin error: %s"
+msgstr "外掛程式錯誤：%s"
+
+#: features/sui_quickactions.lua:3016
+msgid "Plugin not available: %s"
+msgstr "外掛程式不可用：%s"
+
+#: screens/sui_menu.lua:2705
+msgid "PocketBook Home Button Opens Home Screen"
+msgstr "PocketBook Home 鍵開啟主螢幕"
+
+#: screens/sui_menu.lua:2944
+#: screens/sui_menu.lua:3348
+msgid "Position"
+msgstr "位置"
+
+#: features/sui_quickactions.lua:856
+#: infra/sui_config.lua:130
+msgid "Power"
+msgstr "電源"
+
+#: screens/sui_menu.lua:2631
+msgid "Preserve Cover Proportions"
+msgstr "保持封面比例"
+
+#: screens/sui_menu.lua:2682
+msgid "Preserve Deleted Books in Statistics"
+msgstr "在統計數據中保留已刪除的書籍"
+
+#: features/sui_presets.lua:1019
+#: screens/sui_menu.lua:4221
+msgid "Preset \"%s\" imported."
+msgstr "已匯入預設檔「%s」。"
+
+#: features/sui_presets.lua:660
+#: features/sui_presets.lua:738
+#: screens/sui_menu.lua:3950
+msgid "Preset \"%s\" not found."
+msgstr "未找到預設檔「%s」。"
+
+#: features/sui_presets.lua:795
+#: screens/sui_menu.lua:4000
+msgid "Preset \"%s\" saved."
+msgstr "已儲存預設檔「%s」。"
+
+#: features/sui_presets.lua:840
+#: features/sui_presets.lua:972
+#: screens/sui_menu.lua:4046
+#: screens/sui_menu.lua:4175
+msgid "Preset \"%s\" updated."
+msgstr "已更新預設檔「%s」。"
+
+#: features/sui_presets.lua:1052
+#: screens/sui_menu.lua:4257
+msgid "Preset exported to:\n%s"
+msgstr "預設檔已匯出至：\n%s"
+
+#: features/sui_presets.lua:763
+#: screens/sui_menu.lua:3975
+msgid "Preset name"
+msgstr "預設檔名稱"
+
+#: features/sui_presets.lua:339
+#: features/sui_presets.lua:519
+msgid "Preset not found"
+msgstr "未找到預設檔"
+
+#: screens/sui_menu.lua:2735
+#: screens/sui_settings_window.lua:367
+msgid "Presets"
+msgstr "預設檔"
+
+#: screens/sui_settings_window.lua:852
+msgid "Presets module unavailable."
+msgstr "預設檔模組不可用。"
+
+#: screens/sui_onboarding.lua:161
+msgid "Press and hold any element on the screen (like modules or bars) to quickly customize its settings."
+msgstr "長按螢幕上的任何元素（如模組或功能欄）即可快速自訂其設定。"
+
+#: screens/sui_bottombar.lua:569
+msgid "Prev"
+msgstr "上一頁"
+
+#: screens/sui_menu.lua:3119
+msgid "Progress"
+msgstr "進度"
+
+#: engines/sui_book_grid.lua:1920
+msgid "Progress Badge Color"
+msgstr "進度徽章顏色"
+
+#: screens/sui_menu.lua:4345
+msgid "Progress Bar Type"
+msgstr "進度條類型"
+
+#: engines/sui_book_grid.lua:1925
+msgid "Progress Indicator"
+msgstr "進度指示器"
+
+#: engines/sui_book_grid.lua:1912
+msgid "Progress Style"
+msgstr "進度樣式"
+
+#: engines/sui_book_grid.lua:2045
+msgid "Progress and Badges"
+msgstr "進度與徽章"
+
+#: modules/module_currently.lua:1864
+msgid "Progress and Stats"
+msgstr "進度與統計"
+
+#: modules/module_coverdeck.lua:177
+#: modules/module_currently.lua:285
+msgid "Progress bar"
+msgstr "進度條"
+
+#: modules/module_currently.lua:1867
+msgid "Progress bar style"
+msgstr "進度條樣式"
+
+#: modules/module_action_list.lua:475
+#: modules/module_action_list.lua:480
+#: modules/module_action_list.lua:506
+#: modules/module_quick_actions.lua:504
+#: modules/module_quick_actions.lua:509
+#: modules/module_quick_actions.lua:535
+#: modules/module_quick_actions.lua:652
+#: features/sui_quickactions.lua:1461
+#: features/sui_quickactions.lua:3287
+#: screens/sui_menu.lua:2180
+#: screens/sui_menu.lua:4595
+#: screens/sui_quicksettings_bar.lua:1196
+#: screens/sui_quicksettings_bar.lua:1201
+#: screens/sui_quicksettings_bar.lua:1222
+#: screens/sui_settings_window.lua:310
+msgid "Quick Actions"
+msgstr "快速動作"
+
+#: screens/sui_menu.lua:4599
+msgid "Quick Actions  (%d/%d — %d left)"
+msgstr "快速動作（%d/%d — 剩餘 %d 個）"
+
+#: screens/sui_menu.lua:4597
+msgid "Quick Actions  (%d/%d — at limit)"
+msgstr "快速動作（%d/%d — 已達上限）"
+
+#: features/sui_quickactions.lua:1443
+#: features/sui_quickactions.lua:1858
+#: screens/sui_menu.lua:3676
+msgid "Quick Actions Icons"
+msgstr "快速動作圖示"
+
+#: modules/module_quick_actions.lua:352
+#: modules/module_quick_actions.lua:408
+#: modules/module_quick_actions.lua:806
+#: screens/sui_menu.lua:1932
+msgid "Quick Actions Row"
+msgstr "快速動作列"
+
+#: screens/sui_menu.lua:2765
+#: screens/sui_quicksettings_bar.lua:1049
+msgid "Quick Settings Bar"
+msgstr "快速設定欄"
+
+#: screens/sui_onboarding.lua:235
+#: screens/sui_onboarding.lua:236
+msgid "Quick Tips"
+msgstr "快速提示"
+
+#: engines/sui_window.lua:2266
+msgid "Quick toggles"
+msgstr "快速開關"
+
+#: features/sui_quickactions.lua:539
+msgid "Quit"
+msgstr "離開"
+
+#: modules/module_quote.lua:1118
+#: features/sui_presets.lua:150
+msgid "Quote of the Day"
+msgstr "每日佳句"
+
+#: modules/module_quote.lua:1434
+msgid "Quotes + My Highlights"
+msgstr "佳句 + 我的劃線"
+
+#: infra/sui_config.lua:172
+msgid "RAM Usage"
+msgstr "記憶體使用量"
+
+#: modules/module_library.lua:219
+#: features/sui_quickactions.lua:712
+#: infra/sui_config.lua:123
+msgid "Random"
+msgstr "隨機"
+
+#: modules/module_reading_goals.lua:525
+#: modules/module_reading_goals.lua:526
+#: modules/module_reading_goals.lua:552
+#: modules/module_reading_goals.lua:1057
+#: features/sui_presets.lua:165
+msgid "Reading Goals"
+msgstr "閱讀目標"
+
+#: screens/sui_stats_windows.lua:2758
+msgid "Reading Insights"
+msgstr "閱讀洞察"
+
+#: modules/module_reading_stats.lua:350
+#: features/sui_presets.lua:165
+msgid "Reading Stats"
+msgstr "閱讀統計"
+
+#: modules/module_reading_stats.lua:936
+#: modules/module_reading_stats.lua:950
+msgid "Real streak only"
+msgstr "僅真實連續"
+
+#: features/sui_quickactions.lua:527
+msgid "Reboot"
+msgstr "重新啟動"
+
+#: features/sui_quickactions.lua:685
+#: features/sui_quickactions.lua:3450
+#: infra/sui_config.lua:121
+msgid "Recent"
+msgstr "近期"
+
+#: modules/module_recent.lua:15
+#: modules/module_recent.lua:16
+#: modules/module_coverdeck.lua:1242
+#: features/sui_presets.lua:138
+#: features/sui_presets.lua:183
+msgid "Recent Books"
+msgstr "近期書籍"
+
+#: modules/module_tbr.lua:532
 msgid "Remove from To Be Read"
-msgstr "從待讀中移除"
+msgstr "從待讀清單中移除"
 
-#: sui_menu.lua:1774
+#: engines/sui_window.lua:1923
+#: engines/sui_window.lua:2818
+#: features/sui_presets.lua:846
+#: features/sui_presets.lua:853
+#: features/sui_presets.lua:939
+#: screens/sui_menu.lua:4052
+#: screens/sui_menu.lua:4059
+#: screens/sui_menu.lua:4144
+msgid "Rename"
+msgstr "重新命名"
+
+#: features/sui_presets.lua:849
+#: features/sui_presets.lua:935
+#: screens/sui_menu.lua:4055
+#: screens/sui_menu.lua:4140
+msgid "Rename \"%s\""
+msgstr "重新命名「%s」"
+
+#: screens/sui_settings_window.lua:437
+msgid "Rename screen"
+msgstr "重新命名螢幕"
+
+#: screens/sui_menu.lua:2608
+msgid "Replaces the \"Closing book…\" notice above with the cover for that close, when a cover is available."
+msgstr "關閉書籍時，若有封面可用，則以該書的封面取代上述「正在關閉書籍······」提示。"
+
+#: screens/sui_menu.lua:478
+msgid "Replaces the pagination bar with Prev/Next arrows at the edges of the navigation bar.\nThe arrows dim when there is no previous or next page.\nWith navpager active, as few as 1 tab and at most 4 tabs can be configured."
+msgstr "用導航欄邊緣的「上一頁/下一頁」箭頭取代分頁欄。\n當沒有上一頁或下一頁時，箭頭會變暗。\n啟用導航分頁器時，可組態的標籤最少 1 個、最多 4 個。"
+
+#: features/sui_quickactions.lua:1866
+#: features/sui_style.lua:1400
+#: screens/sui_menu.lua:2523
+#: screens/sui_stats_windows.lua:654
+msgid "Reset"
+msgstr "重設"
+
+#: features/sui_quickactions.lua:1860
+#: features/sui_style.lua:1394
+msgid "Reset All"
+msgstr "全部重設"
+
+#: features/sui_quickactions.lua:2677
+msgid "Reset All Quick Action Icons"
+msgstr "重設所有快速動作圖示"
+
+#: features/sui_style.lua:1147
+msgid "Reset All System Icons"
+msgstr "重設所有系統圖示"
+
+#: features/sui_style.lua:2202
+msgid "Reset All Theme Colors"
+msgstr "重設所有主題顏色"
+
+#: features/sui_quickactions.lua:1865
+msgid "Reset all Quick Actions icons to default?"
+msgstr "要將所有快速動作圖示重設為預設值嗎？"
+
+#: screens/sui_menu.lua:2522
+msgid "Reset all scales to default (100%)? This cannot be undone."
+msgstr "要將所有縮放比例重設為預設值（100%）嗎？此操作無法復原。"
+
+#: features/sui_style.lua:1399
+msgid "Reset all system icons to default?"
+msgstr "要將所有系統圖示重設為預設值嗎？"
+
+#: screens/sui_menu.lua:2517
+msgid "Reset to Default Scale"
+msgstr "重設為預設縮放比例"
+
+#: engines/sui_window.lua:2202
+#: features/sui_quickactions.lua:511
+#: infra/sui_updater.lua:458
+#: screens/sui_menu.lua:450
+#: screens/sui_menu.lua:857
+#: screens/sui_menu.lua:1064
+#: screens/sui_menu.lua:1126
+#: screens/sui_menu.lua:1344
+#: screens/sui_menu.lua:1800
+#: screens/sui_menu.lua:3436
+#: screens/sui_menu.lua:3459
+#: screens/sui_menu.lua:3481
+#: screens/sui_menu.lua:4333
+#: screens/sui_menu.lua:4558
+#: screens/sui_quicksettings_bar.lua:1186
+msgid "Restart"
+msgstr "重新啟動"
+
+#: features/sui_style.lua:1789
+#: features/sui_style.lua:1833
+msgid "Restart to fully apply the UI font change."
+msgstr "重新啟動以完全套用介面字型變更。"
+
+#: screens/sui_menu.lua:2537
 msgid "Return to Book Folder"
-msgstr "返回書籍所在資料夾"
+msgstr "返回書籍資料夾"
 
-#: desktop_modules/module_coverdeck.lua:709
+#: screens/sui_menu.lua:2423
+msgid "Return to Home Screen on Wakeup"
+msgstr "喚醒時返回主螢幕"
+
+#: engines/sui_book_grid.lua:2014
+#: screens/sui_menu.lua:3190
+#: screens/sui_menu.lua:3199
+#: screens/sui_menu.lua:3211
+msgid "Ribbon"
+msgstr "絲帶"
+
+#: modules/module_quote.lua:127
+#: modules/module_quote.lua:1575
+#: modules/module_action_list.lua:74
+#: modules/module_action_list.lua:613
+#: modules/module_reading_stats.lua:97
+#: modules/module_reading_stats.lua:902
+#: modules/module_clock.lua:145
+#: modules/module_clock.lua:1048
+#: modules/module_quick_actions.lua:782
+#: screens/sui_menu.lua:722
+#: screens/sui_menu.lua:955
+#: screens/sui_menu.lua:1493
+#: screens/sui_menu.lua:1695
+msgid "Right"
+msgstr "靠右"
+
+#: modules/module_quick_actions.lua:691
+#: screens/sui_quicksettings_bar.lua:1318
+msgid "Round"
+msgstr "圓形"
+
+#: engines/sui_book_grid.lua:1898
+msgid "Round Overlay"
+msgstr "圓形疊加層"
+
+#: modules/module_quick_actions.lua:701
+#: screens/sui_quicksettings_bar.lua:1328
+msgid "Rounded Square"
+msgstr "圓角矩形"
+
+#: engines/sui_book_grid.lua:1798
+msgid "Rows"
+msgstr "行"
+
+#: screens/sui_stats_windows.lua:2830
+msgid "Sat"
+msgstr "週六"
+
+#: modules/module_clock.lua:58
+msgid "Saturday"
+msgstr "星期六"
+
+#: modules/module_reading_goals.lua:383
+#: features/sui_quickactions.lua:2395
+#: features/sui_presets.lua:771
+#: screens/sui_menu.lua:3983
+#: screens/sui_stats_windows.lua:663
+#: screens/sui_settings_window.lua:447
+msgid "Save"
+msgstr "儲存"
+
+#: features/sui_presets.lua:756
+#: screens/sui_menu.lua:3968
+msgid "Save as new preset"
+msgstr "儲存為新預設檔"
+
+#: screens/sui_menu.lua:3973
+msgid "Save icon preset"
+msgstr "儲存圖示預設檔"
+
+#: features/sui_presets.lua:761
+msgid "Save preset"
+msgstr "儲存預設檔"
+
+#: modules/module_quote.lua:1354
+#: modules/module_quote.lua:1358
+#: modules/module_action_list.lua:568
+#: modules/module_action_list.lua:570
+#: modules/module_reading_stats.lua:677
+#: modules/module_reading_stats.lua:679
+#: modules/module_reading_goals.lua:799
+#: modules/module_reading_goals.lua:801
+#: modules/module_clock.lua:950
+#: modules/module_clock.lua:952
+#: modules/module_coverdeck.lua:1151
+#: modules/module_coverdeck.lua:1153
+#: modules/module_currently.lua:1322
+#: modules/module_currently.lua:1324
+#: modules/module_quick_actions.lua:658
+#: modules/module_quick_actions.lua:660
+#: engines/sui_book_grid.lua:1726
+#: engines/sui_book_grid.lua:1728
+#: screens/sui_menu.lua:2435
+msgid "Scale"
+msgstr "縮放比例"
+
+#: modules/module_currently.lua:1351
+msgid "Scale for all text elements (title, author, progress, time).\n100% is the default size."
+msgstr "所有文字元素（標題、作者、進度、時間）的縮放比例。\n預設大小為100%。"
+
+#: modules/module_quick_actions.lua:675
+msgid "Scale for the button label text.\n100% is the default size."
+msgstr "按鈕標籤文字的縮放比例。\n預設大小為100%。"
+
+#: modules/module_collections.lua:1443
+msgid "Scale for the collection count badge."
+msgstr "收藏計數徽章的縮放。"
+
+#: modules/module_currently.lua:1338
+msgid "Scale for the cover thumbnail only.\n100% is the default size.\nWhen Dynamic Cover Size is on, this scales the cover relative to its current dynamic size instead, and the cover never shrinks below its 100% size."
+msgstr "僅封面縮圖的縮放。\n預設大小為100%。\n啟用「動態封面大小」後，此設定將相對於其目前動態大小縮放封面，且封面永遠不會小於其 100% 大小。"
+
+#: modules/module_coverdeck.lua:1162
 msgid "Scale for the cover thumbnails only.\n100% is the default size."
-msgstr ""
+msgstr "僅適用於封面縮圖的縮放比例。\n預設大小為100%。"
 
-#: sui_menu.lua:2043
+#: engines/sui_book_grid.lua:1746
+msgid "Scale for the cover thumbnails only.\nText and progress bar follow the module scale.\n100% is the default size."
+msgstr "僅適用於封面縮圖的縮放比例。\n文字與進度條跟隨模組縮放。\n預設大小為100%。"
+
+#: screens/sui_menu.lua:3409
 msgid "Scale for the folder name overlay text.\n100% is the default size."
-msgstr ""
+msgstr "資料夾名稱重疊文字的縮放比例。\n預設大小為100%。"
 
-#: desktop_modules/module_coverdeck.lua:701
+#: modules/module_action_list.lua:579
+#: screens/sui_quicksettings_bar.lua:1297
+msgid "Scale for the label text.\n100% is the default size."
+msgstr "標籤文字的縮放比例。\n預設大小為100%。"
+
+#: screens/sui_menu.lua:2918
+msgid "Scale for the library badges (progress, pages, etc.).\n100% is the default size."
+msgstr "藏書標記（進度、頁數等）的縮放比例。\n預設大小為100%。"
+
+#: engines/sui_book_grid.lua:1737
+msgid "Scale for the percentage read text.\n100% is the default size."
+msgstr "閱讀百分比文字的縮放比例。\n預設大小為100%。"
+
+#: engines/sui_book_grid.lua:1949
+msgid "Scale for this module's corner badges (progress, pages, series, new book)."
+msgstr "此模組角落徽章（進度、頁數、系列、新書）的縮放。"
+
+#: modules/module_coverdeck.lua:1154
 msgid "Scale for this module."
 msgstr "此模組的縮放比例。"
 
-#: desktop_modules/module_coverdeck.lua:717
+#: modules/module_quote.lua:1360
+#: modules/module_action_list.lua:571
+#: modules/module_reading_stats.lua:680
+#: modules/module_reading_goals.lua:802
+#: modules/module_clock.lua:953
+#: modules/module_currently.lua:1325
+#: modules/module_quick_actions.lua:661
+#: engines/sui_book_grid.lua:1729
+msgid "Scale for this module.\n100% is the default size."
+msgstr "此模組的縮放比例。\n預設大小為100%。"
+
+#: modules/module_coverdeck.lua:1170
 msgid "Scale for title and statistics text.\n100% is the default size."
-msgstr ""
+msgstr "標題與統計文字的縮放比例。\n預設大小為100%。"
 
-#: sui_foldercovers.lua:379
-msgid "Scan subfolders for cover"
-msgstr "掃描子資料夾以查找封面"
+#: screens/sui_menu.lua:2459
+msgid "Scales all modules and labels together.\n100% is the default size."
+msgstr "同時縮放所有模組與標籤。\n預設大小為100%。"
 
-#: sui_menu.lua:1687
+#: screens/sui_menu.lua:2497
+msgid "Scales the section label text above each module.\n100% is the default size."
+msgstr "縮放各模組上方的區塊標籤文字。\n預設大小為100%。"
+
+#: screens/sui_menu.lua:3533
+msgid "Scan Subfolders for Covers"
+msgstr "掃描子資料夾以獲取封面"
+
+#: screens/sui_settings_window.lua:439
+#: screens/sui_settings_window.lua:1110
+msgid "Screen name"
+msgstr "螢幕名稱"
+
+#: screens/sui_titlebar.lua:104
+msgid "Search"
+msgstr "搜尋"
+
+#: features/sui_style.lua:94
+msgid "Search Button"
+msgstr "搜尋按鈕"
+
+#: features/sui_style.lua:2096
+msgid "Secondary / Dim Text"
+msgstr "次要/暗淡文字"
+
+#: engines/sui_window.lua:1912
+#: engines/sui_window.lua:2803
+msgid "Select"
+msgstr "選取"
+
+#: features/sui_presets.lua:669
+#: features/sui_presets.lua:677
+#: features/sui_presets.lua:682
+#: screens/sui_menu.lua:3959
+msgid "Select Preset"
+msgstr "選擇預設檔"
+
+#: screens/sui_menu.lua:2255
+msgid "Select Wallpaper"
+msgstr "選擇桌布"
+
+#: modules/module_collections.lua:1201
+msgid "Select at least 2 collections to arrange."
+msgstr "請至少選擇 2 個收藏以進行排序。"
+
+#: features/sui_style.lua:2097
+msgid "Separator Line"
+msgstr "分隔線"
+
+#: features/sui_style.lua:2061
+msgid "Sepia Classic"
+msgstr "經典復古棕"
+
+#: modules/module_clock.lua:63
+#: screens/sui_stats_windows.lua:2842
+msgid "September"
+msgstr "九月"
+
+#: modules/module_currently.lua:283
+#: features/sui_quickactions.lua:897
+#: infra/sui_config.lua:134
+#: features/library/sui_library_browse.lua:59
+msgid "Series"
+msgstr "系列"
+
+#: engines/sui_book_grid.lua:1987
+#: engines/sui_book_grid.lua:2003
+msgid "Series Badge"
+msgstr "系列徽章"
+
+#: engines/sui_book_grid.lua:1998
+msgid "Series Badge Color"
+msgstr "系列徽章顏色"
+
+#: screens/sui_menu.lua:3065
 msgid "Series Index"
-msgstr "系列序號"
+msgstr "系列索引"
 
-#: sui_foldercovers.lua:304
-msgid "Series cover"
-msgstr "系列封面"
-
-#: sui_menu.lua:568
+#: screens/sui_menu.lua:661
+#: screens/sui_menu.lua:922
 msgid "Set"
 msgstr "設定"
 
-#: sui_foldercovers.lua:363
-msgid "Set series cover…"
-msgstr "設定系列封面…"
+#: modules/module_reading_goals.lua:944
+#: modules/module_reading_goals.lua:959
+#: modules/module_reading_goals.lua:974
+msgid "Set Goal"
+msgstr "設定目標"
 
-#: sui_menu.lua:1787
+#: modules/module_collections.lua:1103
+msgid "Set collection cover"
+msgstr "設定收藏封面"
+
+#: features/library/sui_foldercovers.lua:684
+#: features/library/sui_library_browse.lua:811
+#: features/library/sui_series_grouping.lua:357
+msgid "Set folder cover"
+msgstr "設定資料夾封面"
+
+#: screens/sui_onboarding.lua:168
+msgid "Set your reading goal"
+msgstr "設定您的閱讀目標"
+
+#: features/sui_quickactions.lua:866
+#: infra/sui_config.lua:131
+msgid "Settings"
+msgstr "設定"
+
+#: screens/sui_settings_window.lua:258
+#: screens/sui_settings_window.lua:263
+msgid "Settings not found."
+msgstr "未找到設定。"
+
+#: screens/sui_menu.lua:1095
+#: screens/sui_menu.lua:1393
+#: screens/sui_menu.lua:2669
+#: screens/sui_quicksettings_bar.lua:1388
 msgid "Settings on Long Tap"
-msgstr "長按打開設定"
+msgstr "長按開啟設定"
 
-#: desktop_modules/module_clock.lua:454
+#: modules/module_clock.lua:239
+msgid "Seven"
+msgstr "七"
+
+#: modules/module_clock.lua:242
+msgid "Seventeen"
+msgstr "十七"
+
+#: modules/module_clock.lua:987
+msgid "Show Battery"
+msgstr "顯示電量"
+
+#: modules/module_clock.lua:975
 msgid "Show Clock"
 msgstr "顯示時鐘"
 
-#: sui_config.lua:1748
+#: modules/module_clock.lua:981
+msgid "Show Date"
+msgstr "顯示日期"
+
+#: modules/module_collections.lua:1269
+#: modules/module_collections.lua:1290
+msgid "Show Hidden Collection"
+msgstr "顯示隱藏收藏"
+
+#: modules/module_action_list.lua:588
+msgid "Show Icon"
+msgstr "顯示圖示"
+
+#: screens/sui_menu.lua:609
+msgid "Show Page Count in Title Bar"
+msgstr "在標題欄顯示頁數"
+
+#: screens/sui_menu.lua:2550
+msgid "Show a brief \"Closing book…\" notice when closing a book, preventing accidental double-taps while e-ink refreshes."
+msgstr "關閉書籍時顯示短暫的「正在關閉書籍······」提示，防止電子墨水螢幕刷新時誤觸。"
+
+#: screens/sui_menu.lua:2646
+msgid "Show a brief \"Loading statistics…\" notice when opening a statistics window, preventing accidental double-taps while e-ink refreshes."
+msgstr "開啟統計視窗時，顯示短暫的「正在載入統計資料······」提示，以防止電子墨水屏重新整理期間發生誤觸。"
+
+#: modules/module_library.lua:346
+#: modules/module_recent.lua:50
+#: modules/module_coverdeck.lua:1513
+msgid "Show finished books"
+msgstr "顯示已讀完書籍"
+
+#: screens/sui_menu.lua:2607
+msgid "Show on Close"
+msgstr "關閉時顯示"
+
+#: screens/sui_menu.lua:2596
+msgid "Show on Open"
+msgstr "開啟時顯示"
+
+#: infra/sui_config.lua:1195
 msgid "Show section label"
-msgstr "顯示區段標籤"
+msgstr "顯示區塊標籤"
 
-#: sui_updater.lua:407
+#: screens/sui_menu.lua:2322
+msgid "Show wallpaper on all screens"
+msgstr "在所有畫面顯示桌布"
+
+#: screens/sui_menu.lua:614
+msgid "Shows \"Page X of Y\" in the title bar subtitle when browsing the library, history or collections.\nNavpager enables this automatically.\nNot available when Navpager is active."
+msgstr "在瀏覽藏書、歷史紀錄或收藏時，於標題欄副標題顯示「第 X 頁，共 Y 頁」。\n啟用導覽分頁器時會自動啟用此功能。\n當導覽分頁器已啟用時不可單獨切換。"
+
+#: screens/sui_menu.lua:510
+msgid "Shows a row of dots at the bottom of the homescreen.\nThe active page dot is filled; the others are dimmed.\nAlways active when Navpager is selected."
+msgstr "在主螢幕底部顯示一排圓點。\n目前頁面的圓點會填滿，其餘圓點變暗。\n選擇導覽分頁器時恆常啟用。"
+
+#: modules/module_feat_coll.lua:173
+#: modules/module_tbr.lua:273
+msgid "Shuffle"
+msgstr "隨機排序"
+
+#: modules/module_library.lua:274
+msgid "Shuffle now"
+msgstr "立即隨機播放"
+
+#: modules/module_currently.lua:1869
+msgid "Simple"
+msgstr "簡約"
+
+#: main.lua:2535
+#: main.lua:2548
+#: _meta.lua:5
+#: screens/sui_menu.lua:4532
+#: screens/sui_menu.lua:4540
+#: screens/sui_menu.lua:4629
+msgid "Simple UI"
+msgstr "Simple UI"
+
+#: infra/sui_updater.lua:455
+msgid "Simple UI %s installed.\n\nRestart KOReader to apply the update?"
+msgstr "Simple UI %s 已安裝。\n\n要重新啟動 KOReader 以套用更新嗎？"
+
+#: infra/sui_updater.lua:502
 msgid "Simple UI %s is available!\nYou have %s."
-msgstr ""
+msgstr "Simple UI %s 已可更新！\n目前版本為 %s。"
 
-#: desktop_modules/module_coverdeck.lua:716
+#: screens/sui_settings_window.lua:1019
+msgid "Simple UI Settings"
+msgstr "Simple UI 設定"
+
+#: screens/sui_onboarding.lua:133
+msgid "Simple UI is designed to be simple and flexible. Here are a few tips to get the most out of it."
+msgstr "Simple UI 旨在提供簡單且靈活的體驗。以下是一些協助您善用它的技巧。"
+
+#: infra/sui_updater.lua:496
+msgid "Simple UI is up to date (%s)."
+msgstr "Simple UI 已是最新版本（%s）。"
+
+#: screens/sui_menu.lua:4557
+msgid "Simple UI will be %s after restart.\n\nRestart now?"
+msgstr "重啟後 Simple UI 將改為 %s。\n\n要立即重新啟動嗎？"
+
+#: main.lua:892
+msgid "Simple UI: Go to Homescreen"
+msgstr "Simple UI：前往主螢幕"
+
+#: main.lua:898
+msgid "Simple UI: Go to Library"
+msgstr "Simple UI：前往藏書"
+
+#: main.lua:922
+msgid "Simple UI: Navigation Bar"
+msgstr "Simple UI：導航欄"
+
+#: main.lua:916
+msgid "Simple UI: Recent"
+msgstr "Simple UI：近期"
+
+#: main.lua:910
+msgid "Simple UI: Settings"
+msgstr "Simple UI：設定"
+
+#: main.lua:904
+msgid "Simple UI: Toggle Homescreen / Library"
+msgstr "Simple UI：切換主螢幕/藏書"
+
+#: modules/module_collections.lua:1354
+#: screens/sui_menu.lua:2865
+msgid "Single Cover"
+msgstr "單一封面"
+
+#: modules/module_clock.lua:238
+msgid "Six"
+msgstr "六"
+
+#: modules/module_clock.lua:242
+msgid "Sixteen"
+msgstr "十六"
+
+#: modules/module_action_list.lua:565
+#: modules/module_coverdeck.lua:1503
+#: modules/module_currently.lua:1828
+#: modules/module_quick_actions.lua:673
+#: modules/module_quick_actions.lua:674
+#: engines/sui_book_grid.lua:1810
+#: engines/sui_window.lua:2287
+#: engines/sui_window.lua:2294
+#: screens/sui_menu.lua:1036
+#: screens/sui_menu.lua:2909
+#: screens/sui_quicksettings_bar.lua:1295
+#: screens/sui_quicksettings_bar.lua:1296
+msgid "Size"
+msgstr "尺寸"
+
+#: screens/sui_menu.lua:1358
+msgid "Size of the tab icons.\n100% is the default size."
+msgstr "分頁圖示的尺寸。\n預設大小為100%。"
+
+#: screens/sui_menu.lua:1368
+msgid "Size of the tab label text.\n100% is the default size."
+msgstr "分頁標籤文字的尺寸。\n預設大小為100%。"
+
+#: modules/module_reading_stats.lua:823
+msgid "Size of the text inside the stat cards.\nDoes not affect card size or padding.\n100% is the default size."
+msgstr "統計卡片內部文字的大小。\n不影響卡片尺寸或內邊距。\n預設大小為100%。"
+
+#: features/sui_quickactions.lua:533
+msgid "Sleep"
+msgstr "睡眠"
+
+#: screens/sui_menu.lua:582
+msgid "Small"
+msgstr "小"
+
+#: modules/module_quick_actions.lua:737
+#: screens/sui_menu.lua:3306
+#: screens/sui_menu.lua:3310
+#: screens/sui_quicksettings_bar.lua:1365
+msgid "Solid"
+msgstr "實色"
+
+#: modules/module_reading_goals.lua:1068
+#: modules/module_currently.lua:1852
+#: engines/sui_book_grid.lua:1834
+msgid "Solid Background"
+msgstr "實色背景"
+
+#: modules/module_library.lua:240
+#: modules/module_collections.lua:1328
+#: modules/module_feat_coll.lua:177
+#: modules/module_tbr.lua:283
+msgid "Sort"
+msgstr "排序"
+
+#: modules/module_quote.lua:1386
+#: modules/module_coverdeck.lua:1252
+msgid "Source"
+msgstr "來源"
+
+#: screens/sui_menu.lua:1378
+msgid "Space below the bottom navigation bar.\n100% is the default spacing."
+msgstr "底部導覽欄下方的間距。\n預設間距為100%。"
+
+#: modules/module_spacer.lua:56
+#: modules/module_spacer.lua:109
+msgid "Spacer"
+msgstr "間距區塊"
+
+#: modules/module_spacer.lua:87
+#: modules/module_spacer.lua:88
+msgid "Spacer Size"
+msgstr "間距區塊尺寸"
+
+#: modules/module_clock.lua:1057
+msgid "Spacing"
+msgstr "間距"
+
+#: screens/sui_onboarding.lua:271
+msgid "Start using Simple UI"
+msgstr "開始使用 Simple UI"
+
+#: infra/sui_patches.lua:1137
+#: infra/sui_patches.lua:1139
+msgid "Start with"
+msgstr "預設開啟"
+
+#: screens/sui_menu.lua:2412
+msgid "Start with Home Screen"
+msgstr "預設開啟主螢幕"
+
+#: screens/sui_onboarding.lua:62
+msgid "Start with a ready-made layout. You can change everything later."
+msgstr "從現成版面配置開始。您隨後可以修改任何設定。"
+
+#: modules/module_coverdeck.lua:178
+#: modules/module_coverdeck.lua:1334
+#: modules/module_coverdeck.lua:1365
+#: modules/module_coverdeck.lua:1432
+msgid "Statistics"
+msgstr "統計"
+
+#: screens/sui_menu.lua:2645
+msgid "Statistics Loading Notice"
+msgstr "載入統計提示"
+
+#: screens/sui_stats_windows.lua:163
+msgid "Statistics database library not available."
+msgstr "統計資料庫函式庫不可用。"
+
+#: features/sui_quickactions.lua:850
+msgid "Statistics plugin not available."
+msgstr "統計外掛程式不可用。"
+
+#: modules/module_currently.lua:1547
+#: modules/module_currently.lua:1629
+#: modules/module_currently.lua:1690
+#: features/sui_quickactions.lua:835
+#: infra/sui_config.lua:129
+msgid "Stats"
+msgstr "統計"
+
+#: modules/module_currently.lua:1876
+msgid "Stats layout"
+msgstr "統計版面配置"
+
+#: modules/module_reading_stats.lua:992
+#: modules/module_reading_goals.lua:1109
+#: modules/module_coverdeck.lua:1551
+#: modules/module_currently.lua:1925
+msgid "Stats updated successfully."
+msgstr "統計數據更新成功。"
+
+#: screens/sui_menu.lua:2760
+msgid "Status Bar"
+msgstr "狀態欄"
+
+#: screens/sui_menu.lua:1043
+msgid "Status Bar Size"
+msgstr "狀態欄尺寸"
+
+#: screens/sui_menu.lua:856
+msgid "Status Bar will be %s after restart.\n\nRestart now?"
+msgstr "重啟後狀態欄將改為 %s。\n\n要立即重新啟動嗎？"
+
+#: features/sui_style.lua:2092
+msgid "Status Bar — Background"
+msgstr "狀態欄 — 背景"
+
+#: features/sui_style.lua:2095
+msgid "Status Bar — Text"
+msgstr "狀態欄 — 文字"
+
+#: modules/module_reading_stats.lua:134
+msgid "Status — Abandoned"
+msgstr "狀態 — 已放棄"
+
+#: modules/module_reading_stats.lua:133
+msgid "Status — Reading"
+msgstr "狀態 — 閱讀中"
+
+#: modules/module_reading_stats.lua:132
+msgid "Status — Unread"
+msgstr "狀態 — 未讀"
+
+#: screens/sui_settings_window.lua:290
+msgid "Status, title, navigation and pagination"
+msgstr "狀態欄、標題欄、導覽欄與分頁欄"
+
+#: modules/module_reading_stats.lua:124
+#: screens/sui_stats_windows.lua:3525
+msgid "Streak"
+msgstr "連續閱讀"
+
+#: modules/module_reading_stats.lua:932
+msgid "Streak Mode"
+msgstr "連續模式"
+
+#: screens/sui_menu.lua:2340
+msgid "Stretch to fill screen"
+msgstr "拉伸以填滿螢幕"
+
+#: modules/module_reading_stats.lua:833
+#: screens/sui_menu.lua:4586
+#: screens/sui_settings_window.lua:303
+#: screens/sui_settings_window.lua:1024
+msgid "Style"
+msgstr "樣式"
+
+#: screens/sui_menu.lua:1815
+#: screens/sui_menu.lua:1818
+msgid "Sub-page Buttons"
+msgstr "子頁面按鈕"
+
+#: screens/sui_stats_windows.lua:2830
+msgid "Sun"
+msgstr "週日"
+
+#: modules/module_clock.lua:57
+msgid "Sunday"
+msgstr "星期日"
+
+#: screens/sui_menu.lua:1076
+msgid "Swipe Indicator"
+msgstr "滑動指示器"
+
+#: features/sui_quickactions.lua:1826
+#: features/sui_quickactions.lua:1829
+#: features/sui_quickactions.lua:2517
+#: features/sui_quickactions.lua:2613
+msgid "System Actions"
+msgstr "系統動作"
+
+#: features/sui_style.lua:1392
+#: screens/sui_menu.lua:3645
+#: screens/sui_menu.lua:3653
+msgid "System Icons"
+msgstr "系統圖示"
+
+#: features/sui_quickactions.lua:2987
+msgid "System action error: %s"
+msgstr "系統動作錯誤：%s"
+
+#: screens/sui_stats_windows.lua:2746
+msgid "THIS MONTH"
+msgstr "本月"
+
+#: screens/sui_stats_windows.lua:2745
+msgid "THIS WEEK"
+msgstr "本週"
+
+#: screens/sui_stats_windows.lua:2741
+msgid "TODAY'S SUMMARY"
+msgstr "今日摘要"
+
+#: features/sui_style.lua:1387
+msgid "Tab Bar"
+msgstr "分頁欄"
+
+#: screens/sui_menu.lua:1270
+msgid "Tab Style"
+msgstr "分頁樣式"
+
+#: features/sui_style.lua:1343
+msgid "Tab bar icons must be PNG or SVG."
+msgstr "分頁欄圖示必須為 PNG 或 SVG 格式。"
+
+#: engines/sui_window.lua:2251
+msgid "Tab order"
+msgstr "分頁順序"
+
+#: features/sui_style.lua:270
+msgid "Tab: Back to File Browser"
+msgstr "分頁：返回檔案瀏覽器"
+
+#: features/sui_style.lua:249
+msgid "Tab: File Browser Settings"
+msgstr "分頁：檔案瀏覽器設定"
+
+#: features/sui_style.lua:221
+msgid "Tab: Menu"
+msgstr "分頁：選單"
+
+#: features/sui_style.lua:256
+msgid "Tab: Reader Navigation"
+msgstr "分頁：閱讀器導覽"
+
+#: features/sui_style.lua:263
+msgid "Tab: Reader Typeset"
+msgstr "分頁：閱讀器排版"
+
+#: features/sui_style.lua:242
+msgid "Tab: Search"
+msgstr "分頁：搜尋"
+
+#: features/sui_style.lua:228
+msgid "Tab: Settings"
+msgstr "分頁：設定"
+
+#: features/sui_style.lua:277
+msgid "Tab: SimpleUI Quick Settings"
+msgstr "分頁：SimpleUI 快速設定"
+
+#: features/sui_style.lua:235
+msgid "Tab: Tools"
+msgstr "分頁：工具"
+
+#: screens/sui_menu.lua:1149
+#: screens/sui_menu.lua:1201
+msgid "Tabs"
+msgstr "分頁"
+
+#: screens/sui_menu.lua:1143
+msgid "Tabs  (%d/%d — %d left)"
+msgstr "分頁（%d/%d — 剩餘 %d 個）"
+
+#: screens/sui_menu.lua:1141
+msgid "Tabs  (%d/%d — at limit)"
+msgstr "分頁（%d/%d — 已達上限）"
+
+#: features/sui_quickactions.lua:915
+#: infra/sui_config.lua:136
+#: features/library/sui_library_browse.lua:60
+msgid "Tags"
+msgstr "標籤"
+
+#: screens/sui_settings_window.lua:401
+msgid "Tap \"Create Screen\" below to add one."
+msgstr "點選下方的「建立螢幕」以新增一個。"
+
+#: modules/module_clock.lua:240
+msgid "Ten"
+msgstr "十"
+
+#: engines/sui_book_grid.lua:1896
+#: screens/sui_menu.lua:209
+msgid "Text"
+msgstr "文字"
+
+#: modules/module_action_list.lua:577
+#: modules/module_action_list.lua:578
+#: modules/module_reading_stats.lua:819
+#: modules/module_reading_stats.lua:822
+#: modules/module_currently.lua:1349
+#: modules/module_currently.lua:1350
+#: engines/sui_book_grid.lua:1735
+#: engines/sui_book_grid.lua:1736
+#: screens/sui_menu.lua:3406
+msgid "Text Size"
+msgstr "文字大小"
+
+#: modules/module_reading_stats.lua:820
+msgid "Text Size — %d%%"
+msgstr "文字大小 — %d%%"
+
+#: screens/sui_menu.lua:211
+msgid "Text only"
+msgstr "僅文字"
+
+#: modules/module_coverdeck.lua:1168
+#: modules/module_coverdeck.lua:1169
 msgid "Text size"
 msgstr "文字大小"
 
-#: sui_patches.lua:669
+#: screens/sui_quicksettings_bar.lua:1183
+msgid "The Quick Settings Bar will be %s after restart.\n\nRestart now?"
+msgstr "重啟後快速設定欄將改為 %s。\n\n要立即重新啟動嗎？"
+
+#: screens/sui_menu.lua:2620
+msgid "The cover shown right as a book opens normally comes from the library's cached thumbnail, which can look soft on higher-resolution screens. When on, SimpleUI instead reads the cover straight from the book file for that moment (also covers books never opened before, which otherwise show no cover at all) — at the cost of a brief extra pause while opening, since the file has to be read twice. Cover on close is unaffected either way: it already reads the full-quality cover from the open book."
+msgstr "開啟書籍時顯示的封面通常來自藏書庫快取的縮圖，在較高解析度螢幕上可能會顯得模糊。開啟此選項後，Simple UI 會直接從書籍檔案中讀取原圖封面（亦適用於從未開啟過的書籍），但開啟時需額外讀取檔案一次，會稍有停頓。關閉書籍時的封面不受影響，因為它已直接讀取開啟中書籍的高畫質封面。"
+
+#: main.lua:1399
+#: screens/sui_bottombar.lua:1870
+msgid "The navigation bar is already available on this screen."
+msgstr "此螢幕已提供導航欄。"
+
+#: infra/sui_patches.lua:1283
 msgid "The «To Be Read» collection cannot be renamed."
-msgstr ""
+msgstr "「待讀」收藏無法重新命名。"
 
-#: desktop_modules/module_coverdeck.lua:747
-msgid "Title Position"
-msgstr "標題位置"
+#: screens/sui_menu.lua:4386
+msgid "Theme Colors"
+msgstr "主題顏色"
 
-#: desktop_modules/module_tbr.lua:239
+#: modules/module_clock.lua:241
+msgid "Thirteen"
+msgstr "十三"
+
+#: modules/module_clock.lua:246
+msgid "Thirty"
+msgstr "三十"
+
+#: features/sui_quickactions.lua:3185
+#: features/sui_quickactions.lua:3271
+msgid "This group is empty.\nAdd actions to it from Settings → Quick Actions."
+msgstr "此群組為空。\n請前往 設定 → 快速動作 新增動作。"
+
+#: modules/module_reading_stats.lua:121
+msgid "This month — Pages"
+msgstr "本月 — 頁數"
+
+#: modules/module_reading_stats.lua:120
+msgid "This month — Time"
+msgstr "本月 — 時間"
+
+#: features/sui_presets.lua:785
+#: features/sui_presets.lua:858
+#: features/sui_presets.lua:944
+msgid "This name is reserved by a built-in preset."
+msgstr "此名稱為內建預設檔保留。"
+
+#: modules/module_reading_stats.lua:117
+msgid "This week — Pages"
+msgstr "本週 — 頁數"
+
+#: modules/module_reading_stats.lua:116
+msgid "This week — Time"
+msgstr "本週 — 時間"
+
+#: screens/sui_menu.lua:4452
+msgid "This will delete all Simple UI settings and restart KOReader.\nAre you sure?"
+msgstr "這將刪除所有 Simple UI 設定並重新啟動 KOReader。\n您確定要繼續嗎？"
+
+#: modules/module_clock.lua:237
+msgid "Three"
+msgstr "三"
+
+#: screens/sui_stats_windows.lua:2830
+msgid "Thu"
+msgstr "週四"
+
+#: modules/module_clock.lua:58
+msgid "Thursday"
+msgstr "星期四"
+
+#: modules/module_coverdeck.lua:165
+#: modules/module_currently.lua:288
+msgid "Time read"
+msgstr "閱讀時間"
+
+#: modules/module_coverdeck.lua:166
+#: modules/module_currently.lua:289
+msgid "Time remaining"
+msgstr "剩餘時間"
+
+#: modules/module_coverdeck.lua:175
+#: modules/module_currently.lua:281
+#: screens/sui_titlebar.lua:106
+msgid "Title"
+msgstr "標題"
+
+#: modules/module_library.lua:212
+#: modules/module_feat_coll.lua:168
+#: modules/module_tbr.lua:268
+msgid "Title (A–Z)"
+msgstr "標題（A–Z）"
+
+#: modules/module_library.lua:213
+#: modules/module_feat_coll.lua:169
+#: modules/module_tbr.lua:269
+msgid "Title (Z–A)"
+msgstr "標題（Z–A）"
+
+#: features/sui_style.lua:1382
+#: screens/sui_menu.lua:2762
+msgid "Title Bar"
+msgstr "標題欄"
+
+#: screens/sui_menu.lua:1797
+msgid "Title Bar will be %s after restart.\n\nRestart now?"
+msgstr "重啟後標題欄將改為 %s。\n\n要立即重新啟動嗎？"
+
+#: screens/sui_menu.lua:3468
+msgid "Title and Author"
+msgstr "標題與作者"
+
+#: screens/sui_menu.lua:3419
+msgid "Title and Author Below Covers"
+msgstr "封面下方顯示標題與作者"
+
+#: screens/sui_menu.lua:3480
+msgid "Title and author strip enabled.\n\nRestart now?"
+msgstr "標題與作者條已啟用。\n\n要立即重新啟動嗎？"
+
+#: screens/sui_menu.lua:3446
+msgid "Title only"
+msgstr "僅標題"
+
+#: screens/sui_menu.lua:3435
+msgid "Title strip disabled.\n\nRestart now?"
+msgstr "標題條已停用。\n\n要立即重新啟動嗎？"
+
+#: screens/sui_menu.lua:3458
+msgid "Title strip enabled.\n\nRestart now?"
+msgstr "標題條已啟用。\n\n要立即重新啟動嗎？"
+
+#: modules/module_tbr.lua:507
+#: modules/module_tbr.lua:552
+#: modules/module_tbr.lua:553
+#: modules/module_coverdeck.lua:1244
 msgid "To Be Read"
 msgstr "待讀"
 
-#: desktop_modules/module_tbr.lua:227
-msgid "To Be Read books"
+#: modules/module_tbr.lua:363
+msgid "To Be Read Books"
 msgstr "待讀書籍"
 
-#: sui_patches.lua:829
-msgid "To Be Read list is full (max. 5 books)."
-msgstr ""
+#: modules/module_reading_goals.lua:636
+#: modules/module_reading_goals.lua:638
+#: modules/module_reading_goals.lua:692
+#: modules/module_reading_goals.lua:695
+msgid "Today"
+msgstr "今天"
 
-#: sui_updater.lua:377
+#: modules/module_reading_stats.lua:115
+msgid "Today — Pages"
+msgstr "今日 — 頁數"
+
+#: modules/module_reading_stats.lua:114
+msgid "Today — Time"
+msgstr "今日 — 時間"
+
+#: modules/module_collections.lua:1408
+#: screens/sui_menu.lua:2940
+#: screens/sui_menu.lua:2947
+#: screens/sui_menu.lua:2951
+#: screens/sui_menu.lua:3351
+#: screens/sui_menu.lua:3358
+msgid "Top"
+msgstr "頂部"
+
+#: screens/sui_topbar.lua:515
+msgid "Top Bar"
+msgstr "頂部欄"
+
+#: engines/sui_screen_engine.lua:2115
+msgid "Top Margin"
+msgstr "頂邊距"
+
+#: screens/sui_stats_windows.lua:953
+#: screens/sui_stats_windows.lua:3680
+msgid "Total"
+msgstr "總計"
+
+#: screens/sui_stats_windows.lua:2437
+#: screens/sui_stats_windows.lua:2453
+msgid "Total time"
+msgstr "總時間"
+
+#: modules/module_quick_actions.lua:727
+#: screens/sui_menu.lua:3306
+#: screens/sui_menu.lua:3323
+#: screens/sui_quicksettings_bar.lua:1355
+msgid "Transparent"
+msgstr "透明"
+
+#: screens/sui_menu.lua:2302
+msgid "Transparent navigation bar"
+msgstr "透明導覽欄"
+
+#: screens/sui_menu.lua:2284
+msgid "Transparent status bar"
+msgstr "透明狀態欄"
+
+#: screens/sui_stats_windows.lua:2830
+msgid "Tue"
+msgstr "週二"
+
+#: modules/module_clock.lua:57
+msgid "Tuesday"
+msgstr "星期二"
+
+#: modules/module_clock.lua:240
+msgid "Twelve"
+msgstr "十二"
+
+#: modules/module_clock.lua:246
+msgid "Twenty"
+msgstr "二十"
+
+#: modules/module_clock.lua:237
+msgid "Two"
+msgstr "二"
+
+#: screens/sui_menu.lua:3128
+#: screens/sui_menu.lua:3195
+msgid "Type"
+msgstr "類型"
+
+#: screens/sui_menu.lua:4282
+#: screens/sui_menu.lua:4285
+msgid "UI Font"
+msgstr "介面字型"
+
+#: screens/sui_menu.lua:4289
+msgid "UI Font  (default)"
+msgstr "介面字型（預設）"
+
+#: screens/sui_menu.lua:4291
+msgid "UI Font  [%s]"
+msgstr "介面字型 [%s]"
+
+#: screens/sui_menu.lua:3495
+msgid "Uniformize Covers (2:3)"
+msgstr "統一封面比例（2:3）"
+
+#: modules/module_coverdeck.lua:123
+msgid "Unknown Author"
+msgstr "未知作者"
+
+#: screens/sui_stats_windows.lua:868
+msgid "Unknown error."
+msgstr "未知錯誤。"
+
+#: features/sui_style.lua:2411
+msgid "Unsupported format (use a folder or a .zip file)"
+msgstr "不支援的格式（請使用資料夾或 .zip 檔案）"
+
+#: features/sui_quickactions.lua:93
+#: features/sui_quickactions.lua:1770
+#: features/sui_style.lua:1128
+#: features/sui_style.lua:1336
+msgid "Unsupported icon format.\nPlease use a PNG or SVG file."
+msgstr "不支援的圖示格式。\n請使用 PNG 或 SVG 檔案。"
+
+#: engines/sui_window.lua:1920
+#: engines/sui_window.lua:2815
+msgid "Update"
+msgstr "更新"
+
+#: modules/module_reading_stats.lua:963
+#: modules/module_reading_goals.lua:1079
+#: modules/module_coverdeck.lua:1522
+#: modules/module_currently.lua:1895
+msgid "Update Stats Now"
+msgstr "立即更新統計"
+
+#: infra/sui_updater.lua:475
 msgid "Update cancelled."
-msgstr "更新已取消。"
+msgstr "已取消更新。"
 
-#: sui_updater.lua:487
+#: infra/sui_updater.lua:676
 msgid "Update check cancelled."
-msgstr "更新檢查已取消。"
+msgstr "已取消檢查更新。"
 
-#: sui_menu.lua:2132
+#: features/sui_presets.lua:831
+#: screens/sui_menu.lua:4037
+msgid "Update with current settings"
+msgstr "以目前設定更新"
+
+#: screens/sui_menu.lua:4437
 msgid "Updater module not found."
-msgstr "未找到更新模組。"
+msgstr "未找到更新器模組。"
 
-#: sui_updater.lua:412
+#: screens/sui_stats_windows.lua:3134
+msgid "Use freeze"
+msgstr "使用凍結權"
+
+#: features/sui_quickactions.lua:1989
+msgid "Use this Nerd Font icon?"
+msgstr "使用此 Nerd Font 圖示嗎？"
+
+#: screens/sui_menu.lua:532
+msgid "Uses the standard KOReader pagination bar on the homescreen.\nNot available when Navpager is active."
+msgstr "主螢幕使用標準 KOReader 分頁欄。\n當導覽分頁器啟用時不可用。"
+
+#: screens/sui_settings_window.lua:325
+msgid "Version, author and updates"
+msgstr "版本、作者與更新"
+
+#: screens/sui_menu.lua:4409
+msgid "Version: %s"
+msgstr "版本：%s"
+
+#: engines/sui_screen_engine.lua:2118
+msgid "Vertical space above this module.\n100% is the default spacing."
+msgstr "此模組上方的垂直間距。\n預設間距為100%。"
+
+#: modules/module_clock.lua:1069
+msgid "Vertical space between the clock and the date.\n100% is the default spacing."
+msgstr "時鐘與日期之間的垂直間距。\n預設間距為100%。"
+
+#: modules/module_clock.lua:1095
+msgid "Vertical space between the date (or clock) and the battery.\n100% is the default spacing."
+msgstr "日期（或時鐘）與電量之間的垂直間距。\n預設間距為100%。"
+
+#: modules/module_clock.lua:972
+#: screens/sui_menu.lua:3017
+#: screens/sui_menu.lua:3071
+#: screens/sui_menu.lua:3303
+msgid "Visibility"
+msgstr "可見性"
+
+#: screens/sui_menu.lua:3013
+#: screens/sui_menu.lua:3019
+#: screens/sui_menu.lua:3023
+#: screens/sui_menu.lua:3067
+#: screens/sui_menu.lua:3073
+#: screens/sui_menu.lua:3077
+msgid "Visible"
+msgstr "顯示"
+
+#: screens/sui_stats_windows.lua:2743
+#: screens/sui_stats_windows.lua:3395
+msgid "WEEK STREAK"
+msgstr "連續閱讀週數"
+
+#: modules/module_clock.lua:250
+msgid "WORD_CLOCK_TENS_SEP"
+msgstr "零"
+
+#: screens/sui_menu.lua:2731
+#: screens/sui_settings_window.lua:355
+#: screens/sui_settings_window.lua:361
+msgid "Wallpaper"
+msgstr "桌布"
+
+#: features/sui_style.lua:2019
+msgid "Warm Paper"
+msgstr "暖紙色"
+
+#: screens/sui_quicksettings_bar.lua:500
+#: screens/sui_quicksettings_bar.lua:521
+#: screens/sui_quicksettings_bar.lua:532
+msgid "Warmth"
+msgstr "暖光"
+
+#: screens/sui_quicksettings_bar.lua:1281
+msgid "Warmth Slider"
+msgstr "暖光滑桿"
+
+#: screens/sui_menu.lua:2658
+msgid "Warn when modules on a page exceed the available screen height."
+msgstr "當頁面上的模組超出可用螢幕高度時發出警告。"
+
+#: screens/sui_stats_windows.lua:2830
+msgid "Wed"
+msgstr "週三"
+
+#: modules/module_clock.lua:57
+msgid "Wednesday"
+msgstr "星期三"
+
+#: screens/sui_onboarding.lua:233
+#: screens/sui_onboarding.lua:234
+msgid "Welcome to Simple UI"
+msgstr "歡迎使用 Simple UI"
+
+#: infra/sui_updater.lua:503
 msgid "What's new:"
 msgstr "更新內容："
 
-#: sui_menu.lua:1787
-msgid "When enabled, long-pressing a section opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
-msgstr ""
+#: screens/sui_menu.lua:2683
+msgid "When a finished book is deleted from the device, keep it counted in the Books Read statistics on the Home Screen.\n\nBooks changed back to Reading or Abandoned are automatically removed from this list."
+msgstr "當完讀書籍從裝置刪除時，仍將其計入主螢幕的已讀書籍統計中。\n\n狀態改回閱讀中或已放棄的書籍會自動從此清單中移除。"
 
-#: sui_menu.lua:1798
-msgid "When enabled, long-pressing the bottom bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
-msgstr ""
+#: screens/sui_menu.lua:2538
+msgid "When closing a book from the Home Screen, go back to the folder where the book is located instead of the Library home folder."
+msgstr "從主螢幕關閉書籍時，返回該書籍所在的資料夾，而非藏書首頁資料夾。"
 
-#: sui_menu.lua:1793
+#: screens/sui_menu.lua:2670
+msgid "When enabled, long-pressing a module on the home screen opens its settings menu.\nDisable this to prevent settings from appearing on long tap."
+msgstr "啟用時，長按主螢幕上的模組可開啟其設定選單。\n停用此選項可防止長按時彈出設定選單。"
+
+#: screens/sui_quicksettings_bar.lua:1389
+msgid "When enabled, long-pressing the Quick Settings Bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
+msgstr "啟用時，長按快速設定欄可開啟其設定選單。\n停用此選項可防止長按時彈出設定選單。"
+
+#: screens/sui_menu.lua:1394
+msgid "When enabled, long-pressing the navigation bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
+msgstr "啟用後，長按導航欄會開啟其設定選單。\n停用此項可防止長按時出現設定選單。"
+
+#: screens/sui_menu.lua:1096
 msgid "When enabled, long-pressing the top bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
-msgstr ""
+msgstr "啟用時，長按頂欄可開啟其設定選單。\n停用此選項可防止長按時彈出設定選單。"
 
-#: sui_menu.lua:1775
-msgid "When enabled, opening the file browser after finishing or closing a book navigates to the folder the book is in, matching native KOReader behaviour.\nWhen disabled (default), SimpleUI always returns to the library root.\nThis option works independently of \"Start with Home Screen\"."
-msgstr ""
+#: screens/sui_menu.lua:2424
+msgid "When waking the device from sleep/suspend, always return to the Home Screen — even if a book was open when it went to sleep."
+msgstr "將裝置從睡眠/待機中喚醒時，一律返回主螢幕 — 即使待機前正開啟著書籍。"
 
-#: sui_updater.lua:410
-msgid "\n\nDownload and install now?"
-msgstr "\n\n是否立即下載並安裝？"
+#: features/sui_quickactions.lua:801
+#: infra/sui_config.lua:126
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
 
-#: desktop_modules/module_reading_goals.lua:617
+#: features/sui_quickactions.lua:244
+msgid "Wi-Fi off"
+msgstr "Wi-Fi 關閉"
+
+#: infra/sui_config.lua:168
+msgid "WiFi"
+msgstr "Wi-Fi"
+
+#: features/sui_quickactions.lua:231
+msgid "WiFi not available on this device."
+msgstr "此裝置不支援 Wi-Fi。"
+
+#: features/sui_quickactions.lua:2133
+msgid "Wikipedia Lookup"
+msgstr "維基百科查詢"
+
+#: modules/module_currently.lua:1871
+msgid "With percentage"
+msgstr "附帶百分比"
+
+#: modules/module_clock.lua:1000
+#: modules/module_clock.lua:1013
+msgid "Word"
+msgstr "文字"
+
+#: screens/sui_stats_windows.lua:1227
+msgid "Yes"
+msgstr "是"
+
+#: screens/sui_stats_windows.lua:3123
+msgid "Yesterday is already covered by a freeze."
+msgstr "昨天已使用凍結權覆蓋。"
+
+#: screens/sui_stats_windows.lua:3121
+msgid "You already read yesterday — there's nothing to freeze."
+msgstr "您昨天已完成閱讀 — 無需使用凍結權。"
+
+#: screens/sui_stats_windows.lua:3114
+msgid "You don't have any freezes available yet."
+msgstr "您目前沒有可用的凍結權。"
+
+#: screens/sui_stats_windows.lua:3132
+msgid "You have %d freeze(s) available.\nUse one to cover %s?"
+msgstr "您有 %d 個可用的凍結權。\n要使用一個來覆蓋 %s 嗎？"
+
+#: modules/module_quote.lua:1003
+msgid "Your highlights"
+msgstr "您的劃線"
+
+#: modules/module_reading_stats.lua:134
+msgid "abandoned"
+msgstr "已放棄"
+
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1434
+msgid "apr"
+msgstr "4月"
+
+#: screens/sui_stats_windows.lua:1438
+msgid "april"
+msgstr "四月"
+
+#: screens/sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:1435
+msgid "aug"
+msgstr "8月"
+
+#: screens/sui_stats_windows.lua:1439
+msgid "august"
+msgstr "八月"
+
+#: modules/module_reading_stats.lua:123
+#: screens/sui_stats_windows.lua:2311
+msgid "books finished"
+msgstr "本讀完書籍"
+
+#: modules/module_reading_stats.lua:118
+msgid "daily avg (7 days)"
+msgstr "每日平均（7 天）"
+
+#: modules/module_reading_stats.lua:125
+msgid "day streak"
+msgstr "天連續閱讀"
+
+#: modules/module_reading_stats.lua:125
+msgid "days streak"
+msgstr "天連續閱讀"
+
+#: screens/sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:1435
+msgid "dec"
+msgstr "12月"
+
+#: screens/sui_stats_windows.lua:1439
+msgid "december"
+msgstr "十二月"
+
+#: features/sui_quickactions.lua:1762
+#: features/sui_quickactions.lua:2794
+msgid "default"
+msgstr "預設"
+
+#: screens/sui_menu.lua:856
+#: screens/sui_menu.lua:1125
+#: screens/sui_menu.lua:1798
+#: screens/sui_menu.lua:4557
+#: screens/sui_quicksettings_bar.lua:1184
+msgid "disabled"
+msgstr "已停用"
+
+#: features/sui_style.lua:2114
+msgid "e.g. #F5F0E8  or #1C1C1E  (empty = reset)"
+msgstr "例如 #F5F0E8 或 #1C1C1E（留空 = 重設）"
+
+#: screens/sui_menu.lua:856
+#: screens/sui_menu.lua:1125
+#: screens/sui_menu.lua:1798
+#: screens/sui_menu.lua:4557
+#: screens/sui_quicksettings_bar.lua:1184
+msgid "enabled"
+msgstr "已啟用"
+
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1434
+msgid "feb"
+msgstr "2月"
+
+#: screens/sui_stats_windows.lua:1438
+msgid "february"
+msgstr "二月"
+
+#: features/sui_style.lua:2357
+msgid "ffi/archiver not available in this KOReader version"
+msgstr "此 KOReader 版本不可用 ffi/archiver"
+
+#: features/sui_quickactions.lua:2009
+msgid "hex code, e.g. E001"
+msgstr "十六進位碼，例如 E001"
+
+#: screens/sui_stats_windows.lua:1970
+#: screens/sui_stats_windows.lua:2309
+msgid "hours read"
+msgstr "小時閱讀時間"
+
+#: modules/module_reading_stats.lua:133
+msgid "in progress"
+msgstr "進行中"
+
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1434
+msgid "jan"
+msgstr "1月"
+
+#: screens/sui_stats_windows.lua:1438
+msgid "january"
+msgstr "一月"
+
+#: screens/sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:1435
+msgid "jul"
+msgstr "7月"
+
+#: screens/sui_stats_windows.lua:1439
+msgid "july"
+msgstr "七月"
+
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1434
+msgid "jun"
+msgstr "6月"
+
+#: screens/sui_stats_windows.lua:1438
+msgid "june"
+msgstr "六月"
+
+#: infra/sui_updater.lua:690
+msgid "latest"
+msgstr "最新"
+
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1434
+msgid "mar"
+msgstr "3月"
+
+#: screens/sui_stats_windows.lua:1438
+msgid "march"
+msgstr "三月"
+
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1434
+#: screens/sui_stats_windows.lua:1438
+msgid "may"
+msgstr "5月"
+
+#: modules/module_reading_stats.lua:125
+msgid "no streak"
+msgstr "無連續紀錄"
+
+#: features/sui_quickactions.lua:1499
+#: features/sui_quickactions.lua:2895
+#: features/sui_quickactions.lua:2914
+msgid "not configured"
+msgstr "未設定"
+
+#: screens/sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:1435
+msgid "nov"
+msgstr "11月"
+
+#: screens/sui_stats_windows.lua:1439
+msgid "november"
+msgstr "十一月"
+
+#: screens/sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:1435
+msgid "oct"
+msgstr "10月"
+
+#: screens/sui_stats_windows.lua:1439
+msgid "october"
+msgstr "十月"
+
+#: modules/module_reading_stats.lua:120
+msgid "of reading this month"
+msgstr "本月閱讀時間"
+
+#: modules/module_reading_stats.lua:116
+msgid "of reading this week"
+msgstr "本週閱讀時間"
+
+#: modules/module_reading_stats.lua:114
+msgid "of reading today"
+msgstr "今日閱讀時間"
+
+#: modules/module_reading_stats.lua:122
+msgid "of reading, all time"
+msgstr "累計閱讀時間"
+
+#: features/sui_style.lua:2400
+msgid "pack_path not provided"
+msgstr "未提供 pack_path"
+
+#: screens/sui_stats_windows.lua:2310
+#: screens/sui_stats_windows.lua:2632
+msgid "pages read"
+msgstr "頁已讀"
+
+#: modules/module_reading_stats.lua:121
+msgid "pages read this month"
+msgstr "本月已讀頁數"
+
+#: modules/module_reading_stats.lua:117
+msgid "pages read this week"
+msgstr "本週已讀頁數"
+
+#: modules/module_reading_stats.lua:115
+msgid "pages read today"
+msgstr "今日已讀頁數"
+
+#: modules/module_reading_stats.lua:119
+msgid "pages/day (7 days)"
+msgstr "頁/天（7 天）"
+
+#: screens/sui_stats_windows.lua:2630
+msgid "reading time"
+msgstr "閱讀時間"
+
+#: screens/sui_stats_windows.lua:418
+#: screens/sui_stats_windows.lua:1435
+msgid "sep"
+msgstr "9月"
+
+#: screens/sui_stats_windows.lua:1439
+msgid "september"
+msgstr "九月"
+
+#: modules/module_reading_stats.lua:132
+msgid "unread"
+msgstr "未讀"
+
+#: infra/sui_updater.lua:692
+msgid "⬆ Update available: %s"
+msgstr "⬆ 有可用更新：%s"
+
+#: modules/module_action_list.lua:464
+#: modules/module_reading_stats.lua:921
+#: modules/module_quick_actions.lua:484
+#: screens/sui_menu.lua:351
+#: screens/sui_menu.lua:1979
+msgid "  (%d left)"
+msgid_plural "  (%d left)"
+msgstr[0] "  （剩餘 %d 個）"
+msgstr[1] "  （剩餘 %d 個）"
+
+#: modules/module_reading_goals.lua:832
 msgid "  Set Goal  (%d book in %s)"
-msgstr ""
+msgid_plural "  Set Goal  (%d books in %s)"
+msgstr[0] "  設定目標（讀 %d 本書在 %s 年）"
+msgstr[1] "  設定目標（讀 %d 本書在 %s 年）"
+
+#: modules/module_reading_goals.lua:472
+msgid "%d book"
+msgid_plural "%d books"
+msgstr[0] "%d 本書"
+msgstr[1] "%d 本書"
+
+#: modules/module_reading_goals.lua:937
+msgid "%d book in %s"
+msgid_plural "%d books in %s"
+msgstr[0] "讀 %d 本書在 %s 年"
+msgstr[1] "讀 %d 本書在 %s 年"
+
+#: screens/sui_stats_windows.lua:1296
+msgid "%d book read in %s"
+msgid_plural "%d books read in %s"
+msgstr[0] "已讀 %d 本書在 %s 年"
+msgstr[1] "已讀 %d 本書在 %s 年"
+
+#: screens/sui_stats_windows.lua:2175
+#: screens/sui_stats_windows.lua:2177
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] "%d 天"
+msgstr[1] "%d 天"
+
+#: modules/module_coverdeck.lua:918
+#: modules/module_currently.lua:755
+#: modules/module_currently.lua:756
+#: modules/module_currently.lua:834
+msgid "%d day of reading"
+msgid_plural "%d days of reading"
+msgstr[0] "閱讀 %d 天"
+msgstr[1] "閱讀 %d 天"
+
+#: screens/sui_stats_windows.lua:3441
+msgid "%d freeze available"
+msgid_plural "%d freezes available"
+msgstr[0] "%d 個可用的凍結權"
+msgstr[1] "%d 個可用的凍結權"
+
+#: modules/module_reading_goals.lua:1023
+msgid "%d in %s"
+msgid_plural "%d in %s"
+msgstr[0] "%d 本在 %s 年"
+msgstr[1] "%d 本在 %s 年"
+
+#: features/sui_quickactions.lua:1491
+#: features/sui_quickactions.lua:2887
+#: features/sui_quickactions.lua:2908
+msgid "%d item"
+msgid_plural "%d items"
+msgstr[0] "%d 個項目"
+msgstr[1] "%d 個項目"
+
+#: screens/sui_stats_windows.lua:2195
+#: screens/sui_stats_windows.lua:2197
+msgid "%d week"
+msgid_plural "%d weeks"
+msgstr[0] "%d 週"
+msgstr[1] "%d 週"
+
+#: modules/module_reading_goals.lua:470
+msgid "%d/%d book"
+msgid_plural "%d/%d books"
+msgstr[0] "%d/%d 本書"
+msgstr[1] "%d/%d 本書"
+
+#: modules/module_collections.lua:1593
+msgid "(%d collection)"
+msgid_plural "(%d collections)"
+msgstr[0] "（%d 個收藏）"
+msgstr[1] "（%d 個收藏）"
+
+#: modules/module_reading_stats.lua:380
+#: modules/module_quick_actions.lua:600
+msgid "(%d/%d — %d left)"
+msgid_plural "(%d/%d — %d left)"
+msgstr[0] "（%d/%d — 剩餘 %d 個）"
+msgstr[1] "（%d/%d — 剩餘 %d 個）"
+
+#: features/sui_quickactions.lua:2368
+msgid "Group (%d item)"
+msgid_plural "Group (%d items)"
+msgstr[0] "群組（%d 個項目）"
+msgstr[1] "群組（%d 個項目）"
+
+#: modules/module_reading_goals.lua:1014
+msgid "Manually Tracked Books  (%d in %s)"
+msgid_plural "Manually Tracked Books  (%d in %s)"
+msgstr[0] "手動匯入的書籍（%d 本在 %s 年）"
+msgstr[1] "手動匯入的書籍（%d 本在 %s 年）"
+
+#: screens/sui_quicksettings_bar.lua:1158
+msgid "Maximum of %d slot reached. Remove one first."
+msgid_plural "Maximum of %d slots reached. Remove one first."
+msgstr[0] "已達上限 %d 個欄位。請先移除一個。"
+msgstr[1] "已達上限 %d 個欄位。請先移除一個。"
+
+#: screens/sui_menu.lua:650
+#: screens/sui_menu.lua:916
+msgid "Text shown in the top bar.\nMaximum %d character."
+msgid_plural "Text shown in the top bar.\nMaximum %d characters."
+msgstr[0] "頂部欄顯示的文字。\n最多 %d 個字元。"
+msgstr[1] "頂部欄顯示的文字。\n最多 %d 個字元。"
+
+#: modules/module_action_list.lua:401
+#: modules/module_action_list.lua:538
+#: modules/module_quick_actions.lua:426
+#: modules/module_quick_actions.lua:567
+#: screens/sui_menu.lua:1943
+#: screens/sui_menu.lua:2062
+msgid "The maximum of %d action per module has been reached. Remove one first."
+msgid_plural "The maximum of %d actions per module has been reached. Remove one first."
+msgstr[0] "已達每個模組上限 %d 個動作。請先移除一個。"
+msgstr[1] "已達每個模組上限 %d 個動作。請先移除一個。"
+
+#: features/sui_quickactions.lua:1563
+#: features/sui_quickactions.lua:2849
+msgid "The maximum of %d quick action has been reached. Delete one first."
+msgid_plural "The maximum of %d quick actions has been reached. Delete one first."
+msgstr[0] "已達上限 %d 個快速動作。請先刪除一個。"
+msgstr[1] "已達上限 %d 個快速動作。請先刪除一個。"
+
+#: modules/module_reading_stats.lua:707
+#: modules/module_reading_stats.lua:789
+msgid "The maximum of %d stat per row has been reached. Remove one first."
+msgid_plural "The maximum of %d stats per row has been reached. Remove one first."
+msgstr[0] "已達每列上限 %d 個統計項目。請先移除一個。"
+msgstr[1] "已達每列上限 %d 個統計項目。請先移除一個。"
+
+#: screens/sui_menu.lua:384
+#: screens/sui_menu.lua:1240
+msgid "The maximum of %d tab has been reached. Remove one first."
+msgid_plural "The maximum of %d tabs has been reached. Remove one first."
+msgstr[0] "已達上限 %d 個分頁。請先移除一個。"
+msgstr[1] "已達上限 %d 個分頁。請先移除一個。"
+
+#: screens/sui_stats_windows.lua:1973
+msgid "day read"
+msgid_plural "days read"
+msgstr[0] "天已讀"
+msgstr[1] "天已讀"
+
+#: screens/sui_stats_windows.lua:1988
+msgid "page read"
+msgid_plural "pages read"
+msgstr[0] "頁已讀"
+msgstr[1] "頁已讀"


### PR DESCRIPTION
Updated Simplified Chinese (zh_CN) and Traditional Chinese (zh_TW) translation on the new simpleui.pot.

I noticed that the plugin description string "A simple UI for KOReader" at _meta.lua:6 was not extracted into simpleui.pot. Although this string is only visible via long-press in the plugin manager, I manually added it to the PO files to ensure a complete localization coverage.