### PR TITLE
chore(module_coverdeck): refactor tokenization and simplify rendering

### DIFF
--- a/locale/ja.po
+++ b/locale/ja.po
@@ -3726,7 +3726,7 @@ msgstr "週連続"
 #: desktop_modules/module_clock.lua:234
 #: desktop_modules/module_clock.lua:259
 msgid "WORD_CLOCK_TENS_SEP"
-msgstr "WORD_CLOCK_TENS_SEP"
+msgstr ""
 
 #: sui_menu.lua:2553
 #: sui_settings_window.lua:310

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -3641,7 +3641,7 @@ msgstr "НЕДЕЛЬ ПОДРЯД"
 
 #: desktop_modules/module_clock.lua:234 desktop_modules/module_clock.lua:259
 msgid "WORD_CLOCK_TENS_SEP"
-msgstr "WORD_CLOCK_TENS_SEP"
+msgstr ""
 
 #: sui_menu.lua:2553 sui_settings_window.lua:310 sui_settings_window.lua:854
 msgid "Wallpaper"

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -3829,7 +3829,7 @@ msgstr "ПОСЛІДОВНІСТЬ ТИЖНІВ"
 
 #: desktop_modules/module_clock.lua:234 desktop_modules/module_clock.lua:259
 msgid "WORD_CLOCK_TENS_SEP"
-msgstr "WORD_CLOCK_TENS_SEP"
+msgstr ""
 
 #: sui_menu.lua:2633 sui_settings_window.lua:318 sui_settings_window.lua:862
 msgid "Wallpaper"

--- a/locale/vi.po
+++ b/locale/vi.po
@@ -3726,7 +3726,7 @@ msgstr "CHUỖI TUẦN"
 #: desktop_modules/module_clock.lua:234
 #: desktop_modules/module_clock.lua:259
 msgid "WORD_CLOCK_TENS_SEP"
-msgstr "WORD_CLOCK_TENS_SEP"
+msgstr ""
 
 #: sui_menu.lua:2553
 #: sui_settings_window.lua:310

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -2669,7 +2669,7 @@ msgstr "关闭"
 
 #: modules/module_clock.lua:261
 msgid "Oh"
-msgstr "Oh"
+msgstr "零"
 
 #: engines/sui_book_grid.lua:1979
 #: engines/sui_book_grid.lua:2005
@@ -4364,7 +4364,7 @@ msgstr "连续周数"
 
 #: modules/module_clock.lua:250
 msgid "WORD_CLOCK_TENS_SEP"
-msgstr "零"
+msgstr ""
 
 #: screens/sui_menu.lua:2731
 #: screens/sui_settings_window.lua:355

--- a/locale/zh_TW.po
+++ b/locale/zh_TW.po
@@ -341,7 +341,7 @@ msgstr "套用調色盤······"
 #: modules/module_clock.lua:61
 #: screens/sui_stats_windows.lua:2840
 msgid "April"
-msgstr "四月"
+msgstr "4月"
 
 #: modules/module_feat_coll.lua:206
 #: modules/module_feat_coll.lua:281
@@ -419,7 +419,7 @@ msgstr "概覽"
 #: modules/module_clock.lua:62
 #: screens/sui_stats_windows.lua:2841
 msgid "August"
-msgstr "八月"
+msgstr "8月"
 
 #: modules/module_coverdeck.lua:176
 #: modules/module_currently.lua:282
@@ -1140,7 +1140,7 @@ msgstr "閱讀天數"
 #: modules/module_clock.lua:63
 #: screens/sui_stats_windows.lua:2842
 msgid "December"
-msgstr "十二月"
+msgstr "12月"
 
 #: modules/module_reading_goals.lua:1039
 #: modules/module_currently.lua:1387
@@ -1479,7 +1479,7 @@ msgstr "精選收藏 — 點選以組態"
 #: modules/module_clock.lua:61
 #: screens/sui_stats_windows.lua:2840
 msgid "February"
-msgstr "二月"
+msgstr "2月"
 
 #: features/sui_quickactions.lua:409
 msgid "Fetching bookmarks…"
@@ -1915,17 +1915,17 @@ msgstr "項目"
 #: modules/module_clock.lua:61
 #: screens/sui_stats_windows.lua:2840
 msgid "January"
-msgstr "一月"
+msgstr "1月"
 
 #: modules/module_clock.lua:62
 #: screens/sui_stats_windows.lua:2841
 msgid "July"
-msgstr "七月"
+msgstr "7月"
 
 #: modules/module_clock.lua:62
 #: screens/sui_stats_windows.lua:2841
 msgid "June"
-msgstr "六月"
+msgstr "6月"
 
 #: modules/module_quick_actions.lua:762
 msgid "Justified"
@@ -2110,7 +2110,7 @@ msgstr "手動追蹤的書籍（%s）"
 #: modules/module_clock.lua:61
 #: screens/sui_stats_windows.lua:2840
 msgid "March"
-msgstr "三月"
+msgstr "3月"
 
 #: screens/sui_quicksettings_bar.lua:443
 #: screens/sui_quicksettings_bar.lua:549
@@ -2124,7 +2124,7 @@ msgstr "已達最多欄位限制。"
 #: modules/module_clock.lua:62
 #: screens/sui_stats_windows.lua:2841
 msgid "May"
-msgstr "五月"
+msgstr "5月"
 
 #: screens/sui_titlebar.lua:102
 #: screens/sui_titlebar.lua:107
@@ -2627,7 +2627,7 @@ msgstr "筆記"
 #: modules/module_clock.lua:63
 #: screens/sui_stats_windows.lua:2842
 msgid "November"
-msgstr "十一月"
+msgstr "11月"
 
 #: engines/sui_book_grid.lua:1761
 #: engines/sui_book_grid.lua:1762
@@ -2653,7 +2653,7 @@ msgstr "確定"
 #: modules/module_clock.lua:63
 #: screens/sui_stats_windows.lua:2842
 msgid "October"
-msgstr "十月"
+msgstr "10月"
 
 #: engines/sui_book_grid.lua:1979
 #: engines/sui_book_grid.lua:2005
@@ -3456,7 +3456,7 @@ msgstr "經典復古棕"
 #: modules/module_clock.lua:63
 #: screens/sui_stats_windows.lua:2842
 msgid "September"
-msgstr "九月"
+msgstr "9月"
 
 #: modules/module_currently.lua:283
 #: features/sui_quickactions.lua:897
@@ -4364,7 +4364,7 @@ msgstr "連續閱讀週數"
 
 #: modules/module_clock.lua:250
 msgid "WORD_CLOCK_TENS_SEP"
-msgstr "零"
+msgstr ""
 
 #: screens/sui_menu.lua:2731
 #: screens/sui_settings_window.lua:355

--- a/modules/module_clock.lua
+++ b/modules/module_clock.lua
@@ -47,7 +47,7 @@ local function _localDate()
     -- fails. os.date("*t", os.time()) is always safe.
     local now = os.time()
     local t   = os.date("*t", now)
-    if not t or not t.mday then
+    if not t or not t.day then
         -- Fallback via the datetime module's locale-aware formatter.
         return datetime.secondsToDate(now, true)
     end
@@ -65,7 +65,7 @@ local function _localDate()
     end
     local weekday = _weekdays[t.wday] or os.date("%A", now)
     local month   = _months[t.month]  or os.date("%B", now)
-    return string.format("%s, %d %s", weekday, t.mday, month)
+    return string.format("%s, %d %s", weekday, t.day, month)
 end
 
 -- ---------------------------------------------------------------------------
@@ -246,9 +246,22 @@ local function _wcCache()
         [2] = _("Twenty"), [3] = _("Thirty"),
         [4] = _("Forty"),  [5] = _("Fifty"),
     }
-    -- Fallback to "-" if the translator left WORD_CLOCK_TENS_SEP untranslated.
+    -- Fallback depends on the script family: CJK and Cyrillic languages
+    -- write tens+units directly with no separator ("二十一", "двадцатьодин");
+    -- English needs an explicit "-" (kept here so untranslated English
+    -- locales still read "Twenty-One"); languages that already provide a
+    -- translation (bg " и", pt " e ", cs " ", etc.) override this default.
     local sep = _("WORD_CLOCK_TENS_SEP")
-    _wc_sep_cache = (sep == "WORD_CLOCK_TENS_SEP") and "-" or sep
+    if sep == "WORD_CLOCK_TENS_SEP" then
+        -- KOReader stores "English" as locale "C" (the POSIX default — see
+        -- frontend/ui/language.lua's getLangMenuTable); ICU-style codes
+        -- like "en_GB" / "en_US" share the "en" prefix. Treat both as
+        -- English so all three read "Twenty-One" by default.
+        local lang   = G_reader_settings and G_reader_settings:readSetting("language") or ""
+        local prefix = lang:match("^([a-zA-Z]+)") or ""
+        sep = (prefix == "en" or lang == "C") and "-" or ""
+    end
+    _wc_sep_cache = sep
 end
 
 -- Converts a minute value [0..59] to its word representation.

--- a/modules/module_coverdeck.lua
+++ b/modules/module_coverdeck.lua
@@ -77,79 +77,38 @@ end
 -- ---------------------------------------------------------------------------
 -- Author list rendering
 -- ---------------------------------------------------------------------------
--- Author strings arrive as a single comma-separated string ("A, B, C").
--- Rendering rules, in priority order:
--- 1. keep at most 5 authors, joined with ", ";
--- 2. if the full list doesn't fit max_chars, drop names from the tail one
---    at a time and append " et al." to whatever remains, as long as that
---    combined string still fits;
--- 3. if even "Name1 et al." doesn't fit, fall back to truncating Name1 alone.
-local _ET_AL = _(" et al.")
-
-local function _utf8len(s)
-    if not s then return 0 end
-    local count, i = 0, 1
-    while i <= #s do
-        local b = s:byte(i)
-        local len
-        if     b >= 240 then len = 4
-        elseif b >= 224 then len = 3
-        elseif b >= 192 then len = 2
-        else                     len = 1
-        end
-        count = count + 1
-        i = i + len
-    end
-    return count
-end
-
+-- Author strings arrive as a single newline-separated string ("A\nB\nC").
+-- Aligned with KOReader's actual data format. 
+-- _splitAuthors breaks it into names (trimmed, empty tokens dropped). 
+-- _formatAuthors renders the result with these rules:
+-- 1. empty/whitespace input → "Unknown Author";
+-- 2. single author          → returned verbatim;
+-- 3. two or more author     → "Name1 et al."
+--    only the first name is kept, every other co-author is discarded.
 local function _splitAuthors(s)
-    local out = {}
-    if not s then return out end
-    for token in s:gmatch("([^,]+)") do
-        local trimmed = token:gsub("^%s+", ""):gsub("%s+$", "")
-        if trimmed ~= "" then
-            out[#out + 1] = trimmed
+    local parts = {}
+    if not s or s == "" then return parts end
+    for piece in (s .. "\n"):gmatch("(.-)\r?\n") do
+        local trimmed = piece:match("^%s*(.-)%s*$")
+        if trimmed and trimmed ~= "" then
+            parts[#parts + 1] = trimmed
         end
     end
-    return out
+    return parts
 end
 
-local function _renderAuthors(authors_str, max_chars)
-    if not authors_str or authors_str == "" then return "" end
-    local list = _splitAuthors(authors_str)
-    local n = #list
-
-    if n == 0 then return _("Unknown Author") end
-    if n == 1 then
-        return truncateTitle(list[1], max_chars)
-    end
-    if n > 5 then
-        list = { list[1], list[2], list[3], list[4], list[5] }
-        n = 5
-    end
-
-    -- Try the full list first, then progressively drop names from the
-    -- tail. Each candidate is checked with its " et al." suffix already
-    -- attached, so the suffix's own length is always accounted for.
-    for keep = n, 1, -1 do
-        local head      = table.concat(list, ", ", 1, keep)
-        local candidate = (keep < n) and (head .. _ET_AL) or head
-        if _utf8len(candidate) <= max_chars then
-            return candidate
-        end
-    end
-
-    -- Not even "Name1 et al." fits: fall back to truncating the first
-    -- author's name on its own.
-    return truncateTitle(list[1], max_chars)
+local function _formatAuthors(authors_str)
+    local parts = _splitAuthors(authors_str)
+    if #parts == 0 then return _("Unknown Author") end
+    if #parts == 1 then return parts[1] end
+    return parts[1] .. _(" et al.")
 end
 
 -- ---------------------------------------------------------------------------
 -- Settings keys
 -- ---------------------------------------------------------------------------
 
-local SETTING_SOURCE        = "coverdeck_source"         -- pfx .. this; "recent"|"tbr"
+local SETTING_SOURCE        = "coverdeck_source"          -- pfx .. this; "recent"|"tbr"
 local SETTING_SHOW_FINISHED = "coverdeck_show_finished"   -- pfx .. this; default OFF
 local ELEM_ORDER_KEY        = "coverdeck_stats_order"     -- pfx .. this
 local MAIN_ORDER_KEY        = "coverdeck_main_order"      -- pfx .. this
@@ -848,7 +807,7 @@ function M.build(w, ctx)
         local author_fs   = math.floor(SUIStyle.FS_SUBTITLE * scale * lbl_scale)
         local face_author = Font:getFace(SUIStyle.FACE_REGULAR, math.max(8, author_fs))
         author_widget = UI.makeColoredText{
-            text            = _renderAuthors(bd.authors, 20),
+            text            = _formatAuthors(bd.authors),
             face            = face_author,
             fgcolor         = CLR_TEXT_SUB_EFF,
             width           = inner_w,


### PR DESCRIPTION
1. Change author separator from ", " to "\n" to align with KOReader's actual data format.
2. Simplify rendering rules: keep only the first author and discard the rest, multiple authors are now rendered as "Name1 et al.".