### PR TITLE
Fix Quick Settings page-turn crash

### DIFF
--- a/screens/sui_quicksettings_bar.lua
+++ b/screens/sui_quicksettings_bar.lua
@@ -612,6 +612,12 @@ local function patchTouchMenu()
         -- Build panel (sets self._sui_qs_refs)
         local panel, refs = buildPanel(self)
         self._sui_qs_refs = refs
+
+        -- Native page handlers expect numeric pagination state. This panel is
+        -- a single fixed page, so keep page-key and swipe events safe.
+        self.page = 1
+        self.page_num = 1
+
         table.insert(self.item_group, panel)
 
         -- Footer (no pagination)


### PR DESCRIPTION
### Summary

- initialise the injected Quick Settings panel as page 1 of 1
- keep native page-key and swipe handlers from performing arithmetic on a nil page value

### Verification

- reproduced from a KOReader v2026.07.1 crash log on a Kindle Oasis
- applied the same change to SimpleUI v2.7.0 on the device and confirmed that the plugin starts successfully
- parsed the changed Lua file with `luaparse` 0.3.1
- built the plugin archive and verified it with `unzip -t`

Closes #512
