### PR TITLE
Optional Rakuyomi manga integration + Bar Injection safety net

### DIFF
--- a/infra/sui_patches.lua
+++ b/infra/sui_patches.lua
@@ -1968,6 +1968,15 @@ function M.patchUIManagerShow(plugin)
         local extra_args = n_extra > 0 and { ... } or _EMPTY
         _show_depth = _show_depth + 1
 
+        -- Set true the moment orig_show() has been reached inside the pcall
+        -- below (whether via the passthrough branch or after a full
+        -- injection). If the pcall throws *before* this — e.g. a Bar
+        -- Injection target whose widget structure the injection pipeline
+        -- can't wrap — the error handler shows the widget unadorned rather
+        -- than letting it be swallowed (no orig_show → blank screen, caller
+        -- stuck on the previous view).
+        local navbar_shown = false
+
         -- Wrap in pcall so _show_depth is always decremented even on error.
         local ok, result = pcall(function()
 
@@ -1990,6 +1999,7 @@ function M.patchUIManagerShow(plugin)
                  or _bi_desc ~= nil)
 
         if not should_inject then
+            navbar_shown = true
             if n_extra > 0 then
                 return orig_show(um_self, widget, table.unpack(extra_args))
             else
@@ -2219,6 +2229,7 @@ function M.patchUIManagerShow(plugin)
 
         Bottombar.resizePaginationButtons(widget, Bottombar.getPaginationIconSize())
 
+        navbar_shown = true
         if n_extra > 0 then
             orig_show(um_self, widget, table.unpack(extra_args))
         else
@@ -2287,6 +2298,20 @@ function M.patchUIManagerShow(plugin)
         _show_depth = _show_depth - 1
         if not ok then
             logger.warn("simpleui: UIManager.show error:", tostring(result))
+            -- Injection threw before the widget was shown — show it now,
+            -- unadorned, so it can never be lost. Guarded so a widget that
+            -- errored *after* orig_show is not shown twice.
+            if widget and not navbar_shown and not widget._navbar_show_fallback then
+                widget._navbar_show_fallback = true
+                widget._navbar_skip_inject   = true
+                pcall(function()
+                    if n_extra > 0 then
+                        orig_show(um_self, widget, table.unpack(extra_args))
+                    else
+                        orig_show(um_self, widget)
+                    end
+                end)
+            end
         end
 
         -- Close the homescreen when a different fullscreen widget appears on top.

--- a/main.lua
+++ b/main.lua
@@ -948,8 +948,12 @@ function SimpleUIPlugin:init()
 
         if SUISettings:nilOrTrue("simpleui_enabled") then
             Patches.installAll(self)
-            
+
             pcall(function() QSBar.install() end)
+            -- Rakuyomi integration: home-screen library row, chapter filtering,
+            -- navbar-on-vnds descriptor, and a deferred backend warm-up. Self-
+            -- contained and pcall-guarded — no-op when Rakuyomi isn't present.
+            pcall(function() require("modules/sui_rakuyomi").install(self) end)
             -- Register the TBR button in the Library hold dialog (single book).
             -- addFileDialogButtons is the official KOReader API for this.
             -- The multi-selection button is injected via patchGetPlusDialogButtons
@@ -1310,6 +1314,8 @@ local _PLUGIN_MODULES = {
     "modules/module_new_books",
     "modules/module_tbr",
     "modules/module_feat_coll",
+    "modules/module_rakuyomi_row",
+    "modules/sui_rakuyomi",
     "modules/quotes",
     "infra/sui_custom_screens",
     "engines/sui_screen_engine",

--- a/modules/module_rakuyomi_row.lua
+++ b/modules/module_rakuyomi_row.lua
@@ -1,0 +1,422 @@
+-- module_rakuyomi_row.lua — Simple UI
+-- Home-screen cover row showing your Rakuyomi manga library, sorted by most
+-- recently read. Same visual layout as Recent Books (module_recent.lua),
+-- but built independently rather than through GridRenderer.makeModule: that
+-- factory assumes every item is a real on-disk document (cover extraction,
+-- title lookup and the tap handler all key off a KOReader-openable `fp`),
+-- which a manga library entry is not — a manga is metadata plus a set of
+-- separately-downloaded chapters, not a single file.
+--
+-- REQUIRES the tachibana-shin/rakuyomi fork specifically (koplugin name
+-- "rakuyomi"). The original hanatsumi/rakuyomi (now archived) has no cover
+-- art, no "continue reading" action and no local cover cache to read from,
+-- so this row simply won't populate if that's what's installed instead —
+-- every call in here is pcall-guarded and the whole module degrades to
+-- "renders nothing" rather than erroring.
+--
+-- Reaches into two of the fork's own Lua modules (require("Backend"),
+-- require("LibraryView")) because there's no public plugin API for "list my
+-- library" or "resume this manga" — same require() gets whichever koplugin
+-- first defined that module name, and neither name is namespaced, so a
+-- sanity check (expected functions present) runs before every use. This is
+-- inherently coupled to the fork's current internal layout and can break on
+-- a future Rakuyomi update.
+--
+-- The backend server is started lazily by Rakuyomi itself (on first opening
+-- its library view), NOT at KOReader startup — starting it ourselves would
+-- block the UI for several seconds (or minutes on slow devices, per its own
+-- startup-timeout constants) the very first time the home screen paints. So
+-- this row only ever queries an already-running backend (Backend.getInitialized()
+-- gate below); the module_sui_rakuyomi glue warms it up a few seconds after
+-- boot so the row fills in without the user opening Rakuyomi first.
+
+local Blitbuffer      = require("ffi/blitbuffer")
+local Font            = require("ui/font")
+local FrameContainer  = require("ui/widget/container/framecontainer")
+local Geom            = require("ui/geometry")
+local GestureRange    = require("ui/gesturerange")
+local HorizontalGroup = require("ui/widget/horizontalgroup")
+local HorizontalSpan  = require("ui/widget/horizontalspan")
+local InputContainer  = require("ui/widget/container/inputcontainer")
+local VerticalGroup   = require("ui/widget/verticalgroup")
+local _ = require("infra/sui_i18n").translate
+
+local Config      = require("infra/sui_config")
+local UI          = require("infra/sui_core")
+local SUISettings = require("infra/sui_store")
+local SUIStyle    = require("features/sui_style")
+local GridRenderer = require("engines/sui_book_grid")
+local PAD    = UI.PAD
+local Screen = require("device").screen
+
+local CLR_TEXT_SUB = UI.CLR_TEXT_SUB
+local ID = "rakuyomi_row"
+
+local _SH = nil
+local function getSH()
+    if not _SH then
+        local ok, m = pcall(require, "modules/module_books_shared")
+        if ok and m then _SH = m end
+    end
+    return _SH
+end
+
+-- ---------------------------------------------------------------------------
+-- Rakuyomi plugin detection / Backend access
+-- ---------------------------------------------------------------------------
+
+local function _rakuyomiInstance()
+    local ok_pl, PluginLoader = pcall(require, "pluginloader")
+    if not (ok_pl and PluginLoader) then return nil end
+    local ok_inst, inst = pcall(PluginLoader.getPluginInstance, PluginLoader, "rakuyomi")
+    if not (ok_inst and inst) then return nil end
+    return inst
+end
+
+-- Returns the fork's Backend module, but only once its server is already
+-- running (see the file-header note on why we never start it ourselves),
+-- and only after a shape check so a same-named module from some unrelated
+-- koplugin can't be mistaken for it.
+local function _getBackend()
+    if not _rakuyomiInstance() then return nil end
+    local ok, Backend = pcall(require, "Backend")
+    if not (ok and type(Backend) == "table"
+                and type(Backend.getMangasInLibrary) == "function"
+                and type(Backend.getInitialized)     == "function"
+                and type(Backend.requestJson)         == "function") then
+        return nil
+    end
+    if not Backend.getInitialized() then return nil end
+    return Backend
+end
+
+-- ---------------------------------------------------------------------------
+-- Library fetch — short TTL cache so repeated home-screen repaints don't
+-- each pay for an HTTP round trip to the backend.
+-- ---------------------------------------------------------------------------
+local _cached_mangas, _cached_mangas_time = nil, 0
+local _CACHE_TTL = 60
+
+local function _getLibraryMangas()
+    local now = os.time()
+    if _cached_mangas and (now - _cached_mangas_time < _CACHE_TTL) then
+        return _cached_mangas
+    end
+    local Backend = _getBackend()
+    if not Backend then return nil end
+    local ok, response = pcall(Backend.requestJson, { path = "/library", timeout = 3 })
+    if not (ok and type(response) == "table" and response.type == "SUCCESS"
+                and type(response.body) == "table") then
+        -- Transient failure (backend busy/slow) — keep serving the last good
+        -- list rather than blanking the row.
+        return _cached_mangas
+    end
+    local mangas = response.body
+    table.sort(mangas, function(a, b) return (a.last_read or 0) > (b.last_read or 0) end)
+    _cached_mangas  = mangas
+    _cached_mangas_time = now
+    return mangas
+end
+
+-- ---------------------------------------------------------------------------
+-- Cover loading — Rakuyomi caches a real local image per manga (exposed as
+-- a `file://` URI); this is a plain picture file, not a document, so it goes
+-- through ui/renderimage directly rather than SH.getBookCover's
+-- BookInfoManager/document-cover-extraction path (which expects an openable
+-- book and would not know what to do with a bare jpg).
+-- ---------------------------------------------------------------------------
+local function _filePathFromCoverURI(uri)
+    if type(uri) ~= "string" or uri:sub(1, 7) ~= "file://" then return nil end
+    local path = uri:sub(8)
+    path = path:gsub("%%(%x%x)", function(hex) return string.char(tonumber(hex, 16)) end)
+    return path
+end
+
+-- Decode + scale-to-fill + center-crop to exactly w×h, mirroring the visual
+-- treatment sui_config.lua's cover pipeline applies to book covers.
+local function _decodeCoverToBB(path, w, h)
+    local ok_ri, RenderImage = pcall(require, "ui/renderimage")
+    if not (ok_ri and RenderImage) then return nil end
+    local ok_bb, bb = pcall(RenderImage.renderImageFile, RenderImage, path, false, w, h)
+    if not (ok_bb and bb) then return nil end
+    local src_w, src_h = bb:getWidth(), bb:getHeight()
+    if src_w <= 0 or src_h <= 0 then return bb end
+    if src_w == w and src_h == h then return bb end
+    local scale = math.max(w / src_w, h / src_h)
+    local sw, sh = math.floor(src_w * scale + 0.5), math.floor(src_h * scale + 0.5)
+    local ok_sc, scaled = pcall(RenderImage.scaleBlitBuffer, RenderImage, bb, sw, sh, true)
+    if not (ok_sc and scaled) then return bb end
+    if sw == w and sh == h then return scaled end
+    local ok_slot, slot = pcall(Blitbuffer.new, w, h, scaled:getType())
+    if not (ok_slot and slot) then return scaled end
+    local sx = math.floor((sw - w) / 2)
+    local sy = math.floor((sh - h) / 2)
+    pcall(slot.blitFrom, slot, scaled, 0, 0, sx, sy, w, h)
+    pcall(scaled.free, scaled)
+    return slot
+end
+
+-- path|WxH -> BlitBuffer, or `false` to remember a decode failure without
+-- retrying it every repaint. Cleared on M.reset().
+local _cover_cache = {}
+
+local function _getCoverBB(cover_uri, w, h)
+    local path = _filePathFromCoverURI(cover_uri)
+    if not path then return nil end
+    local key = path .. "|" .. w .. "x" .. h
+    local cached = _cover_cache[key]
+    if cached ~= nil then return cached or nil end
+    local ok_lfs, lfs = pcall(require, "libs/libkoreader-lfs")
+    if not (ok_lfs and lfs and lfs.attributes(path, "mode") == "file") then
+        _cover_cache[key] = false
+        return nil
+    end
+    local bb = _decodeCoverToBB(path, w, h)
+    _cover_cache[key] = bb or false
+    return bb
+end
+
+-- Same bordered-frame treatment SH.getBookCover gives book covers.
+local function _wrapCover(bb, w, h)
+    local ok_img, img = pcall(function()
+        return require("ui/widget/imagewidget"):new{
+            image             = bb,
+            image_disposable  = false,
+            width             = w,
+            height            = h,
+            scale_factor      = 1,
+        }
+    end)
+    if not (ok_img and img) then return nil end
+    return FrameContainer:new{
+        bordersize = SUIStyle.BADGE_BORDER_SZ, color = Blitbuffer.COLOR_BLACK,
+        padding    = 0, margin = 0,
+        dimen      = Geom:new{ w = w, h = h },
+        img,
+    }
+end
+
+-- ---------------------------------------------------------------------------
+-- Tap → "Continue Reading": delegate to the fork's own LibraryView, which
+-- already implements finding the right next/last-read chapter (incl.
+-- language preference, confirm dialog, "no next chapter" messaging) — the
+-- exact behaviour "Continue Reading" has inside Rakuyomi's own library view.
+-- Called on the bare class table (no :new{} instance): the method only
+-- touches self.page / self.hide_top_close / self.current_playlist, all of
+-- which are fine to leave nil here.
+-- ---------------------------------------------------------------------------
+local function _openManga(manga)
+    if not (manga and _rakuyomiInstance()) then return end
+    local ok, LibraryView = pcall(require, "LibraryView")
+    if not (ok and type(LibraryView) == "table"
+                and type(LibraryView._handleContinueReading) == "function") then
+        return
+    end
+    pcall(LibraryView._handleContinueReading, LibraryView, manga)
+end
+
+-- ---------------------------------------------------------------------------
+-- Module
+-- ---------------------------------------------------------------------------
+local M = {}
+M.id          = ID
+M.name        = _("Rakuyomi Library")
+M.label       = _("Rakuyomi Library")
+M.enabled_key = ID .. "_enabled"
+M.default_on  = false
+M.has_covers  = true   -- e-ink dithering for the cover images (no updateCovers of our own — covers are decoded synchronously in build())
+M.is_book_mod = true   -- suppresses the "No books opened yet" empty-state when active
+
+function M.reset()
+    _cover_cache = {}
+    _cached_mangas, _cached_mangas_time = nil, 0
+end
+
+local MAX_ITEMS = 5
+
+function M.build(w, ctx)
+    local mangas = _getLibraryMangas()
+    if not mangas or #mangas == 0 then return nil end
+
+    local SH  = getSH()
+    if not SH then return nil end
+    local pfx = ctx.pfx
+
+    local COLOR = SUIStyle.COLOR or {}
+    local _clr_sub = COLOR.text_secondary or COLOR.text_primary or CLR_TEXT_SUB
+
+    local scale       = Config.getModuleScale(ID, pfx)
+    local thumb_scale = Config.getThumbScale(ID, pfx)
+    local lbl_scale   = Config.getItemLabelScale(ID, pfx)
+    local D = SH.getDims(scale, thumb_scale)
+
+    local cols    = math.min(#mangas, MAX_ITEMS)
+    local inner_w = w - PAD * 2
+
+    local cw, ch, gap
+    local cs = scale * thumb_scale
+    local autofit_cw = math.max(1, math.floor((inner_w - (MAX_ITEMS - 1) * PAD) / MAX_ITEMS))
+    if cs == 1.0 then
+        gap = PAD
+        cw  = autofit_cw
+        ch  = math.max(1, math.floor(cw * (D.RECENT_H / D.RECENT_W)))
+    else
+        cw  = math.max(1, math.floor(autofit_cw * cs))
+        ch  = math.max(1, math.floor(cw * (D.RECENT_H / D.RECENT_W)))
+        gap = MAX_ITEMS > 1 and math.floor((inner_w - MAX_ITEMS * cw) / (MAX_ITEMS - 1)) or 0
+    end
+
+    local lbl_fs   = math.max(8, math.floor(SUIStyle.FS_DETAIL * scale * lbl_scale))
+    local lbl_face = Font:getFace(SUIStyle.FACE_REGULAR, lbl_fs)
+    local ok_h, face_height = pcall(function() return lbl_face.ftsize:getHeightAndAscender() end)
+    local label_h = (ok_h and face_height and math.ceil(face_height)) or math.ceil(lbl_fs * 1.8)
+    local cell_h  = ch + D.RB_GAP1 + label_h
+
+    local row = HorizontalGroup:new{ align = "top" }
+    for i = 1, cols do
+        local manga = mangas[i]
+
+        local inner_w_cov = math.max(1, cw - 2 * SUIStyle.BADGE_BORDER_SZ)
+        local inner_h_cov = math.max(1, ch - 2 * SUIStyle.BADGE_BORDER_SZ)
+        local bb    = _getCoverBB(manga.manga_cover, inner_w_cov, inner_h_cov)
+        local cover = (bb and _wrapCover(bb, cw, ch))
+                      or SH.coverPlaceholder(manga.title,
+                            manga.source and manga.source.name, cw, ch)
+
+        local cell = VerticalGroup:new{}
+        table.insert(cell, cover)
+        table.insert(cell, SH.vspan(D.RB_GAP1, ctx.vspan_pool))
+        table.insert(cell, UI.makeColoredText{
+            text      = manga.title or "?",
+            face      = lbl_face,
+            fgcolor   = _clr_sub,
+            max_width = cw,
+            alignment = "center",
+        })
+
+        local tappable = InputContainer:new{
+            dimen  = Geom:new{ w = cw, h = cell_h },
+            [1]    = cell,
+            _manga = manga,
+        }
+        tappable.ges_events = {
+            TapBook = {
+                GestureRange:new{
+                    ges   = "tap",
+                    range = function() return tappable.dimen end,
+                },
+            },
+        }
+        function tappable:onTapBook()
+            _openManga(self._manga)
+            return true
+        end
+
+        if i > 1 then row[#row + 1] = HorizontalSpan:new{ width = gap } end
+        row[#row + 1] = tappable
+    end
+
+    local show_frame = GridRenderer.showFrame(pfx, ID)
+    local solid_bg    = GridRenderer.solidBg(pfx, ID)
+    local has_box     = show_frame or solid_bg
+    local border_sz   = show_frame and SUIStyle.BORDER_SZ or 0
+    local radius      = has_box and math.floor(Screen:scaleBySize(12) * scale) or 0
+    local border_color = COLOR.gray or Blitbuffer.gray(0.72)
+    local bg_color = solid_bg and (COLOR.surface or Blitbuffer.COLOR_WHITE) or nil
+
+    return FrameContainer:new{
+        bordersize = border_sz,
+        radius     = radius,
+        color      = border_color,
+        background = bg_color,
+        padding = PAD, padding_top = has_box and PAD or 0, padding_bottom = has_box and PAD or 0,
+        row,
+    }
+end
+
+-- Deliberately NOT GridRenderer.getHeight(): that formula always reserves
+-- progress-bar + double-gap space (so Recent/New Books/TBR stay a stable
+-- height across their progress-bar/text toggles) — this module never draws
+-- a progress bar at all (a manga doesn't have a single "% read"), so its
+-- own build() cell is shorter (cover + one gap + one label). getHeight must
+-- mirror that exact shape or the page layout reserves the wrong amount of
+-- space for it.
+function M.getHeight(ctx)
+    local SH = getSH()
+    if not SH then return 0 end
+    local pfx = ctx and ctx.pfx or ""
+    local scale       = Config.getModuleScale(ID, pfx)
+    local thumb_scale = Config.getThumbScale(ID, pfx)
+    local lbl_scale   = Config.getItemLabelScale(ID, pfx)
+    local D = SH.getDims(scale, thumb_scale)
+
+    local w = (ctx and (ctx.col_w or ctx.inner_w)) or (Screen:getWidth() - UI.SIDE_PAD * 2)
+    local inner_w = w - PAD * 2
+    local autofit_cw = math.max(1, math.floor((inner_w - (MAX_ITEMS - 1) * PAD) / MAX_ITEMS))
+    local cs = scale * thumb_scale
+    local cw = (cs == 1.0) and autofit_cw or math.max(1, math.floor(autofit_cw * cs))
+    local ch = math.max(1, math.floor(cw * (D.RECENT_H / D.RECENT_W)))
+
+    local lbl_fs   = math.max(8, math.floor(SUIStyle.FS_DETAIL * scale * lbl_scale))
+    local lbl_face = Font:getFace(SUIStyle.FACE_REGULAR, lbl_fs)
+    local ok_h, face_height = pcall(function() return lbl_face.ftsize:getHeightAndAscender() end)
+    local label_h = (ok_h and face_height and math.ceil(face_height)) or math.ceil(lbl_fs * 1.8)
+
+    local h = ch + D.RB_GAP1 + label_h
+
+    local show_frame = GridRenderer.showFrame(pfx, ID)
+    if show_frame or GridRenderer.solidBg(pfx, ID) then
+        h = h + PAD * 2
+    end
+    if show_frame then
+        h = h + SUIStyle.BORDER_SZ * 2
+    end
+    return Config.getScaledLabelH() + h
+end
+
+function M.getMenuItems(ctx_menu)
+    local _lc     = ctx_menu._
+    local refresh = ctx_menu.refresh
+    local pfx     = ctx_menu.pfx
+
+    return {
+        Config.makeScaleItem{
+            text_func    = function() return _lc("Scale") end,
+            enabled_func = function() return not Config.isScaleLinked() end,
+            title        = _lc("Scale"),
+            info         = _lc("Scale for this module.\n100% is the default size."),
+            get          = function() return Config.getModuleScalePct(ID, pfx) end,
+            set          = function(v) Config.setModuleScale(v, ID, pfx) end,
+            refresh      = refresh,
+        },
+        Config.makeScaleItem{
+            text_func = function() return _lc("Cover Size") end,
+            separator = true,
+            title     = _lc("Cover Size"),
+            info      = _lc("Scale for the cover thumbnails only.\n100% is the default size."),
+            get       = function() return Config.getThumbScalePct(ID, pfx) end,
+            set       = function(v) Config.setThumbScale(v, ID, pfx) end,
+            refresh   = refresh,
+        },
+        {
+            text           = _lc("Frame"),
+            checked_func   = function() return GridRenderer.showFrame(pfx, ID) end,
+            keep_menu_open = true,
+            callback       = function()
+                SUISettings:saveSetting(pfx .. ID .. "_show_frame", not GridRenderer.showFrame(pfx, ID))
+                refresh()
+            end,
+        },
+        {
+            text           = _lc("Solid Background"),
+            checked_func   = function() return GridRenderer.solidBg(pfx, ID) end,
+            keep_menu_open = true,
+            callback       = function()
+                SUISettings:saveSetting(pfx .. ID .. "_solid_bg", not GridRenderer.solidBg(pfx, ID))
+                refresh()
+            end,
+        },
+    }
+end
+
+return M

--- a/modules/sui_rakuyomi.lua
+++ b/modules/sui_rakuyomi.lua
@@ -1,0 +1,214 @@
+-- modules/sui_rakuyomi.lua — Simple UI × Rakuyomi integration glue.
+--
+-- One entry point, M.install(plugin), called once from main.lua:init().
+-- It wires four otherwise-independent pieces, each pcall-guarded so a
+-- missing/renamed dependency degrades to "does nothing" rather than
+-- breaking the plugin:
+--
+--   1. Registers modules/module_rakuyomi_row (the home-screen cover row)
+--      as an external module via moduleregistry's public register() API —
+--      no edit to the built-in MODULES list.
+--
+--   2. Registers a Bar Injection descriptor so the Simple UI navbar stays
+--      visible on the `vnds` plugin's library screen (matched by widget
+--      name). Passive: zero effect unless that plugin is installed and its
+--      screen actually carries the tag.
+--
+--   3. Wraps SH.prefetchBooks so Rakuyomi's downloaded chapter files
+--      (stored under `<koreader>/rakuyomi/…/<chapter>.cbz`, which land in
+--      ReadHistory like any book) never appear in Currently Reading /
+--      Recent Books. Done by hiding those entries from ReadHistory.hist for
+--      the duration of the prefetch call only — no edit to
+--      module_books_shared.lua, and the "current slot falls through to the
+--      next real book" behaviour comes for free from the unmodified
+--      prefetch logic.
+--
+--   4. A few seconds after boot (off the first-paint path), warms up
+--      Rakuyomi's HTTP backend so the row from (1) can populate without the
+--      user opening Rakuyomi once per session. Rakuyomi starts that backend
+--      lazily on first opening its library view; Backend.initialize()'s
+--      health-check wait blocks for seconds (minutes on slow devices), so
+--      this is deliberately deferred and gated on the row being enabled.
+--
+-- Everything Rakuyomi-side (require("Backend") / require("Platform") /
+-- require("LibraryView")) is coupled to the tachibana-shin/rakuyomi fork's
+-- current internal layout and may break on a future Rakuyomi update — hence
+-- the shape checks before every use.
+
+local UIManager = require("ui/uimanager")
+local UI        = require("infra/sui_core")
+
+local ROW_ID          = "rakuyomi_row"
+local ROW_ENABLED_KEY = ROW_ID .. "_enabled"
+local ROW_MODULE      = "modules/module_rakuyomi_row"
+
+local M = {}
+local _installed = false
+
+-- ---------------------------------------------------------------------------
+-- 1. Home-screen row
+-- ---------------------------------------------------------------------------
+local function _registerRow()
+    local ok, Registry = pcall(require, "modules/moduleregistry")
+    if not (ok and Registry and type(Registry.register) == "function") then return end
+    Registry.register(ROW_MODULE)
+end
+
+-- ---------------------------------------------------------------------------
+-- 2. Bar Injection descriptor for the vnds plugin's library screen
+-- ---------------------------------------------------------------------------
+local function _registerBarInjection()
+    if not (UI and UI.BarInjection and type(UI.BarInjection.register) == "function") then return end
+    -- is_pageable is left unset so it falls back to the same page_num
+    -- auto-detection used for the native Collections/History cases.
+    UI.BarInjection.register{
+        id          = "vnds_library",
+        widget_name = "vnds_library",
+    }
+end
+
+-- ---------------------------------------------------------------------------
+-- 3. Keep Rakuyomi chapters out of Currently Reading / Recent Books
+-- ---------------------------------------------------------------------------
+local function _isRakuyomiPath(fp)
+    return type(fp) == "string" and fp:lower():find("/rakuyomi/", 1, true) ~= nil
+end
+
+local function _installHistoryFilter()
+    local ok, SH = pcall(require, "modules/module_books_shared")
+    if not (ok and SH and type(SH.prefetchBooks) == "function") then return end
+    if SH._sui_rakuyomi_wrapped then return end   -- idempotent across hot-reload
+    SH._sui_rakuyomi_wrapped = true
+
+    local orig = SH.prefetchBooks
+    SH.prefetchBooks = function(...)
+        local ReadHistory = package.loaded["readhistory"] or require("readhistory")
+        local hist = ReadHistory and ReadHistory.hist
+        if type(hist) ~= "table" or #hist == 0 then
+            return orig(...)   -- nothing to filter (also skips the reload path)
+        end
+
+        local filtered, dropped = {}, false
+        for i = 1, #hist do
+            local e = hist[i]
+            if e and _isRakuyomiPath(e.file) then
+                dropped = true
+            else
+                filtered[#filtered + 1] = e
+            end
+        end
+        if not dropped then
+            return orig(...)   -- no manga chapters in history — fast path
+        end
+
+        ReadHistory.hist = filtered
+        local ok_call, state = pcall(orig, ...)
+        ReadHistory.hist = hist   -- always restore, even on error
+        if ok_call then return state end
+        return orig(...)          -- prefetch errored with the swap in place; retry clean
+    end
+end
+
+-- ---------------------------------------------------------------------------
+-- 4. Backend warm-up
+-- ---------------------------------------------------------------------------
+local function _rowEnabledAnywhere()
+    local ok, Registry = pcall(require, "modules/moduleregistry")
+    if not (ok and Registry and type(Registry.get) == "function") then return false end
+    local mod = Registry.get(ROW_ID)
+    if not mod then return false end
+    if Registry.isEnabled(mod, "simpleui_hs_") then return true end
+    local ok_cs, CS = pcall(require, "infra/sui_custom_screens")
+    if ok_cs and CS and type(CS.list) == "function" then
+        local ok_l, screens = pcall(CS.list)
+        if ok_l and type(screens) == "table" then
+            for _, s in ipairs(screens) do
+                if s and s.pfx and Registry.isEnabled(mod, s.pfx) then return true end
+            end
+        end
+    end
+    return false
+end
+
+-- Repaint every screen that could be hosting the row, once the backend is
+-- confirmed serving. Mirrors the cache-invalidation pattern used elsewhere
+-- (see modules/module_coverdeck.lua).
+local function _refreshScreens()
+    local ok_m, RowMod = pcall(require, ROW_MODULE)
+    if ok_m and RowMod and type(RowMod.reset) == "function" then
+        pcall(RowMod.reset)
+    end
+    local ok, ScreenEngine = pcall(require, "engines/sui_screen_engine")
+    if not (ok and ScreenEngine and type(ScreenEngine.knownScreenIds) == "function") then return end
+    for _, sid in ipairs(ScreenEngine.knownScreenIds()) do
+        pcall(ScreenEngine.setCachedBooksState, sid, nil)
+        pcall(ScreenEngine.setCfgCache, sid, nil)
+        pcall(ScreenEngine.refreshScreen, sid, false)
+    end
+end
+
+local function _warmup()
+    if not _rowEnabledAnywhere() then return end
+
+    local ok_pl, PluginLoader = pcall(require, "pluginloader")
+    if not (ok_pl and PluginLoader) then return end
+    local ok_inst, inst = pcall(PluginLoader.getPluginInstance, PluginLoader, "rakuyomi")
+    if not (ok_inst and inst) then return end
+
+    local ok_b, Backend = pcall(require, "Backend")
+    if not (ok_b and type(Backend) == "table"
+                and type(Backend.getBackend)     == "function"
+                and type(Backend.getInitialized) == "function"
+                and type(Backend.requestJson)    == "function") then
+        return
+    end
+
+    -- Spawn the backend process now (Platform:startServer() returns
+    -- immediately) so that when getBackend() runs below, Backend.running()
+    -- is already true and its blocking health-check wait is skipped. If the
+    -- fork names Platform differently, getBackend() still works — it just
+    -- pays the blocking wait once, here, instead of on first paint.
+    if not Backend.getInitialized()
+            and type(Backend.running) == "function" and not Backend.running() then
+        local ok_plat, Platform = pcall(require, "Platform")
+        if ok_plat and type(Platform) == "table"
+                and type(Platform.startServer) == "function" then
+            pcall(function() Backend.server = Platform:startServer() end)
+        end
+    end
+
+    -- getBackend() flips backendInitialized once initialize() succeeds; then
+    -- probe /library (exactly what the row calls) to confirm the server
+    -- actually answers before repainting. Retry a few times with a short
+    -- gap rather than busy-waiting.
+    local function step(attempt)
+        pcall(Backend.getBackend)
+        local served = false
+        if Backend.getInitialized() then
+            local ok_req, resp = pcall(Backend.requestJson, { path = "/library", timeout = 2 })
+            served = ok_req and type(resp) == "table" and resp.type == "SUCCESS"
+        end
+        if served then
+            _refreshScreens()
+        elseif attempt < 8 then
+            UIManager:scheduleIn(2, function() step(attempt + 1) end)
+        end
+    end
+    step(1)
+end
+
+-- ---------------------------------------------------------------------------
+-- Entry point
+-- ---------------------------------------------------------------------------
+function M.install(_plugin)
+    if _installed then return end
+    _installed = true
+    pcall(_registerRow)
+    pcall(_registerBarInjection)
+    pcall(_installHistoryFilter)
+    -- scheduleIn(5) trails the module preload (2) and update check (3) in
+    -- main.lua:init(); well after the FileManager UI is painted and stable.
+    UIManager:scheduleIn(5, function() pcall(_warmup) end)
+end
+
+return M

--- a/modules/sui_rakuyomi.lua
+++ b/modules/sui_rakuyomi.lua
@@ -9,10 +9,16 @@
 --      as an external module via moduleregistry's public register() API —
 --      no edit to the built-in MODULES list.
 --
---   2. Registers a Bar Injection descriptor so the Simple UI navbar stays
---      visible on the `vnds` plugin's library screen (matched by widget
---      name). Passive: zero effect unless that plugin is installed and its
---      screen actually carries the tag.
+--   2. Registers Bar Injection descriptors so the Simple UI navbar stays
+--      visible on the `vnds` plugin's library screen and on Rakuyomi's
+--      LibraryView (both matched by widget name). Each descriptor also
+--      supplies get_active_action so the bottom bar lights up whichever tab
+--      launches that plugin. Passive: zero effect unless the plugin is
+--      installed and its screen actually carries the tag. Rakuyomi's
+--      LibraryView is a heavily customised MenuCustom widget the injection
+--      pipeline may fail to wrap — sui_patches.lua's show wrapper now shows
+--      the widget unadorned in that case rather than losing it, so the
+--      worst case is "no bar on that screen", never a blank screen.
 --
 --   3. Wraps SH.prefetchBooks so Rakuyomi's downloaded chapter files
 --      (stored under `<koreader>/rakuyomi/…/<chapter>.cbz`, which land in
@@ -38,9 +44,8 @@
 local UIManager = require("ui/uimanager")
 local UI        = require("infra/sui_core")
 
-local ROW_ID          = "rakuyomi_row"
-local ROW_ENABLED_KEY = ROW_ID .. "_enabled"
-local ROW_MODULE      = "modules/module_rakuyomi_row"
+local ROW_ID     = "rakuyomi_row"
+local ROW_MODULE = "modules/module_rakuyomi_row"
 
 local M = {}
 local _installed = false
@@ -55,15 +60,49 @@ local function _registerRow()
 end
 
 -- ---------------------------------------------------------------------------
--- 2. Bar Injection descriptor for the vnds plugin's library screen
+-- 2. Bar Injection descriptors — keep the navbar on vnds / Rakuyomi screens
 -- ---------------------------------------------------------------------------
+
+-- Find the bottom-bar tab (a custom Quick Action) that launches the plugin
+-- named by `needle`, so the injected screen can highlight the matching icon.
+-- Returns the tab id, or nil when the user has no such launcher in the bar
+-- (nothing to highlight — correct, not an error).
+local function _tabIdForPlugin(needle)
+    local ok, Config = pcall(require, "infra/sui_config")
+    if not (ok and Config and type(Config.loadTabConfig) == "function"
+                and type(Config.getCustomQAConfig) == "function") then
+        return nil
+    end
+    local ok_t, tabs = pcall(Config.loadTabConfig)
+    if not (ok_t and type(tabs) == "table") then return nil end
+    needle = needle:lower()
+    for _, id in ipairs(tabs) do
+        if type(id) == "string" and id:match("^custom_qa_%d+$") then
+            local ok_c, cfg = pcall(Config.getCustomQAConfig, id)
+            if ok_c and type(cfg) == "table" then
+                local hay = ((cfg.plugin_key or "") .. " " ..
+                             (cfg.dispatcher_action or "")):lower()
+                if hay:find(needle, 1, true) then return id end
+            end
+        end
+    end
+    return nil
+end
+
 local function _registerBarInjection()
     if not (UI and UI.BarInjection and type(UI.BarInjection.register) == "function") then return end
-    -- is_pageable is left unset so it falls back to the same page_num
-    -- auto-detection used for the native Collections/History cases.
+    -- is_pageable left unset on both: falls back to the same page_num
+    -- auto-detection used for the native Collections/History cases (both
+    -- screens are paginated Menu widgets).
     UI.BarInjection.register{
-        id          = "vnds_library",
-        widget_name = "vnds_library",
+        id                = "vnds_library",
+        widget_name       = "vnds_library",
+        get_active_action = function() return _tabIdForPlugin("vnds") end,
+    }
+    UI.BarInjection.register{
+        id                = "rakuyomi_library_view",
+        widget_name       = "library_view",   -- Rakuyomi's MenuCustom:extend{ name = "library_view" }
+        get_active_action = function() return _tabIdForPlugin("rakuyomi") end,
     }
 end
 


### PR DESCRIPTION
## Summary

Adds an **optional Rakuyomi manga integration** to the Home Screen, plus a small **Bar Injection safety net** that benefits any third-party screen.

Everything Rakuyomi-specific lives in **two new files** and self-installs through existing public APIs (`Registry.register`, `UI.BarInjection.register`). The only edits to existing files are **one line in `main.lua:init()`** and a **defensive fallback in `infra/sui_patches.lua`**. It is a complete no-op when Rakuyomi isn't installed.

| File | Change |
|---|---|
| `modules/module_rakuyomi_row.lua` | **new** — the Home Screen cover row |
| `modules/sui_rakuyomi.lua` | **new** — `M.install(plugin)`: registers the row + Bar Injection descriptors, installs the history filter, schedules the backend warm-up |
| `main.lua` | `+7 / −1` — one `pcall`'d `require("modules/sui_rakuyomi").install(self)` after `Patches.installAll`, plus both modules added to `_PLUGIN_MODULES` (hot-reload eviction) |
| `infra/sui_patches.lua` | `+25` — Bar Injection safety net (see below) |

## What it does

### 1. `Rakuyomi Library` Home Screen row — opt-in, default **off**
A cover row showing your Rakuyomi manga library, sorted most-recently-read, styled like *Recent Books*. Tapping a cover invokes Rakuyomi's own **Continue Reading** (right next/last chapter, language preference, confirm dialog). Enable it in **Arrange Modules**.

Built independently of `GridRenderer.makeModule` because a manga library entry is metadata plus a set of separately-downloaded chapters, not a single openable file. Reads Rakuyomi's local cover cache directly via `ui/renderimage`.

Requires the [`tachibana-shin/rakuyomi`](https://github.com/tachibana-shin/rakuyomi) fork (koplugin name `rakuyomi`). Every reach into its internals (`require("Backend")`, `require("LibraryView")`) is shape-checked and `pcall`-guarded — with a different or absent Rakuyomi build the row renders nothing rather than erroring.

### 2. Rakuyomi chapters excluded from *Currently Reading* / *Recent Books*
Rakuyomi downloads each chapter as a `.cbz` under `<koreader>/rakuyomi/…`, and those land in `ReadHistory` like any book — flooding the Home Screen book rows with individual chapters.

`sui_rakuyomi.lua` wraps `SH.prefetchBooks` and hides `/rakuyomi/` paths from `ReadHistory.hist` **for the duration of that one call only**. `module_books_shared.lua` is untouched, and the "current slot falls through to the next real book" behaviour comes for free from the unmodified prefetch logic.

### 3. Bar Injection: navbar on `vnds` and Rakuyomi library screens
Registers Bar Injection descriptors for the `vnds` plugin's library screen and Rakuyomi's `LibraryView` (`MenuCustom:extend{ name = "library_view" }`). Each descriptor supplies `get_active_action`, which resolves the bottom-bar tab whose custom Quick Action launches that plugin so the matching icon highlights while the screen is open (returns `nil` — nothing highlighted — when there is no such launcher).

### 4. Bar Injection safety net — `infra/sui_patches.lua`
Independent of Rakuyomi and useful on its own. In the patched `UIManager.show`, the navbar-injection block and the `orig_show()` that actually displays the widget both run inside one `pcall` with **no fallback**. If injection throws before `orig_show` — e.g. a Bar Injection target whose widget tree the pipeline can't wrap — the widget is silently never shown and the caller is stuck on the previous view.

This tracks whether `orig_show` was reached and, on a caught error before that point, shows the widget **unadorned** rather than losing it. Guarded against a double-show when the error occurred *after* `orig_show`.

### 5. Backend warm-up
The row in (1) can only render once Rakuyomi's HTTP backend is running, which Rakuyomi starts lazily on first opening its library view. A few seconds after boot (off the first-paint path, gated on the row being enabled on any screen), `sui_rakuyomi.lua` warms the backend up and repaints the affected screens, so the row fills in without the user opening Rakuyomi once per session.

## Testing

- All four files pass `luac -p`.
- Verified by source inspection against this branch's base: every `require` target resolves; the helper APIs used (`GridRenderer.showFrame/solidBg`, `SH.getDims/coverPlaceholder/vspan`, `Config.*` scale helpers, `UI.makeColoredText`, `SUIStyle.COLOR`, `Registry.register/get/isEnabled`, `ScreenEngine.knownScreenIds/getPfx/refreshScreen`, `ctx.pfx/vspan_pool`, `ctx_menu.pfx/refresh/_`) exist with compatible signatures; `SH.prefetchBooks` returns a single `state` table and reads `ReadHistory.hist`.
- **Not yet exercised on a device.** Open items a real run should confirm:
  - Whether navbar injection succeeds on Rakuyomi's customised `MenuCustom`, or falls to the new safety net (screen shown, bar absent). If it fails, the KOReader log line `simpleui: UIManager.show error: …` will show which pipeline step to guard.
  - `get_active_action` matching against the actual `plugin_key` stored for a Rakuyomi/`vnds` launcher Quick Action.
  - Row layout/scaling on e-ink.

Happy to adjust naming, placement, or split this up however you prefer.
