### PR TITLE
fix(module_clock): correct date translation and Word Clock tens separator

### DIFF
--- a/locale/ja.po
+++ b/locale/ja.po
@@ -3726,7 +3726,7 @@ msgstr "週連続"
 #: desktop_modules/module_clock.lua:234
 #: desktop_modules/module_clock.lua:259
 msgid "WORD_CLOCK_TENS_SEP"
-msgstr "WORD_CLOCK_TENS_SEP"
+msgstr ""
 
 #: sui_menu.lua:2553
 #: sui_settings_window.lua:310

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -3641,7 +3641,7 @@ msgstr "НЕДЕЛЬ ПОДРЯД"
 
 #: desktop_modules/module_clock.lua:234 desktop_modules/module_clock.lua:259
 msgid "WORD_CLOCK_TENS_SEP"
-msgstr "WORD_CLOCK_TENS_SEP"
+msgstr ""
 
 #: sui_menu.lua:2553 sui_settings_window.lua:310 sui_settings_window.lua:854
 msgid "Wallpaper"

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -3829,7 +3829,7 @@ msgstr "ПОСЛІДОВНІСТЬ ТИЖНІВ"
 
 #: desktop_modules/module_clock.lua:234 desktop_modules/module_clock.lua:259
 msgid "WORD_CLOCK_TENS_SEP"
-msgstr "WORD_CLOCK_TENS_SEP"
+msgstr ""
 
 #: sui_menu.lua:2633 sui_settings_window.lua:318 sui_settings_window.lua:862
 msgid "Wallpaper"

--- a/locale/vi.po
+++ b/locale/vi.po
@@ -3726,7 +3726,7 @@ msgstr "CHUỖI TUẦN"
 #: desktop_modules/module_clock.lua:234
 #: desktop_modules/module_clock.lua:259
 msgid "WORD_CLOCK_TENS_SEP"
-msgstr "WORD_CLOCK_TENS_SEP"
+msgstr ""
 
 #: sui_menu.lua:2553
 #: sui_settings_window.lua:310

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -2669,7 +2669,7 @@ msgstr "关闭"
 
 #: modules/module_clock.lua:261
 msgid "Oh"
-msgstr "Oh"
+msgstr "零"
 
 #: engines/sui_book_grid.lua:1979
 #: engines/sui_book_grid.lua:2005
@@ -4364,7 +4364,7 @@ msgstr "连续周数"
 
 #: modules/module_clock.lua:250
 msgid "WORD_CLOCK_TENS_SEP"
-msgstr "零"
+msgstr ""
 
 #: screens/sui_menu.lua:2731
 #: screens/sui_settings_window.lua:355

--- a/locale/zh_TW.po
+++ b/locale/zh_TW.po
@@ -341,7 +341,7 @@ msgstr "套用調色盤······"
 #: modules/module_clock.lua:61
 #: screens/sui_stats_windows.lua:2840
 msgid "April"
-msgstr "四月"
+msgstr "4月"
 
 #: modules/module_feat_coll.lua:206
 #: modules/module_feat_coll.lua:281
@@ -419,7 +419,7 @@ msgstr "概覽"
 #: modules/module_clock.lua:62
 #: screens/sui_stats_windows.lua:2841
 msgid "August"
-msgstr "八月"
+msgstr "8月"
 
 #: modules/module_coverdeck.lua:176
 #: modules/module_currently.lua:282
@@ -1140,7 +1140,7 @@ msgstr "閱讀天數"
 #: modules/module_clock.lua:63
 #: screens/sui_stats_windows.lua:2842
 msgid "December"
-msgstr "十二月"
+msgstr "12月"
 
 #: modules/module_reading_goals.lua:1039
 #: modules/module_currently.lua:1387
@@ -1479,7 +1479,7 @@ msgstr "精選收藏 — 點選以組態"
 #: modules/module_clock.lua:61
 #: screens/sui_stats_windows.lua:2840
 msgid "February"
-msgstr "二月"
+msgstr "2月"
 
 #: features/sui_quickactions.lua:409
 msgid "Fetching bookmarks…"
@@ -1915,17 +1915,17 @@ msgstr "項目"
 #: modules/module_clock.lua:61
 #: screens/sui_stats_windows.lua:2840
 msgid "January"
-msgstr "一月"
+msgstr "1月"
 
 #: modules/module_clock.lua:62
 #: screens/sui_stats_windows.lua:2841
 msgid "July"
-msgstr "七月"
+msgstr "7月"
 
 #: modules/module_clock.lua:62
 #: screens/sui_stats_windows.lua:2841
 msgid "June"
-msgstr "六月"
+msgstr "6月"
 
 #: modules/module_quick_actions.lua:762
 msgid "Justified"
@@ -2110,7 +2110,7 @@ msgstr "手動追蹤的書籍（%s）"
 #: modules/module_clock.lua:61
 #: screens/sui_stats_windows.lua:2840
 msgid "March"
-msgstr "三月"
+msgstr "3月"
 
 #: screens/sui_quicksettings_bar.lua:443
 #: screens/sui_quicksettings_bar.lua:549
@@ -2124,7 +2124,7 @@ msgstr "已達最多欄位限制。"
 #: modules/module_clock.lua:62
 #: screens/sui_stats_windows.lua:2841
 msgid "May"
-msgstr "五月"
+msgstr "5月"
 
 #: screens/sui_titlebar.lua:102
 #: screens/sui_titlebar.lua:107
@@ -2627,7 +2627,7 @@ msgstr "筆記"
 #: modules/module_clock.lua:63
 #: screens/sui_stats_windows.lua:2842
 msgid "November"
-msgstr "十一月"
+msgstr "11月"
 
 #: engines/sui_book_grid.lua:1761
 #: engines/sui_book_grid.lua:1762
@@ -2653,7 +2653,7 @@ msgstr "確定"
 #: modules/module_clock.lua:63
 #: screens/sui_stats_windows.lua:2842
 msgid "October"
-msgstr "十月"
+msgstr "10月"
 
 #: engines/sui_book_grid.lua:1979
 #: engines/sui_book_grid.lua:2005
@@ -3456,7 +3456,7 @@ msgstr "經典復古棕"
 #: modules/module_clock.lua:63
 #: screens/sui_stats_windows.lua:2842
 msgid "September"
-msgstr "九月"
+msgstr "9月"
 
 #: modules/module_currently.lua:283
 #: features/sui_quickactions.lua:897
@@ -4364,7 +4364,7 @@ msgstr "連續閱讀週數"
 
 #: modules/module_clock.lua:250
 msgid "WORD_CLOCK_TENS_SEP"
-msgstr "零"
+msgstr ""
 
 #: screens/sui_menu.lua:2731
 #: screens/sui_settings_window.lua:355

--- a/modules/module_clock.lua
+++ b/modules/module_clock.lua
@@ -47,7 +47,7 @@ local function _localDate()
     -- fails. os.date("*t", os.time()) is always safe.
     local now = os.time()
     local t   = os.date("*t", now)
-    if not t or not t.mday then
+    if not t or not t.day then
         -- Fallback via the datetime module's locale-aware formatter.
         return datetime.secondsToDate(now, true)
     end
@@ -65,7 +65,7 @@ local function _localDate()
     end
     local weekday = _weekdays[t.wday] or os.date("%A", now)
     local month   = _months[t.month]  or os.date("%B", now)
-    return string.format("%s, %d %s", weekday, t.mday, month)
+    return string.format("%s, %d %s", weekday, t.day, month)
 end
 
 -- ---------------------------------------------------------------------------
@@ -246,9 +246,22 @@ local function _wcCache()
         [2] = _("Twenty"), [3] = _("Thirty"),
         [4] = _("Forty"),  [5] = _("Fifty"),
     }
-    -- Fallback to "-" if the translator left WORD_CLOCK_TENS_SEP untranslated.
+    -- Fallback depends on the script family: CJK and Cyrillic languages
+    -- write tens+units directly with no separator ("二十一", "двадцатьодин");
+    -- English needs an explicit "-" (kept here so untranslated English
+    -- locales still read "Twenty-One"); languages that already provide a
+    -- translation (bg " и", pt " e ", cs " ", etc.) override this default.
     local sep = _("WORD_CLOCK_TENS_SEP")
-    _wc_sep_cache = (sep == "WORD_CLOCK_TENS_SEP") and "-" or sep
+    if sep == "WORD_CLOCK_TENS_SEP" then
+        -- KOReader stores "English" as locale "C" (the POSIX default — see
+        -- frontend/ui/language.lua's getLangMenuTable); ICU-style codes
+        -- like "en_GB" / "en_US" share the "en" prefix. Treat both as
+        -- English so all three read "Twenty-One" by default.
+        local lang   = G_reader_settings and G_reader_settings:readSetting("language") or ""
+        local prefix = lang:match("^([a-zA-Z]+)") or ""
+        sep = (prefix == "en" or lang == "C") and "-" or ""
+    end
+    _wc_sep_cache = sep
 end
 
 -- Converts a minute value [0..59] to its word representation.


### PR DESCRIPTION
1. Translation issue fixed by correcting t.mday to t.day (os.date("*t") has no mday field).
2. Improve tens separator logic and prevent incorrect display in non-hyphen languages.