### PR TITLE
add azerbaijani translation

### DIFF
--- a/locale/az.po
+++ b/locale/az.po
@@ -1,0 +1,5246 @@
+# Simple UI — KOReader plugin
+# Azerbaijani translation
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: simpleui\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-09-08 09:19\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: az\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: modules/module_reading_goals.lua:1325
+msgid "  Set Goal  (%d hr/month)"
+msgstr "  Məqsəd təyin et  (%d saat/ay)"
+
+#: modules/module_reading_goals.lua:1345
+msgid "  Set Goal  (%d min/day)"
+msgstr "  Məqsəd təyin et  (%d dəq/gün)"
+
+#: modules/module_reading_goals.lua:1305
+msgid "  Set Goal  (%s)"
+msgstr "  Məqsəd təyin et  (%s)"
+
+#: modules/module_reading_goals.lua:1324
+#: modules/module_reading_goals.lua:1344
+msgid "  Set Goal  (disabled)"
+msgstr "  Məqsəd təyin et  (söndürülüb)"
+
+#: modules/module_coverdeck.lua:110
+#: modules/module_currently.lua:347
+msgid " et al."
+msgstr " və b."
+
+#: engines/sui_book_grid.lua:480
+#: features/library/sui_foldercovers.lua:1222
+msgid " p."
+msgstr " səh."
+
+#: modules/module_feat_coll.lua:169
+#: modules/module_tbr.lua:307
+msgid "% Read (ascending)"
+msgstr "Oxunan % (artan)"
+
+#: modules/module_feat_coll.lua:170
+#: modules/module_tbr.lua:308
+msgid "% Read (descending)"
+msgstr "Oxunan % (azalan)"
+
+#: modules/module_heatmap.lua:222
+msgid "%1 weeks"
+msgstr "%1 həftə"
+
+#: engines/sui_book_grid.lua:1823
+#: engines/sui_book_grid.lua:1828
+msgid "%1 × %2"
+msgstr "%1 × %2"
+
+#: features/sui_backup.lua:665
+msgid "%d files (%s)"
+msgstr "%d fayl (%s)"
+
+#: modules/module_reading_goals.lua:1424
+msgid "%d hr/month"
+msgstr "%d saat/ay"
+
+#: modules/module_reading_goals.lua:1439
+msgid "%d min/day"
+msgstr "%d dəq/gün"
+
+#: features/sui_backup.lua:663
+msgid "%d settings"
+msgstr "%d parametr"
+
+#: engines/sui_book_grid.lua:888
+msgid "%d%%"
+msgstr "%d%%"
+
+#: engines/sui_book_grid.lua:947
+#: engines/sui_book_grid.lua:959
+#: modules/module_coverdeck.lua:1075
+#: modules/module_currently.lua:833
+#: modules/module_currently.lua:842
+#: modules/module_new_books.lua:138
+msgid "%d%% Read"
+msgstr "%d%% oxunub"
+
+#: screens/sui_stats_windows.lua:3419
+msgid "%d/%d days · %d/%d min to next freeze"
+msgstr "%d/%d gün · növbəti dondurmaya %d/%d dəq"
+
+#: modules/module_currently.lua:938
+msgid "%s left"
+msgstr "%s qalıb"
+
+#: modules/module_coverdeck.lua:1080
+#: modules/module_currently.lua:876
+#: modules/module_currently.lua:877
+#: modules/module_currently.lua:936
+#: modules/module_currently.lua:950
+#: modules/module_reading_goals.lua:835
+#: modules/module_reading_goals.lua:855
+msgid "%s read"
+msgstr "%s oxunub"
+
+#: modules/module_coverdeck.lua:1086
+#: modules/module_currently.lua:899
+#: modules/module_currently.lua:903
+msgid "%s remaining"
+msgstr "%s qalıb"
+
+#: modules/module_quick_actions.lua:485
+#: modules/module_reading_stats.lua:386
+msgid "(%d/%d — at limit)"
+msgstr "(%d/%d — həddə çatıb)"
+
+#: modules/module_feat_coll.lua:95
+msgid "(collection not found)"
+msgstr "(kolleksiya tapılmadı)"
+
+#: modules/module_collections.lua:1347
+msgid "4-Cover Grid"
+msgstr "4 üzlüklü tor"
+
+#: screens/sui_menu.lua:2888
+msgid "4-Cover Grid (Mosaic View Only)"
+msgstr "4 üzlüklü tor (yalnız mozaika görünüşündə)"
+
+#: screens/sui_stats_windows.lua:3094
+msgid "A freeze can only bridge a single missed day right after an active one — yesterday doesn't qualify."
+msgstr "Dondurma yalnız oxuduğunuz gündən dərhal sonrakı bir buraxılmış günü əvəz edə bilər — dünən bu şərtə uyğun deyil."
+
+#: features/sui_presets.lua:936
+#: features/sui_presets.lua:1022
+#: screens/sui_menu.lua:4084
+#: screens/sui_menu.lua:4169
+msgid "A preset named \"%s\" already exists."
+msgstr "\"%s\" adlı hazır quruluş artıq mövcuddur."
+
+#: features/sui_presets.lua:877
+#: screens/sui_menu.lua:4030
+msgid "A preset named \"%s\" already exists.\nOverwrite it?"
+msgstr "\"%s\" adlı hazır quruluş artıq mövcuddur.\nÜzərinə yazılsın?"
+
+#: screens/sui_menu.lua:1056
+#: screens/sui_menu.lua:1333
+msgid "A restart is required to apply the new bar size across all layouts.\n\nRestart now?"
+msgstr "Yeni panel ölçüsünü bütün düzülüşlərə tətbiq etmək üçün yenidən başlatmaq lazımdır.\n\nİndi yenidən başladılsın?"
+
+#: screens/sui_menu.lua:4340
+msgid "A restart is required to apply the new text size everywhere.\n\nRestart now?"
+msgstr "Yeni mətn ölçüsünü hər yerdə tətbiq etmək üçün yenidən başlatmaq lazımdır.\n\nİndi yenidən başladılsın?"
+
+#: _meta.lua:6
+msgid "A simple UI for KOReader"
+msgstr "KOReader üçün sadə interfeys"
+
+#: screens/sui_stats_windows.lua:2694
+msgid "ALL TIME"
+msgstr "Bütün dövr"
+
+#: screens/sui_menu.lua:4593
+#: screens/sui_settings_window.lua:365
+#: screens/sui_settings_window.lua:1082
+msgid "About"
+msgstr "Haqqında"
+
+#: features/sui_quickactions.lua:2453
+#: features/sui_quickactions.lua:2499
+msgid "Action"
+msgstr "Əməl"
+
+#: modules/module_action_list.lua:219
+msgid "Action List"
+msgstr "Əməllər siyahısı"
+
+#: features/sui_quickactions.lua:2703
+msgid "Action Type"
+msgstr "Əməlin növü"
+
+#: features/sui_quickactions.lua:1159
+msgid "Action error: %s"
+msgstr "Əməl xətası: %s"
+
+#: features/sui_quickactions.lua:2475
+msgid "Action name…"
+msgstr "Əməlin adı…"
+
+#: features/sui_quickactions.lua:1152
+msgid "Action not available: %s"
+msgstr "Əməl əlçatan deyil: %s"
+
+#: screens/sui_quicksettings_bar.lua:1168
+#: screens/sui_quicksettings_bar.lua:1193
+msgid "Add Action"
+msgstr "Əməl əlavə et"
+
+#: screens/sui_menu.lua:1598
+#: screens/sui_menu.lua:1636
+msgid "Add Button"
+msgstr "Düymə əlavə et"
+
+#: engines/sui_screen_engine.lua:2165
+#: engines/sui_window.lua:850
+#: modules/module_action_list.lua:387
+#: modules/module_action_list.lua:417
+#: modules/module_coverdeck.lua:1528
+#: modules/module_coverdeck.lua:1550
+#: modules/module_coverdeck.lua:1665
+#: modules/module_coverdeck.lua:1683
+#: modules/module_currently.lua:1647
+#: modules/module_currently.lua:1694
+#: modules/module_quick_actions.lua:439
+#: modules/module_quick_actions.lua:469
+#: modules/module_reading_goals.lua:1370
+#: modules/module_reading_goals.lua:1399
+#: modules/module_reading_stats.lua:749
+#: modules/module_reading_stats.lua:778
+#: screens/sui_menu.lua:978
+#: screens/sui_menu.lua:1015
+#: screens/sui_menu.lua:1207
+#: screens/sui_menu.lua:1247
+#: screens/sui_menu.lua:2034
+#: screens/sui_menu.lua:2064
+#: screens/sui_quicksettings_bar.lua:978
+#: screens/sui_settings_window.lua:1090
+msgid "Add Item"
+msgstr "Element əlavə et"
+
+#: screens/sui_settings_window.lua:1087
+#: screens/sui_settings_window.lua:1230
+msgid "Add Module"
+msgstr "Modul əlavə et"
+
+#: screens/sui_settings_window.lua:1193
+msgid "Add Page"
+msgstr "Səhifə əlavə et"
+
+#: modules/module_action_list.lua:298
+#: modules/module_quick_actions.lua:344
+#: screens/sui_menu.lua:1954
+#: screens/sui_quicksettings_bar.lua:1046
+msgid "Add at least 2 actions to arrange."
+msgstr "Sıralamaq üçün ən azı 2 əməl əlavə edin."
+
+#: modules/module_feat_coll.lua:217
+#: modules/module_tbr.lua:363
+msgid "Add at least 2 books to arrange."
+msgstr "Sıralamaq üçün ən azı 2 kitab əlavə edin."
+
+#: modules/module_reading_stats.lua:698
+msgid "Add at least 2 stats to arrange."
+msgstr "Sıralamaq üçün ən azı 2 statistik göstərici əlavə edin."
+
+#: modules/module_tbr.lua:589
+msgid "Add to To Be Read"
+msgstr "Oxunacaqlara əlavə et"
+
+#: modules/module_action_list.lua:460
+#: modules/module_clock.lua:1193
+#: modules/module_quick_actions.lua:645
+#: modules/module_quote.lua:1554
+#: modules/module_reading_stats.lua:846
+msgid "Alignment"
+msgstr "Düzləndirmə"
+
+#: engines/sui_window.lua:3409
+#: screens/sui_settings_window.lua:852
+msgid "All items have already been added."
+msgstr "Bütün elementlər artıq əlavə edilib."
+
+#: screens/sui_settings_window.lua:830
+msgid "All modules have already been added."
+msgstr "Bütün modullar artıq əlavə edilib."
+
+#: features/sui_quickactions.lua:3484
+msgid "All recent books are finished."
+msgstr "Son kitabların hamısı oxunub bitirilib."
+
+#: modules/module_reading_stats.lua:118
+msgid "All time — Books"
+msgstr "Bütün dövr — kitablar"
+
+#: modules/module_reading_stats.lua:117
+msgid "All time — Time"
+msgstr "Bütün dövr — vaxt"
+
+#: screens/sui_menu.lua:2560
+msgid "Always"
+msgstr "Həmişə"
+
+#: modules/module_clock.lua:1165
+#: modules/module_clock.lua:1184
+msgid "Analogue"
+msgstr "Əqrəbli"
+
+#: modules/module_reading_goals.lua:1292
+#: modules/module_reading_goals.lua:1358
+#: modules/module_reading_goals.lua:1395
+#: modules/module_reading_goals.lua:1412
+msgid "Annual Goal"
+msgstr "İllik məqsəd"
+
+#: modules/module_reading_goals.lua:743
+msgid "Annual Reading Goal"
+msgstr "İllik oxu məqsədi"
+
+#: engines/sui_book_grid.lua:1888
+#: modules/module_currently.lua:1925
+#: modules/module_heatmap.lua:352
+#: modules/module_quick_actions.lua:571
+#: modules/module_reading_goals.lua:1507
+#: screens/sui_menu.lua:1814
+#: screens/sui_menu.lua:1817
+msgid "Appearance"
+msgstr "Görünüş"
+
+#: features/sui_backup.lua:104
+msgid "Appearance & Style"
+msgstr "Görünüş və üslub"
+
+#: infra/sui_config.lua:937
+#: infra/sui_config.lua:971
+#: infra/sui_config.lua:1086
+#: infra/sui_config.lua:1159
+#: modules/module_clock.lua:1237
+#: screens/sui_menu.lua:1040
+#: screens/sui_menu.lua:1317
+#: screens/sui_menu.lua:2406
+#: screens/sui_menu.lua:2478
+#: screens/sui_menu.lua:2510
+#: screens/sui_menu.lua:2936
+#: screens/sui_menu.lua:3297
+#: screens/sui_menu.lua:4334
+msgid "Apply"
+msgstr "Tətbiq et"
+
+#: infra/sui_core.lua:1119
+msgid "Applying preset…"
+msgstr "Hazır quruluş tətbiq edilir…"
+
+#: engines/sui_heatmap_widgets.lua:87
+msgid "Apr"
+msgstr "Apr"
+
+#: modules/module_clock.lua:62
+#: screens/sui_stats_windows.lua:2815
+msgid "April"
+msgstr "Aprel"
+
+#: modules/module_feat_coll.lua:204
+#: modules/module_feat_coll.lua:278
+#: modules/module_feat_coll.lua:297
+#: modules/module_tbr.lua:352
+#: modules/module_tbr.lua:424
+#: modules/module_tbr.lua:447
+msgid "Arrange"
+msgstr "Sırala"
+
+#: modules/module_action_list.lua:318
+#: modules/module_quick_actions.lua:362
+#: screens/sui_menu.lua:1958
+msgid "Arrange %s"
+msgstr "%s sıralansın"
+
+#: screens/sui_menu.lua:1554
+#: screens/sui_menu.lua:1561
+#: screens/sui_menu.lua:1738
+#: screens/sui_menu.lua:1753
+msgid "Arrange Buttons"
+msgstr "Düymələri sırala"
+
+#: modules/module_feat_coll.lua:212
+#: modules/module_feat_coll.lua:246
+msgid "Arrange Collection"
+msgstr "Kolleksiyanı sırala"
+
+#: engines/sui_screen_engine.lua:2164
+#: modules/module_action_list.lua:291
+#: modules/module_coverdeck.lua:1605
+#: modules/module_coverdeck.lua:1611
+#: modules/module_currently.lua:1520
+#: modules/module_currently.lua:1563
+#: modules/module_quick_actions.lua:337
+#: screens/sui_bottombar.lua:820
+#: screens/sui_menu.lua:694
+#: screens/sui_menu.lua:761
+#: screens/sui_menu.lua:768
+#: screens/sui_menu.lua:1948
+#: screens/sui_quicksettings_bar.lua:977
+#: screens/sui_quicksettings_bar.lua:1038
+#: screens/sui_settings_window.lua:1111
+#: screens/sui_topbar.lua:507
+msgid "Arrange Items"
+msgstr "Elementləri sırala"
+
+#: screens/sui_quicksettings_bar.lua:1062
+msgid "Arrange Quick Settings"
+msgstr "Sürətli parametrləri sırala"
+
+#: modules/module_reading_stats.lua:709
+msgid "Arrange Reading Stats"
+msgstr "Oxu statistikasını sırala"
+
+#: modules/module_coverdeck.lua:1626
+msgid "Arrange Statistics"
+msgstr "Statistikanı sırala"
+
+#: screens/sui_menu.lua:306
+#: screens/sui_menu.lua:324
+msgid "Arrange Tabs"
+msgstr "Vərəqləri sırala"
+
+#: modules/module_tbr.lua:357
+#: modules/module_tbr.lua:394
+msgid "Arrange To Be Read List"
+msgstr "Oxunacaqlar siyahısını sırala"
+
+#: features/sui_presets.lua:137
+msgid "At a Glance"
+msgstr "Bir baxışda"
+
+#: engines/sui_heatmap_widgets.lua:88
+msgid "Aug"
+msgstr "Avq"
+
+#: modules/module_clock.lua:63
+#: screens/sui_stats_windows.lua:2816
+msgid "August"
+msgstr "Avqust"
+
+#: modules/module_coverdeck.lua:156
+#: modules/module_currently.lua:280
+msgid "Author"
+msgstr "Müəllif"
+
+#: modules/module_feat_coll.lua:168
+#: modules/module_library.lua:213
+#: modules/module_tbr.lua:306
+msgid "Author (A–Z)"
+msgstr "Müəllif (A–Z)"
+
+#: screens/sui_menu.lua:4396
+msgid "Author: %s"
+msgstr "Müəllif: %s"
+
+#: features/sui_quickactions.lua:947
+#: infra/sui_config.lua:131
+#: features/library/sui_library_browse.lua:58
+msgid "Authors"
+msgstr "Müəlliflər"
+
+#: modules/module_collections.lua:1356
+#: screens/sui_menu.lua:2899
+msgid "Auto (Single ↔ 4-Cover Grid)"
+msgstr "Avtomatik (tək ↔ 4 üzlüklü tor)"
+
+#: modules/module_collections.lua:339
+#: features/library/sui_group_actions.lua:48
+msgid "Auto (first book)"
+msgstr "Avtomatik (ilk kitab)"
+
+#: screens/sui_menu.lua:2363
+msgid "Auto-rotate"
+msgstr "Avtomatik döndərmə"
+
+#: screens/sui_menu.lua:4401
+msgid "Automatic Update Check"
+msgstr "Yeniləmələrin avtomatik yoxlanması"
+
+#: screens/sui_stats_windows.lua:1205
+#: screens/sui_stats_windows.lua:2410
+#: screens/sui_stats_windows.lua:3879
+msgid "Average per day"
+msgstr "Gündəlik orta"
+
+#: screens/sui_stats_windows.lua:1207
+#: screens/sui_stats_windows.lua:3881
+msgid "Average per page"
+msgstr "Səhifə üzrə orta"
+
+#: screens/sui_titlebar.lua:103
+#: screens/sui_titlebar.lua:109
+msgid "Back"
+msgstr "Geri"
+
+#: features/sui_style.lua:93
+msgid "Back Button"
+msgstr "Geri düyməsi"
+
+#: features/sui_quickactions.lua:935
+msgid "Backup"
+msgstr "Ehtiyat nüsxə"
+
+#: screens/sui_menu.lua:4423
+msgid "Backup & Restore"
+msgstr "Ehtiyat nüsxə və bərpa"
+
+#: features/sui_backup.lua:641
+msgid "Backup created"
+msgstr "Ehtiyat nüsxə yaradıldı"
+
+#: features/sui_backup.lua:890
+#: features/sui_backup.lua:1111
+msgid "Backup created:"
+msgstr "Ehtiyat nüsxə yaradıldı:"
+
+#: features/sui_backup.lua:887
+#: features/sui_backup.lua:1114
+msgid "Backup failed."
+msgstr "Ehtiyat nüsxə yaradıla bilmədi."
+
+#: features/sui_backup.lua:949
+msgid "Backup loaded. Choose what to import, then tap \"Restore Selected…\"."
+msgstr "Ehtiyat nüsxə yükləndi. İdxal ediləcəkləri seçin, sonra \"Seçilənləri bərpa et…\" düyməsinə toxunun."
+
+#: features/sui_backup.lua:1007
+msgid "Backup restored.\nRestart KOReader now to finish applying all changes?"
+msgstr "Ehtiyat nüsxə bərpa edildi.\nBütün dəyişiklikləri tətbiq etməyi tamamlamaq üçün KOReader indi yenidən başladılsın?"
+
+#: features/sui_backup.lua:583
+msgid "Backup was made by a newer SimpleUI version. Please update this plugin first."
+msgstr "Ehtiyat nüsxə daha yeni Simple UI versiyası ilə yaradılıb. Əvvəlcə bu qoşmanı yeniləyin."
+
+#: engines/sui_book_grid.lua:2057
+#: modules/module_collections.lua:1378
+#: screens/sui_menu.lua:3201
+#: screens/sui_menu.lua:3210
+#: screens/sui_menu.lua:3216
+msgid "Badge"
+msgstr "Nişan"
+
+#: engines/sui_book_grid.lua:1990
+#: engines/sui_book_grid.lua:1992
+#: modules/module_collections.lua:1422
+#: modules/module_collections.lua:1425
+#: screens/sui_menu.lua:2929
+msgid "Badge Size"
+msgstr "Nişan ölçüsü"
+
+#: screens/sui_menu.lua:2917
+msgid "Badges"
+msgstr "Nişanlar"
+
+#: screens/sui_menu.lua:3134
+#: screens/sui_menu.lua:3143
+#: screens/sui_menu.lua:3149
+#: features/library/sui_foldercovers.lua:309
+msgid "Banner"
+msgstr "Zolaq"
+
+#: engines/sui_book_grid.lua:1939
+msgid "Bar"
+msgstr "Panel"
+
+#: engines/sui_book_grid.lua:1941
+msgid "Bar + Text"
+msgstr "Panel + mətn"
+
+#: screens/sui_menu.lua:560
+#: screens/sui_menu.lua:1303
+msgid "Bar Size"
+msgstr "Panel ölçüsü"
+
+#: screens/sui_menu.lua:1261
+msgid "Bar Style"
+msgstr "Panel üslubu"
+
+#: modules/module_quick_actions.lua:597
+#: screens/sui_menu.lua:1288
+#: screens/sui_quicksettings_bar.lua:1270
+msgid "Bare"
+msgstr "Çərçivəsiz"
+
+#: features/sui_backup.lua:114
+#: screens/sui_menu.lua:4555
+#: screens/sui_settings_window.lua:330
+#: screens/sui_settings_window.lua:1079
+msgid "Bars"
+msgstr "Panellər"
+
+#: infra/sui_config.lua:169
+#: modules/module_clock.lua:239
+msgid "Battery"
+msgstr "Batareya"
+
+#: modules/module_clock.lua:1031
+#: modules/module_clock.lua:1033
+msgid "Battery Size"
+msgstr "Batareya ölçüsü"
+
+#: screens/sui_menu.lua:2764
+#: screens/sui_settings_window.lua:414
+#: screens/sui_settings_window.lua:1092
+msgid "Behaviour"
+msgstr "Davranış"
+
+#: screens/sui_stats_windows.lua:2180
+#: screens/sui_stats_windows.lua:2200
+msgid "Best streak"
+msgstr "Ən uzun ardıcıllıq"
+
+#: screens/sui_menu.lua:2603
+msgid "Book Cover Transition"
+msgstr "Kitab üzlüyü keçidi"
+
+#: features/sui_quickactions.lua:2225
+msgid "Book Info"
+msgstr "Kitab məlumatı"
+
+#: infra/sui_config.lua:1275
+msgid "Book Menu"
+msgstr "Kitab menyusu"
+
+#: screens/sui_stats_windows.lua:3932
+msgid "Book Statistics"
+msgstr "Kitab statistikası"
+
+#: main.lua:1134
+msgid "Book statistics"
+msgstr "Kitab statistikası"
+
+#: screens/sui_settings_window.lua:338
+msgid "Book-browser settings"
+msgstr "Kitab brauzerinin parametrləri"
+
+#: features/sui_quickactions.lua:468
+msgid "Bookmark browser"
+msgstr "Əlfəcin brauzeri"
+
+#: features/sui_quickactions.lua:402
+msgid "Bookmark browser not available."
+msgstr "Əlfəcin brauzeri əlçatan deyil."
+
+#: features/sui_quickactions.lua:830
+#: infra/sui_config.lua:124
+msgid "Bookmarks"
+msgstr "Əlfəcinlər"
+
+#: modules/module_feat_coll.lua:254
+#: modules/module_library.lua:293
+msgid "Books"
+msgstr "Kitablar"
+
+#: modules/module_reading_goals.lua:744
+msgid "Books to read in %s:"
+msgstr "%s ərzində oxunacaq kitablar:"
+
+#: modules/module_collections.lua:1399
+#: screens/sui_menu.lua:2952
+#: screens/sui_menu.lua:2959
+#: screens/sui_menu.lua:2974
+#: screens/sui_menu.lua:3365
+#: screens/sui_menu.lua:3384
+msgid "Bottom"
+msgstr "Aşağı"
+
+#: screens/sui_menu.lua:1372
+#: screens/sui_menu.lua:1373
+msgid "Bottom Margin"
+msgstr "Aşağı kənar boşluğu"
+
+#: screens/sui_menu.lua:2604
+msgid "Briefly show the book cover full-screen when opening or closing a book, masking the page-layout flash. Normally requires the book to already be indexed by the cover browser (its cover must have been seen at least once in a grid/list view) — see \"High-Quality Cover\" below to also cover un-indexed books."
+msgstr "Kitabı açarkən və ya bağlayarkən səhifə düzülüşünün yanıb-sönməsini gizlətmək üçün kitab üzlüyünü qısa müddət tam ekranda göstərir. Adətən kitabın üzlük brauzerində artıq indekslənmiş olması tələb olunur (üzlük ən azı bir dəfə tor/siyahı görünüşündə görünməlidir) — indekslənməmiş kitablara da tətbiq etmək üçün aşağıdakı \"Yüksək keyfiyyətli üzlük\" seçiminə baxın."
+
+#: features/sui_quickactions.lua:871
+#: infra/sui_config.lua:126
+#: infra/sui_config.lua:168
+msgid "Brightness"
+msgstr "Parlaqlıq"
+
+#: screens/sui_titlebar.lua:105
+msgid "Browse"
+msgstr "Gözdən keçir"
+
+#: features/sui_style.lua:108
+msgid "Browse Button (author)"
+msgstr "Gözdən keçirmə düyməsi (müəllif)"
+
+#: features/sui_style.lua:102
+msgid "Browse Button (default)"
+msgstr "Gözdən keçirmə düyməsi (standart)"
+
+#: features/sui_style.lua:114
+msgid "Browse Button (series)"
+msgstr "Gözdən keçirmə düyməsi (silsilə)"
+
+#: features/sui_style.lua:120
+msgid "Browse Button (tags)"
+msgstr "Gözdən keçirmə düyməsi (etiketlər)"
+
+#: features/sui_style.lua:1293
+msgid "Browse Icons"
+msgstr "Gözdən keçirmə işarələri"
+
+#: features/library/sui_library_browse.lua:416
+msgid "Browse by"
+msgstr "Gözdən keçirmə meyarı"
+
+#: features/sui_quickactions.lua:954
+#: features/sui_quickactions.lua:972
+#: features/sui_quickactions.lua:990
+msgid "Browse by Authors/Series/Tags not available."
+msgstr "Müəlliflər/silsilələr/etiketlər üzrə gözdən keçirmə əlçatan deyil."
+
+#: screens/sui_titlebar.lua:1000
+msgid "Browse library"
+msgstr "Kitabxananı gözdən keçir"
+
+#: features/sui_quickactions.lua:2166
+#: screens/sui_menu.lua:2256
+#: screens/sui_menu.lua:3796
+msgid "Browse…"
+msgstr "Gözdən keçir…"
+
+#: modules/module_quick_actions.lua:609
+#: screens/sui_quicksettings_bar.lua:1283
+msgid "Button Background"
+msgstr "Düymə fonu"
+
+#: screens/sui_menu.lua:1825
+msgid "Button Size"
+msgstr "Düymə ölçüsü"
+
+#: modules/module_quick_actions.lua:574
+#: screens/sui_quicksettings_bar.lua:1247
+msgid "Button Type"
+msgstr "Düymə növü"
+
+#: screens/sui_titlebar.lua:1004
+msgid "By author"
+msgstr "Müəllif üzrə"
+
+#: screens/sui_menu.lua:2643
+msgid "By default the cover is stretched to fill the whole screen, which can distort it if its proportions don't match your screen's. When on, the cover keeps its original proportions instead, centered over a black background."
+msgstr "Standart olaraq üzlük bütün ekranı doldurmaq üçün dartılır. Nisbətləri ekranın nisbətləri ilə uyğun gəlmirsə, bu, təsviri təhrif edə bilər. Bu seçim qoşulduqda üzlük ilkin nisbətlərini saxlayaraq qara fonun mərkəzində göstərilir."
+
+#: screens/sui_titlebar.lua:1005
+msgid "By series"
+msgstr "Silsilə üzrə"
+
+#: screens/sui_titlebar.lua:1006
+msgid "By tags"
+msgstr "Etiketlər üzrə"
+
+#: screens/sui_heatmap_popup.lua:140
+#: screens/sui_stats_windows.lua:3115
+msgid "CALENDAR"
+msgstr "Təqvim"
+
+#: modules/module_heatmap.lua:342
+msgid "Calendar"
+msgstr "Təqvim"
+
+#: features/sui_backup.lua:995
+#: features/sui_backup.lua:1094
+#: features/sui_presets.lua:849
+#: features/sui_presets.lua:879
+#: features/sui_presets.lua:909
+#: features/sui_presets.lua:926
+#: features/sui_presets.lua:954
+#: features/sui_presets.lua:994
+#: features/sui_presets.lua:1012
+#: features/sui_presets.lua:1041
+#: features/sui_quickactions.lua:493
+#: features/sui_quickactions.lua:1589
+#: features/sui_quickactions.lua:1922
+#: features/sui_quickactions.lua:2074
+#: features/sui_quickactions.lua:2095
+#: features/sui_quickactions.lua:2205
+#: features/sui_quickactions.lua:2490
+#: features/sui_quickactions.lua:2561
+#: features/sui_quickactions.lua:2587
+#: features/sui_quickactions.lua:2612
+#: features/sui_quickactions.lua:2690
+#: features/sui_quickactions.lua:2714
+#: features/sui_quickactions.lua:3027
+#: features/sui_quickactions.lua:3422
+#: features/sui_style.lua:1311
+#: infra/sui_config.lua:938
+#: infra/sui_config.lua:972
+#: infra/sui_config.lua:1087
+#: infra/sui_config.lua:1160
+#: infra/sui_updater.lua:500
+#: infra/sui_updater.lua:517
+#: modules/module_clock.lua:1238
+#: modules/module_collections.lua:365
+#: modules/module_quote.lua:1300
+#: modules/module_reading_goals.lua:731
+#: screens/sui_menu.lua:650
+#: screens/sui_menu.lua:911
+#: screens/sui_menu.lua:1041
+#: screens/sui_menu.lua:1318
+#: screens/sui_menu.lua:2407
+#: screens/sui_menu.lua:2479
+#: screens/sui_menu.lua:2511
+#: screens/sui_menu.lua:2937
+#: screens/sui_menu.lua:3298
+#: screens/sui_menu.lua:4004
+#: screens/sui_menu.lua:4032
+#: screens/sui_menu.lua:4061
+#: screens/sui_menu.lua:4078
+#: screens/sui_menu.lua:4104
+#: screens/sui_menu.lua:4145
+#: screens/sui_menu.lua:4163
+#: screens/sui_menu.lua:4190
+#: screens/sui_menu.lua:4335
+#: screens/sui_menu.lua:4440
+#: screens/sui_settings_window.lua:483
+#: screens/sui_settings_window.lua:1170
+#: screens/sui_stats_windows.lua:649
+#: screens/sui_stats_windows.lua:772
+#: screens/sui_titlebar.lua:1007
+#: features/library/sui_group_actions.lua:71
+#: features/library/sui_group_actions.lua:101
+#: features/library/sui_library_browse.lua:826
+#: features/library/sui_series_grouping.lua:377
+msgid "Cancel"
+msgstr "Ləğv et"
+
+#: modules/module_reading_stats.lua:804
+msgid "Cards"
+msgstr "Kartlar"
+
+#: modules/module_reading_stats.lua:814
+msgid "Cards - Transparent"
+msgstr "Kartlar - şəffaf"
+
+#: modules/module_action_list.lua:68
+#: modules/module_action_list.lua:470
+#: modules/module_clock.lua:168
+#: modules/module_clock.lua:1205
+#: modules/module_quote.lua:127
+#: modules/module_quote.lua:1564
+#: modules/module_reading_goals.lua:121
+#: modules/module_reading_goals.lua:1573
+#: modules/module_reading_stats.lua:93
+#: modules/module_reading_stats.lua:860
+#: screens/sui_menu.lua:710
+#: screens/sui_menu.lua:941
+#: screens/sui_menu.lua:3364
+#: screens/sui_menu.lua:3377
+msgid "Center"
+msgstr "Mərkəz"
+
+#: screens/sui_menu.lua:4412
+msgid "Check for Updates"
+msgstr "Yeniləmələri yoxla"
+
+#: infra/sui_updater.lua:633
+msgid "Checking for updates…"
+msgstr "Yeniləmələr yoxlanılır…"
+
+#: features/sui_backup.lua:964
+msgid "Choose backup file"
+msgstr "Ehtiyat nüsxə faylını seç"
+
+#: features/sui_backup.lua:1140
+msgid "Choose backup file…"
+msgstr "Ehtiyat nüsxə faylını seç…"
+
+#: engines/sui_asset_browser.lua:91
+msgid "Choose file"
+msgstr "Fayl seç"
+
+#: features/sui_quickactions.lua:2179
+msgid "Choose icon"
+msgstr "İşarə seç"
+
+#: screens/sui_menu.lua:3806
+msgid "Choose icon pack"
+msgstr "İşarə dəstini seç"
+
+#: screens/sui_menu.lua:2263
+msgid "Choose wallpaper"
+msgstr "Fon şəklini seç"
+
+#: screens/sui_onboarding.lua:55
+msgid "Choose your initial layout"
+msgstr "İlkin düzülüşü seçin"
+
+#: features/sui_presets.lua:150
+#: features/sui_presets.lua:215
+#: infra/sui_config.lua:166
+#: modules/module_clock.lua:237
+#: modules/module_clock.lua:740
+msgid "Clock"
+msgstr "Saat"
+
+#: modules/module_clock.lua:1013
+#: modules/module_clock.lua:1015
+msgid "Clock Size"
+msgstr "Saat ölçüsü"
+
+#: modules/module_clock.lua:1161
+msgid "Clock Style"
+msgstr "Saat üslubu"
+
+#: screens/sui_titlebar.lua:108
+msgid "Close"
+msgstr "Bağla"
+
+#: screens/sui_menu.lua:2556
+msgid "Closing Book Notice"
+msgstr "Kitabın bağlanması bildirişi"
+
+#: main.lua:1891
+msgid "Closing book…"
+msgstr "Kitab bağlanır…"
+
+#: features/sui_quickactions.lua:2120
+msgid "Codepoint out of valid Unicode range (0–10FFFF)."
+msgstr "Kod nöqtəsi etibarlı Unicode aralığından (0–10FFFF) kənardadır."
+
+#: features/sui_quickactions.lua:2563
+#: features/sui_quickactions.lua:2706
+msgid "Collection"
+msgstr "Kolleksiya"
+
+#: modules/module_collections.lua:1486
+msgid "Collection Menu"
+msgstr "Kolleksiya menyusu"
+
+#: features/library/sui_group_actions.lua:127
+msgid "Collection \"%1\" created with %2 books."
+msgstr "\"%1\" kolleksiyası %2 kitabla yaradıldı."
+
+#: features/library/sui_group_actions.lua:113
+msgid "Collection already exists: %1"
+msgstr "Kolleksiya artıq mövcuddur: %1"
+
+#: modules/module_collections.lua:326
+#: modules/module_collections.lua:332
+msgid "Collection is empty."
+msgstr "Kolleksiya boşdur."
+
+#: features/sui_quickactions.lua:3116
+msgid "Collection not available: %s"
+msgstr "Kolleksiya əlçatan deyil: %s"
+
+#: modules/module_feat_coll.lua:125
+msgid "Collection: "
+msgstr "Kolleksiya: "
+
+#: modules/module_feat_coll.lua:125
+msgid "Collection: (none)"
+msgstr "Kolleksiya: (yoxdur)"
+
+#: features/sui_quickactions.lua:479
+#: features/sui_quickactions.lua:715
+#: features/sui_quickactions.lua:2227
+#: infra/sui_config.lua:118
+#: modules/module_collections.lua:1188
+#: modules/module_collections.lua:1207
+#: modules/module_collections.lua:1216
+#: modules/module_collections.lua:1269
+#: modules/module_collections.lua:1477
+#: modules/module_collections.lua:1478
+#: modules/module_coverdeck.lua:1452
+msgid "Collections"
+msgstr "Kolleksiyalar"
+
+#: infra/sui_patches.lua:1409
+msgid "Collections (%1)"
+msgstr "Kolleksiyalar (%1)"
+
+#: features/sui_quickactions.lua:722
+msgid "Collections not available."
+msgstr "Kolleksiyalar əlçatan deyil."
+
+#: features/sui_style.lua:170
+msgid "Collections: Back Button"
+msgstr "Kolleksiyalar: geri düyməsi"
+
+#: screens/sui_menu.lua:2997
+#: screens/sui_menu.lua:3051
+#: screens/sui_menu.lua:3105
+#: screens/sui_menu.lua:3172
+#: screens/sui_menu.lua:3239
+#: screens/sui_menu.lua:3393
+msgid "Color"
+msgstr "Rəng"
+
+#: infra/sui_config.lua:1144
+#: infra/sui_config.lua:1152
+msgid "Column Width (Bento Grid)"
+msgstr "Sütun eni (bölməli tor)"
+
+#: engines/sui_book_grid.lua:1834
+msgid "Columns"
+msgstr "Sütunlar"
+
+#: modules/module_currently.lua:1967
+#: modules/module_reading_goals.lua:1519
+#: screens/sui_menu.lua:1828
+msgid "Compact"
+msgstr "Yığcam"
+
+#: features/sui_quickactions.lua:2073
+msgid "Confirm"
+msgstr "Təsdiq et"
+
+#: features/sui_quickactions.lua:748
+#: infra/sui_config.lua:121
+#: screens/sui_onboarding.lua:254
+#: screens/sui_onboarding.lua:260
+#: screens/sui_onboarding.lua:266
+msgid "Continue"
+msgstr "Davam et"
+
+#: features/sui_backup.lua:1112
+msgid "Copy this file somewhere safe (e.g. over USB)."
+msgstr "Bu faylı təhlükəsiz yerə köçürün (məsələn, USB vasitəsilə)."
+
+#: engines/sui_book_grid.lua:1943
+msgid "Corner Badge"
+msgstr "Künc nişanı"
+
+#: features/sui_backup.lua:881
+#: features/sui_backup.lua:956
+#: features/sui_backup.lua:1083
+msgid "Could not determine backup folder."
+msgstr "Ehtiyat nüsxə qovluğunu müəyyən etmək mümkün olmadı."
+
+#: features/sui_style.lua:1991
+msgid "Could not determine packs folder"
+msgstr "Dəstlər qovluğunu müəyyən etmək mümkün olmadı"
+
+#: features/sui_backup.lua:528
+msgid "Could not open backup file for writing"
+msgstr "Ehtiyat nüsxə faylını yazmaq üçün açmaq mümkün olmadı"
+
+#: screens/sui_stats_windows.lua:172
+msgid "Could not open statistics database."
+msgstr "Statistika verilənlər bazasını açmaq mümkün olmadı."
+
+#: features/sui_style.lua:1993
+msgid "Could not open zip (invalid format or corrupted)"
+msgstr "ZIP faylını açmaq mümkün olmadı (format yanlışdır və ya fayl zədələnib)"
+
+#: features/sui_backup.lua:540
+msgid "Could not write backup file"
+msgstr "Ehtiyat nüsxə faylını yazmaq mümkün olmadı"
+
+#: features/sui_presets.lua:170
+#: features/sui_presets.lua:188
+#: modules/module_coverdeck.lua:637
+msgid "Cover Deck"
+msgstr "Üzlük dəsti"
+
+#: screens/sui_menu.lua:2869
+msgid "Cover Settings"
+msgstr "Üzlük parametrləri"
+
+#: engines/sui_book_grid.lua:1787
+#: engines/sui_book_grid.lua:1789
+#: modules/module_coverdeck.lua:1348
+#: modules/module_coverdeck.lua:1349
+#: modules/module_currently.lua:1424
+#: modules/module_currently.lua:1425
+msgid "Cover Size"
+msgstr "Üzlük ölçüsü"
+
+#: modules/module_currently.lua:1451
+#: modules/module_currently.lua:1452
+msgid "Cover Spacing"
+msgstr "Üzlük aralığı"
+
+#: modules/module_collections.lua:1333
+msgid "Cover Style"
+msgstr "Üzlük üslubu"
+
+#: modules/module_collections.lua:369
+msgid "Cover for \"%s\""
+msgstr "\"%s\" üçün üzlük"
+
+#: modules/module_coverdeck.lua:154
+msgid "Covers"
+msgstr "Üzlüklər"
+
+#: screens/sui_settings_window.lua:1175
+#: features/library/sui_group_actions.lua:106
+msgid "Create"
+msgstr "Yarat"
+
+#: features/sui_quickactions.lua:1625
+#: features/sui_quickactions.lua:2934
+msgid "Create Quick Action"
+msgstr "Sürətli əməl yarat"
+
+#: screens/sui_settings_window.lua:1158
+msgid "Create Screen"
+msgstr "Ekran yarat"
+
+#: features/library/sui_foldercovers.lua:726
+#: features/library/sui_library_browse.lua:819
+#: features/library/sui_series_grouping.lua:369
+msgid "Create collection"
+msgstr "Kolleksiya yarat"
+
+#: screens/sui_settings_window.lua:1165
+msgid "Create screen"
+msgstr "Ekran yarat"
+
+#: features/sui_backup.lua:878
+#: features/sui_backup.lua:1108
+msgid "Creating backup…"
+msgstr "Ehtiyat nüsxə yaradılır…"
+
+#: screens/sui_stats_windows.lua:2178
+#: screens/sui_stats_windows.lua:2198
+msgid "Current streak"
+msgstr "Cari ardıcıllıq"
+
+#: features/sui_presets.lua:138
+#: features/sui_presets.lua:150
+#: features/sui_presets.lua:215
+#: modules/module_currently.lua:355
+#: modules/module_currently.lua:356
+#: modules/module_currently.lua:487
+#: modules/module_currently.lua:1928
+msgid "Currently Reading"
+msgstr "Hazırda oxunan"
+
+#: infra/sui_config.lua:2104
+msgid "Custom"
+msgstr "Fərdi"
+
+#: features/sui_quickactions.lua:1891
+#: features/sui_quickactions.lua:1894
+msgid "Custom Actions"
+msgstr "Fərdi əməllər"
+
+#: modules/module_quote.lua:1451
+msgid "Custom File"
+msgstr "Fərdi fayl"
+
+#: modules/module_quote.lua:1500
+msgid "Custom File + My Highlights"
+msgstr "Fərdi fayl + vurğulamalarım"
+
+#: features/sui_quickactions.lua:1518
+#: features/sui_quickactions.lua:1622
+msgid "Custom Quick Actions"
+msgstr "Fərdi sürətli əməllər"
+
+#: infra/sui_custom_screens.lua:158
+msgid "Custom Screen"
+msgstr "Fərdi ekran"
+
+#: features/sui_quickactions.lua:1901
+#: features/sui_quickactions.lua:1904
+msgid "Custom Screens"
+msgstr "Fərdi ekranlar"
+
+#: screens/sui_settings_window.lua:434
+msgid "Custom Screens unavailable."
+msgstr "Fərdi ekranlar əlçatan deyil."
+
+#: infra/sui_config.lua:172
+#: screens/sui_menu.lua:642
+#: screens/sui_menu.lua:904
+msgid "Custom Text"
+msgstr "Fərdi mətn"
+
+#: features/sui_backup.lua:125
+msgid "Custom actions, rows and dispatcher bindings"
+msgstr "Fərdi əməllər, sətirlər və Dispatcher təyinatları"
+
+#: features/sui_backup.lua:146
+msgid "Custom icons"
+msgstr "Fərdi işarələr"
+
+#: features/sui_backup.lua:140
+msgid "Custom quotes"
+msgstr "Fərdi sitatlar"
+
+#: screens/sui_onboarding.lua:173
+msgid "Custom wallpapers and icons"
+msgstr "Fərdi fon şəkilləri və işarələr"
+
+#: screens/sui_onboarding.lua:165
+msgid "Customize even more"
+msgstr "Daha çox fərdiləşdirin"
+
+#: screens/sui_stats_windows.lua:2725
+#: screens/sui_stats_windows.lua:3357
+msgid "DAY STREAK"
+msgstr "Ardıcıl günlər"
+
+#: modules/module_reading_goals.lua:1332
+#: modules/module_reading_goals.lua:1360
+#: modules/module_reading_goals.lua:1397
+#: modules/module_reading_goals.lua:1442
+msgid "Daily Goal"
+msgstr "Gündəlik məqsəd"
+
+#: modules/module_reading_goals.lua:777
+msgid "Daily Reading Goal"
+msgstr "Gündəlik oxu məqsədi"
+
+#: modules/module_reading_stats.lua:114
+msgid "Daily avg — Pages"
+msgstr "Gündəlik orta — səhifələr"
+
+#: modules/module_reading_stats.lua:113
+msgid "Daily avg — Time"
+msgstr "Gündəlik orta — vaxt"
+
+#: engines/sui_book_grid.lua:1914
+#: modules/module_collections.lua:1408
+#: modules/module_coverdeck.lua:1736
+#: screens/sui_menu.lua:2999
+#: screens/sui_menu.lua:3004
+#: screens/sui_menu.lua:3053
+#: screens/sui_menu.lua:3058
+#: screens/sui_menu.lua:3107
+#: screens/sui_menu.lua:3112
+#: screens/sui_menu.lua:3174
+#: screens/sui_menu.lua:3179
+#: screens/sui_menu.lua:3241
+#: screens/sui_menu.lua:3246
+#: screens/sui_menu.lua:3395
+#: screens/sui_menu.lua:3407
+msgid "Dark"
+msgstr "Tünd"
+
+#: features/sui_presets.lua:214
+msgid "Dashboard"
+msgstr "İdarəetmə paneli"
+
+#: modules/module_clock.lua:238
+msgid "Date"
+msgstr "Tarix"
+
+#: modules/module_clock.lua:1022
+#: modules/module_clock.lua:1024
+msgid "Date Size"
+msgstr "Tarix ölçüsü"
+
+#: modules/module_library.lua:214
+msgid "Date added (newest)"
+msgstr "Əlavə edilmə tarixi (ən yeni)"
+
+#: modules/module_library.lua:215
+msgid "Date added (oldest)"
+msgstr "Əlavə edilmə tarixi (ən köhnə)"
+
+#: screens/sui_stats_windows.lua:724
+msgid "Date finished"
+msgstr "Bitirmə tarixi"
+
+#: screens/sui_stats_windows.lua:717
+msgid "Date started"
+msgstr "Başlama tarixi"
+
+#: screens/sui_stats_windows.lua:945
+#: screens/sui_stats_windows.lua:3648
+msgid "Days"
+msgstr "Günlər"
+
+#: modules/module_coverdeck.lua:144
+#: modules/module_currently.lua:285
+msgid "Days of reading"
+msgstr "Oxunan günlər"
+
+#: engines/sui_heatmap_widgets.lua:88
+msgid "Dec"
+msgstr "Dek"
+
+#: modules/module_clock.lua:64
+#: screens/sui_stats_windows.lua:2817
+msgid "December"
+msgstr "Dekabr"
+
+#: features/sui_quickactions.lua:2144
+#: features/sui_quickactions.lua:2430
+#: modules/module_currently.lua:1475
+#: modules/module_currently.lua:1965
+#: modules/module_reading_goals.lua:1511
+#: screens/sui_menu.lua:459
+#: screens/sui_menu.lua:588
+#: screens/sui_menu.lua:1264
+#: screens/sui_menu.lua:1829
+#: screens/sui_titlebar.lua:1003
+msgid "Default"
+msgstr "Standart"
+
+#: features/sui_quickactions.lua:2431
+msgid "Default (Folder)"
+msgstr "Standart (qovluq)"
+
+#: features/sui_quickactions.lua:2432
+msgid "Default (Plugin)"
+msgstr "Standart (qoşma)"
+
+#: features/sui_quickactions.lua:2433
+msgid "Default (System)"
+msgstr "Standart (sistem)"
+
+#: modules/module_quote.lua:1387
+msgid "Default Quotes"
+msgstr "Standart sitatlar"
+
+#: features/sui_style.lua:177
+msgid "Default: Folder"
+msgstr "Standart: qovluq"
+
+#: features/sui_style.lua:195
+msgid "Default: Group"
+msgstr "Standart: qrup"
+
+#: features/sui_style.lua:183
+msgid "Default: Plugin"
+msgstr "Standart: qoşma"
+
+#: features/sui_style.lua:189
+msgid "Default: System"
+msgstr "Standart: sistem"
+
+#: engines/sui_window.lua:1941
+#: engines/sui_window.lua:2870
+#: features/sui_presets.lua:950
+#: features/sui_presets.lua:953
+#: features/sui_presets.lua:993
+#: features/sui_quickactions.lua:1588
+#: features/sui_quickactions.lua:3021
+#: features/sui_quickactions.lua:3026
+#: screens/sui_menu.lua:4100
+#: screens/sui_menu.lua:4103
+#: screens/sui_menu.lua:4144
+#: screens/sui_settings_window.lua:510
+#: screens/sui_settings_window.lua:555
+#: screens/sui_settings_window.lua:685
+#: features/library/sui_book_hold_dialog.lua:151
+msgid "Delete"
+msgstr "Sil"
+
+#: screens/sui_menu.lua:4439
+msgid "Delete Settings"
+msgstr "Parametrləri sil"
+
+#: screens/sui_settings_window.lua:508
+msgid "Delete \"%s\"? This removes its layout, modules and Quick Action."
+msgstr "\"%s\" silinsin? Onun düzülüşü, modulları və sürətli əməli silinəcək."
+
+#: features/sui_presets.lua:952
+#: features/sui_presets.lua:992
+#: screens/sui_menu.lua:4102
+#: screens/sui_menu.lua:4143
+msgid "Delete preset \"%s\"?"
+msgstr "\"%s\" hazır quruluşu silinsin?"
+
+#: features/sui_quickactions.lua:1587
+#: features/sui_quickactions.lua:3025
+msgid "Delete quick action \"%s\"?"
+msgstr "\"%s\" sürətli əməli silinsin?"
+
+#: modules/module_currently.lua:282
+msgid "Description"
+msgstr "Təsvir"
+
+#: modules/module_reading_goals.lua:1541
+#: modules/module_reading_goals.lua:1553
+msgid "Detail Below Ring"
+msgstr "Təfərrüat halqanın altında"
+
+#: modules/module_reading_goals.lua:1541
+#: modules/module_reading_goals.lua:1545
+msgid "Detail Inside Ring"
+msgstr "Təfərrüat halqanın içində"
+
+#: features/sui_quickactions.lua:2230
+msgid "Dictionary Lookup"
+msgstr "Lüğətdə axtarış"
+
+#: modules/module_clock.lua:1166
+#: modules/module_clock.lua:1170
+msgid "Digital"
+msgstr "Rəqəmsal"
+
+#: screens/sui_menu.lua:2497
+msgid "Disable \"Lock Scale\" first to set a custom label scale."
+msgstr "Fərdi yazı miqyası təyin etmək üçün əvvəlcə \"Miqyası kilidlə\" seçimini söndürün."
+
+#: infra/sui_config.lua:923
+msgid "Disable \"Lock Scale\" first to set a per-module scale."
+msgstr "Modul üçün ayrıca miqyas təyin etmək üçün əvvəlcə \"Miqyası kilidlə\" seçimini söndürün."
+
+#: infra/sui_config.lua:170
+msgid "Disk Usage"
+msgstr "Disk istifadəsi"
+
+#: features/sui_quickactions.lua:3075
+msgid "Dispatcher not available."
+msgstr "Dispatcher əlçatan deyil."
+
+#: screens/sui_menu.lua:3565
+msgid "Display"
+msgstr "Ekran"
+
+#: features/sui_quickactions.lua:2681
+msgid "Done"
+msgstr "Hazırdır"
+
+#: screens/sui_menu.lua:496
+msgid "Dot Pager"
+msgstr "Nöqtəli səhifə göstəricisi"
+
+#: infra/sui_updater.lua:516
+msgid "Download and install"
+msgstr "Endir və quraşdır"
+
+#: infra/sui_updater.lua:515
+msgid "Download and install now?"
+msgstr "İndi endirilib quraşdırılsın?"
+
+#: infra/sui_updater.lua:438
+msgid "Download error: "
+msgstr "Endirmə xətası: "
+
+#: infra/sui_updater.lua:414
+msgid "Downloading Simple UI %s…"
+msgstr "Simple UI %s endirilir…"
+
+#: modules/module_currently.lua:1478
+msgid "Dynamic"
+msgstr "Dinamik"
+
+#: features/sui_quickactions.lua:3008
+msgid "Edit"
+msgstr "Redaktə et"
+
+#: screens/sui_menu.lua:634
+#: screens/sui_menu.lua:636
+#: screens/sui_menu.lua:898
+msgid "Edit Custom Text"
+msgstr "Fərdi mətni redaktə et"
+
+#: screens/sui_menu.lua:2191
+#: screens/sui_settings_window.lua:379
+msgid "Edit Home Screen Layout"
+msgstr "Əsas ekranın düzülüşünü redaktə et"
+
+#: features/sui_quickactions.lua:2348
+msgid "Edit Quick Action"
+msgstr "Sürətli əməli redaktə et"
+
+#: modules/module_clock.lua:317
+msgid "Eight"
+msgstr "Səkkiz"
+
+#: modules/module_clock.lua:320
+msgid "Eighteen"
+msgstr "On səkkiz"
+
+#: modules/module_clock.lua:318
+msgid "Eleven"
+msgstr "On bir"
+
+#: screens/sui_menu.lua:891
+msgid "Empty"
+msgstr "Boş"
+
+#: features/sui_quickactions.lua:955
+#: features/sui_quickactions.lua:973
+#: features/sui_quickactions.lua:991
+msgid "Enable 'Browse by Author / Series / Tags' in the library menu first."
+msgstr "Əvvəlcə kitabxana menyusunda \"Müəllif / silsilə / etiketlər üzrə gözdən keçirmə\" seçimini qoşun."
+
+#: screens/sui_menu.lua:2820
+msgid "Enable Browse by Author / Series / Tags"
+msgstr "Müəllif / silsilə / etiketlər üzrə gözdən keçirməni qoş"
+
+#: screens/sui_menu.lua:2804
+msgid "Enable Library Custom Covers"
+msgstr "Kitabxanada fərdi üzlükləri qoş"
+
+#: screens/sui_menu.lua:1110
+msgid "Enable Navigation Bar"
+msgstr "Naviqasiya panelini qoş"
+
+#: screens/sui_quicksettings_bar.lua:1106
+msgid "Enable Quick Settings Bar"
+msgstr "Sürətli parametrlər panelini qoş"
+
+#: screens/sui_menu.lua:838
+msgid "Enable Status Bar"
+msgstr "Vəziyyət panelini qoş"
+
+#: screens/sui_menu.lua:1779
+msgid "Enable Title Bar"
+msgstr "Başlıq panelini qoş"
+
+#: screens/sui_menu.lua:2239
+msgid "Enable Wallpaper"
+msgstr "Fon şəklini qoş"
+
+#: features/sui_style.lua:1789
+msgid "Enable custom UI font"
+msgstr "Fərdi interfeys şriftini qoş"
+
+#: features/sui_quickactions.lua:2092
+msgid "Enter the Unicode codepoint (hex) of a Nerd Fonts symbol.\nYou can look up codes with wakamaifondue.com using the file:\n  /koreader/fonts/nerdfonts/symbols.ttf\nLeave blank and press OK to remove a Nerd Font icon."
+msgstr "Nerd Fonts simvolunun Unicode kod nöqtəsini (onaltılıq) daxil edin.\nKodları wakamaifondue.com saytında bu faylla axtara bilərsiniz:\n  /koreader/fonts/nerdfonts/symbols.ttf\nNerd Font işarəsini silmək üçün boş saxlayıb \"Oldu\" düyməsinə basın."
+
+#: screens/sui_menu.lua:3867
+msgid "Error applying pack:"
+msgstr "Dəstin tətbiqi zamanı xəta:"
+
+#: infra/sui_updater.lua:638
+msgid "Error checking for updates."
+msgstr "Yeniləmələri yoxlayarkən xəta baş verdi."
+
+#: infra/sui_updater.lua:643
+msgid "Error checking for updates: "
+msgstr "Yeniləmələri yoxlayarkən xəta: "
+
+#: features/sui_presets.lua:1121
+#: screens/sui_menu.lua:4272
+msgid "Error exporting preset: "
+msgstr "Hazır quruluşu ixrac edərkən xəta: "
+
+#: features/sui_style.lua:2040
+msgid "Error extracting zip: "
+msgstr "ZIP faylını çıxararkən xəta: "
+
+#: features/sui_presets.lua:1095
+#: screens/sui_menu.lua:4245
+msgid "Error importing preset: "
+msgstr "Hazır quruluşu idxal edərkən xəta: "
+
+#: modules/module_reading_goals.lua:1150
+msgid "Error in Reading Goals: check crash.log"
+msgstr "Oxu məqsədlərində xəta: crash.log faylına baxın"
+
+#: screens/sui_menu.lua:3785
+msgid "Error installing pack:"
+msgstr "Dəstin quraşdırılması zamanı xəta:"
+
+#: screens/sui_stats_windows.lua:1216
+msgid "Exclude from goals"
+msgstr "Məqsədlərə daxil etmə"
+
+#: screens/sui_stats_windows.lua:839
+#: screens/sui_stats_windows.lua:845
+msgid "Excluded"
+msgstr "Daxil edilməyib"
+
+#: features/sui_backup.lua:1099
+msgid "Export"
+msgstr "İxrac et"
+
+#: features/sui_backup.lua:1125
+msgid "Export Full Backup…"
+msgstr "Tam ehtiyat nüsxəni ixrac et…"
+
+#: features/sui_backup.lua:1078
+msgid "Export now…"
+msgstr "İndi ixrac et…"
+
+#: features/sui_presets.lua:1109
+#: screens/sui_menu.lua:4259
+msgid "Export preset"
+msgstr "Hazır quruluşu ixrac et"
+
+#: screens/sui_settings_window.lua:390
+#: screens/sui_settings_window.lua:1078
+msgid "Extra Custom Screens"
+msgstr "Əlavə fərdi ekranlar"
+
+#: screens/sui_menu.lua:564
+msgid "Extra Small"
+msgstr "Çox kiçik"
+
+#: infra/sui_updater.lua:439
+msgid "Extraction error: "
+msgstr "Çıxarma xətası: "
+
+#: screens/sui_stats_windows.lua:3469
+msgid "FREEZES"
+msgstr "Dondurmalar"
+
+#: screens/sui_menu.lua:4432
+msgid "Factory Reset"
+msgstr "Zavod parametrlərinə qaytar"
+
+#: screens/sui_menu.lua:3274
+msgid "Fade Finished Books"
+msgstr "Bitirilmiş kitabları solğunlaşdır"
+
+#: screens/sui_menu.lua:3290
+msgid "Fade Intensity"
+msgstr "Solğunluq dərəcəsi"
+
+#: screens/sui_menu.lua:3291
+msgid "Fades finished book covers towards white.\n50% is the default."
+msgstr "Bitirilmiş kitabların üzlüklərini ağa doğru solğunlaşdırır.\nStandart dəyər: 50%."
+
+#: screens/sui_menu.lua:2400
+msgid "Fades the wallpaper towards white to improve text readability.\n0% is the default (no lightening)."
+msgstr "Mətnin oxunaqlığını artırmaq üçün fon şəklini ağa doğru solğunlaşdırır.\nStandart dəyər: 0% (açıqlaşdırma yoxdur)."
+
+#: features/sui_quickactions.lua:817
+#: features/sui_quickactions.lua:2226
+#: infra/sui_config.lua:123
+#: modules/module_coverdeck.lua:1434
+msgid "Favorites"
+msgstr "Seçilmişlər"
+
+#: features/sui_quickactions.lua:824
+msgid "Favorites not available."
+msgstr "Seçilmişlər əlçatan deyil."
+
+#: modules/module_feat_coll.lua:370
+#: modules/module_feat_coll.lua:426
+msgid "Featured Collection"
+msgstr "Önə çıxarılan kolleksiya"
+
+#: modules/module_feat_coll.lua:87
+msgid "Featured Collection — tap to configure"
+msgstr "Önə çıxarılan kolleksiya — tənzimləmək üçün toxunun"
+
+#: engines/sui_heatmap_widgets.lua:87
+msgid "Feb"
+msgstr "Fev"
+
+#: modules/module_clock.lua:62
+#: screens/sui_stats_windows.lua:2815
+msgid "February"
+msgstr "Fevral"
+
+#: features/sui_quickactions.lua:424
+msgid "Fetching bookmarks…"
+msgstr "Əlfəcinlər alınır…"
+
+#: modules/module_clock.lua:319
+msgid "Fifteen"
+msgstr "On beş"
+
+#: modules/module_clock.lua:325
+msgid "Fifty"
+msgstr "Əlli"
+
+#: features/sui_quickactions.lua:805
+msgid "File Manager not available."
+msgstr "Fayl meneceri əlçatan deyil."
+
+#: features/sui_quickactions.lua:2228
+msgid "File Search"
+msgstr "Fayl axtarışı"
+
+#: features/sui_backup.lua:566
+msgid "File not found."
+msgstr "Fayl tapılmadı."
+
+#: features/sui_style.lua:1987
+msgid "File not found: "
+msgstr "Fayl tapılmadı: "
+
+#: modules/module_library.lua:216
+msgid "File size (largest)"
+msgstr "Fayl ölçüsü (ən böyük)"
+
+#: modules/module_library.lua:217
+msgid "File size (smallest)"
+msgstr "Fayl ölçüsü (ən kiçik)"
+
+#: engines/sui_asset_browser.lua:274
+msgid "Filter by name…"
+msgstr "Ada görə süzgəcdən keçir…"
+
+#: screens/sui_menu.lua:3267
+msgid "Finished Books"
+msgstr "Bitirilmiş kitablar"
+
+#: modules/module_clock.lua:316
+msgid "Five"
+msgstr "Beş"
+
+#: modules/module_quote.lua:1579
+msgid "Fixed Height"
+msgstr "Sabit hündürlük"
+
+#: modules/module_quick_actions.lua:633
+#: modules/module_reading_stats.lua:824
+#: screens/sui_menu.lua:4356
+#: screens/sui_quicksettings_bar.lua:1307
+msgid "Flat"
+msgstr "Yastı"
+
+#: modules/module_library.lua:292
+msgid "Flat Library"
+msgstr "Yastı kitabxana"
+
+#: features/sui_quickactions.lua:2704
+msgid "Folder"
+msgstr "Qovluq"
+
+#: screens/sui_menu.lua:2874
+msgid "Folder Cover Type"
+msgstr "Qovluq üzlüyünün növü"
+
+#: features/sui_style.lua:1296
+msgid "Folder Covers"
+msgstr "Qovluq üzlükləri"
+
+#: features/sui_style.lua:202
+msgid "Folder Covers: Empty Folder"
+msgstr "Qovluq üzlükləri: boş qovluq"
+
+#: screens/sui_menu.lua:3311
+msgid "Folder Name"
+msgstr "Qovluq adı"
+
+#: screens/sui_menu.lua:3420
+msgid "Folder Name Text Size"
+msgstr "Qovluq adının mətn ölçüsü"
+
+#: features/sui_quickactions.lua:2229
+msgid "Folder Shortcuts"
+msgstr "Qovluqlara sürətli keçidlər"
+
+#: features/library/sui_foldercovers.lua:647
+#: features/library/sui_group_actions.lua:76
+#: features/library/sui_library_browse.lua:366
+#: features/library/sui_series_grouping.lua:87
+msgid "Folder cover"
+msgstr "Qovluq üzlüyü"
+
+#: features/sui_backup.lua:120
+msgid "Folder covers, browse modes, series grouping"
+msgstr "Qovluq üzlükləri, gözdən keçirmə rejimləri, silsilə üzrə qruplaşdırma"
+
+#: engines/sui_book_grid.lua:1913
+#: modules/module_coverdeck.lua:1735
+msgid "Follow Library"
+msgstr "Kitabxanaya uyğun"
+
+#: features/sui_backup.lua:105
+msgid "Fonts, icon assignments, icon presets"
+msgstr "Şriftlər, işarə təyinatları, hazır işarə quruluşları"
+
+#: modules/module_clock.lua:325
+msgid "Forty"
+msgstr "Qırx"
+
+#: modules/module_clock.lua:316
+msgid "Four"
+msgstr "Dörd"
+
+#: modules/module_clock.lua:319
+msgid "Fourteen"
+msgstr "On dörd"
+
+#: engines/sui_book_grid.lua:1869
+#: modules/module_currently.lua:1930
+#: modules/module_heatmap.lua:365
+#: modules/module_reading_goals.lua:1587
+msgid "Frame"
+msgstr "Çərçivə"
+
+#: screens/sui_menu.lua:1276
+#: screens/sui_menu.lua:4367
+msgid "Framed"
+msgstr "Çərçivəli"
+
+#: modules/module_reading_stats.lua:903
+#: modules/module_reading_stats.lua:908
+msgid "Freezes"
+msgstr "Dondurmalar"
+
+#: screens/sui_stats_windows.lua:3075
+msgid "Freezes can only cover a single missed day, and only right after an active one. Tap yesterday's cell to use one, when eligible."
+msgstr "Dondurma yalnız oxuduğunuz gündən dərhal sonrakı bir buraxılmış günü əvəz edə bilər. Şərtlər uyğundursa, dondurmadan istifadə etmək üçün dünənin xanasına toxunun."
+
+#: engines/sui_heatmap_widgets.lua:95
+#: screens/sui_stats_windows.lua:2805
+msgid "Fri"
+msgstr "Cüm"
+
+#: modules/module_clock.lua:59
+msgid "Friday"
+msgstr "Cümə"
+
+#: screens/sui_quicksettings_bar.lua:320
+#: screens/sui_quicksettings_bar.lua:342
+msgid "Frontlight"
+msgstr "Ön işıq"
+
+#: screens/sui_quicksettings_bar.lua:1202
+msgid "Frontlight Slider"
+msgstr "Ön işıq sürüşdürmə çubuğu"
+
+#: features/sui_quickactions.lua:389
+msgid "Frontlight not available on this device."
+msgstr "Bu cihazda ön işıq əlçatan deyil."
+
+#: features/sui_backup.lua:649
+msgid "General — %d settings"
+msgstr "Ümumi — %d parametr"
+
+#: screens/sui_menu.lua:2575
+msgid "Gesture Only"
+msgstr "Yalnız jest"
+
+#: screens/sui_menu.lua:4320
+#: screens/sui_menu.lua:4327
+msgid "Global Text Size"
+msgstr "Ümumi mətn ölçüsü"
+
+#: screens/sui_settings_window.lua:352
+msgid "Global custom actions & icons"
+msgstr "Ümumi fərdi əməllər və işarələr"
+
+#: screens/sui_menu.lua:4328
+msgid "Global scale applied to all of KOReader's interface text — menus, dialogs, titles, and Simple UI. It does not change the book's reading font size, which has its own setting.\n100% is the default size. Useful when a chosen UI font (see UI Font above) renders smaller or larger than usual."
+msgstr "KOReader interfeysindəki bütün mətnlərə — menyulara, dialoqlara, başlıqlara və Simple UI mətnlərinə tətbiq olunan ümumi miqyas. Kitabın ayrıca tənzimlənən oxu şriftinin ölçüsünü dəyişmir.\nStandart ölçü: 100%. Seçilmiş interfeys şrifti (yuxarıdakı interfeys şriftinə baxın) adi ölçüdən kiçik və ya böyük görünəndə faydalıdır."
+
+#: screens/sui_menu.lua:2472
+msgid "Global scale for all modules.\nIndividual overrides in Module Settings take precedence.\n100% is the default size."
+msgstr "Bütün modullar üçün ümumi miqyas.\nModul parametrlərindəki fərdi dəyərlərə üstünlük verilir.\nStandart ölçü: 100%."
+
+#: screens/sui_onboarding.lua:166
+msgid "Go to Settings > Home Screen to edit your layout whenever you want."
+msgstr "Düzülüşü istənilən vaxt redaktə etmək üçün Parametrlər > Əsas ekran bölməsinə keçin."
+
+#: modules/module_reading_goals.lua:1289
+#: modules/module_reading_goals.lua:1354
+#: modules/module_reading_goals.lua:1368
+msgid "Goals"
+msgstr "Məqsədlər"
+
+#: features/sui_backup.lua:129
+msgid "Goals & Streaks"
+msgstr "Məqsədlər və ardıcıllıqlar"
+
+#: engines/sui_book_grid.lua:1821
+#: engines/sui_book_grid.lua:1832
+msgid "Grid size"
+msgstr "Tor ölçüsü"
+
+#: features/sui_quickactions.lua:2359
+#: features/sui_quickactions.lua:2687
+msgid "Group"
+msgstr "Qrup"
+
+#: screens/sui_menu.lua:2856
+msgid "Group by Book Series"
+msgstr "Kitab silsiləsi üzrə qruplaşdır"
+
+#: features/sui_quickactions.lua:2712
+msgid "Group of Quick Actions"
+msgstr "Sürətli əməllər qrupu"
+
+#: features/sui_quickactions.lua:2694
+msgid "Group: select actions"
+msgstr "Qrup: əməlləri seçin"
+
+#: modules/module_currently.lua:1486
+msgid "Grows or shrinks the cover so its height always matches the text column, keeping the cover's proportions.\nThe spacing between cover and text stays as set above.\nThe Cover size setting still applies on top of this, and the cover never shrinks below its 100% size."
+msgstr "Üzlüyün nisbətlərini qoruyaraq hündürlüyünü həmişə mətn sütununa uyğunlaşdırmaq üçün onu böyüdür və ya kiçildir.\nÜzlüklə mətn arasındakı məsafə yuxarıda təyin edildiyi kimi qalır.\nÜzlük ölçüsü parametri buna əlavə olaraq tətbiq edilir və üzlük heç vaxt 100% ölçüsündən kiçik olmur."
+
+#: screens/sui_menu.lua:1311
+msgid "Height of the bottom navigation bar.\n100% is the default size."
+msgstr "Aşağı naviqasiya panelinin hündürlüyü.\nStandart ölçü: 100%."
+
+#: modules/module_spacer.lua:91
+msgid "Height of the spacer.\n100% is the default size.\nTap the arrows for fine steps, hold for larger ones."
+msgstr "Boşluq elementinin hündürlüyü.\nStandart ölçü: 100%.\nKiçik addımlar üçün oxlara toxunun, böyük addımlar üçün basıb saxlayın."
+
+#: screens/sui_menu.lua:1034
+msgid "Height of the top status bar.\n100% is the default size."
+msgstr "Yuxarı vəziyyət panelinin hündürlüyü.\nStandart ölçü: 100%."
+
+#: modules/module_collections.lua:1381
+#: screens/sui_menu.lua:480
+#: screens/sui_menu.lua:539
+#: screens/sui_menu.lua:2951
+#: screens/sui_menu.lua:2958
+#: screens/sui_menu.lua:2985
+#: screens/sui_menu.lua:3025
+#: screens/sui_menu.lua:3031
+#: screens/sui_menu.lua:3042
+#: screens/sui_menu.lua:3079
+#: screens/sui_menu.lua:3085
+#: screens/sui_menu.lua:3096
+#: screens/sui_menu.lua:3317
+#: screens/sui_menu.lua:3348
+msgid "Hidden"
+msgstr "Gizli"
+
+#: modules/module_collections.lua:1370
+msgid "Hide Book Spine"
+msgstr "Kitabın belini gizlət"
+
+#: modules/module_recent.lua:70
+msgid "Hide Currently Reading book"
+msgstr "Hazırda oxunan kitabı gizlət"
+
+#: screens/sui_menu.lua:3522
+msgid "Hide Folder Book Spine"
+msgstr "Qovluqdakı kitabın belini gizlət"
+
+#: modules/module_quick_actions.lua:386
+#: modules/module_quick_actions.lua:539
+#: screens/sui_menu.lua:1981
+#: screens/sui_quicksettings_bar.lua:1235
+msgid "Hide Label"
+msgstr "Yazını gizlət"
+
+#: screens/sui_menu.lua:3516
+msgid "Hide Selection Underline"
+msgstr "Seçimin alt xəttini gizlət"
+
+#: screens/sui_menu.lua:1079
+msgid "Hide Wi-Fi Icon When Off"
+msgstr "Wi-Fi sönülü olduqda işarəsini gizlət"
+
+#: screens/sui_menu.lua:547
+msgid "Hides the pagination bar on the homescreen.\nNot available when Navpager is active."
+msgstr "Əsas ekranda səhifələmə panelini gizlədir.\nNaviqasiya ilə səhifələmə aktiv olduqda əlçatan deyil."
+
+#: screens/sui_menu.lua:2630
+msgid "High-Quality Cover"
+msgstr "Yüksək keyfiyyətli üzlük"
+
+#: screens/sui_stats_windows.lua:1210
+#: screens/sui_stats_windows.lua:3884
+msgid "Highlights"
+msgstr "Vurğulamalar"
+
+#: features/sui_quickactions.lua:472
+#: features/sui_quickactions.lua:727
+#: features/sui_quickactions.lua:2224
+#: infra/sui_config.lua:119
+msgid "History"
+msgstr "Tarixçə"
+
+#: features/sui_quickactions.lua:734
+msgid "History not available."
+msgstr "Tarixçə əlçatan deyil."
+
+#: features/sui_quickactions.lua:668
+#: infra/sui_config.lua:117
+msgid "Home"
+msgstr "Əsas"
+
+#: engines/sui_screen_engine.lua:1371
+#: features/sui_backup.lua:109
+#: infra/sui_patches.lua:1134
+#: infra/sui_patches.lua:1161
+#: screens/sui_menu.lua:4560
+#: screens/sui_settings_window.lua:323
+#: screens/sui_settings_window.lua:1077
+msgid "Home Screen"
+msgstr "Əsas ekran"
+
+#: screens/sui_settings_window.lua:1093
+msgid "Home Screen Presets"
+msgstr "Əsas ekranın hazır quruluşları"
+
+#: screens/sui_menu.lua:493
+msgid "Home Screen Style"
+msgstr "Əsas ekranın üslubu"
+
+#: features/sui_quickactions.lua:489
+msgid "Home folder"
+msgstr "Əsas qovluq"
+
+#: features/sui_quickactions.lua:491
+msgid "Home folder + subfolders"
+msgstr "Əsas qovluq + alt qovluqlar"
+
+#: screens/sui_menu.lua:2717
+msgid "Home key opens Home Screen"
+msgstr "Əsas ekran düyməsi əsas ekranı açır"
+
+#: features/sui_quickactions.lua:709
+msgid "Homescreen not available."
+msgstr "Əsas ekran əlçatan deyil."
+
+#: modules/module_currently.lua:1453
+msgid "Horizontal space between the cover and the text.\n100% is the default spacing."
+msgstr "Üzlüklə mətn arasındakı üfüqi məsafə.\nStandart aralıq: 100%."
+
+#: modules/module_reading_goals.lua:766
+msgid "Hours per month:"
+msgstr "Ayda saat:"
+
+#: modules/module_heatmap.lua:296
+msgid "How many weeks of history to include, and (in Calendar view) how many weeks the grid shows — this count is unaffected by Scale, which only resizes the cells. In Time of day view, this only changes how much history feeds the shading — the grid itself always has one column per hour."
+msgstr "Tarixçənin neçə həftəsini daxil etməyi və təqvim görünüşündə torun neçə həftə göstərməsini təyin edir — bu say yalnız xanaların ölçüsünü dəyişən miqyasdan asılı deyil. Günün vaxtı görünüşündə bu, yalnız kölgələndirmə üçün istifadə olunan tarixçənin həcmini dəyişir — torun özündə həmişə hər saat üçün bir sütun olur."
+
+#: features/sui_quickactions.lua:2384
+#: features/sui_quickactions.lua:2388
+msgid "Icon"
+msgstr "İşarə"
+
+#: screens/sui_menu.lua:3705
+msgid "Icon Packs"
+msgstr "İşarə dəstləri"
+
+#: screens/sui_menu.lua:3882
+msgid "Icon Presets"
+msgstr "Hazır işarə quruluşları"
+
+#: screens/sui_menu.lua:1346
+#: screens/sui_menu.lua:1347
+msgid "Icon Size"
+msgstr "İşarə ölçüsü"
+
+#: features/sui_backup.lua:147
+msgid "Icon files and installed packs from sui_icons/"
+msgstr "sui_icons/ qovluğundakı işarə faylları və quraşdırılmış dəstlər"
+
+#: features/sui_quickactions.lua:2380
+msgid "Icon: Default"
+msgstr "İşarə: standart"
+
+#: screens/sui_menu.lua:208
+#: screens/sui_menu.lua:3651
+msgid "Icons"
+msgstr "İşarələr"
+
+#: screens/sui_menu.lua:209
+msgid "Icons only"
+msgstr "Yalnız işarələr"
+
+#: screens/sui_settings_window.lua:345
+msgid "Icons, fonts and appearance"
+msgstr "İşarələr, şriftlər və görünüş"
+
+#: screens/sui_onboarding.lua:170
+msgid "If you selected the Momentum Preset, long press the Reading Goal module to choose and set your reading goals."
+msgstr "Təkan hazır quruluşunu seçmisinizsə, oxu məqsədlərinizi seçib təyin etmək üçün oxu məqsədi modulunu basıb saxlayın."
+
+#: features/sui_backup.lua:1135
+msgid "Import Backup…"
+msgstr "Ehtiyat nüsxəni idxal et…"
+
+#: features/sui_presets.lua:1072
+#: screens/sui_menu.lua:4221
+msgid "Import preset"
+msgstr "Hazır quruluşu idxal et"
+
+#: screens/sui_menu.lua:3790
+msgid "Install pack from ZIP"
+msgstr "ZIP faylından dəst quraşdır"
+
+#: screens/sui_menu.lua:3283
+msgid "Intensity"
+msgstr "İntensivlik"
+
+#: screens/sui_menu.lua:1508
+msgid "Invalid arrangement.\nKeep items between the Left and Right separators."
+msgstr "Yanlış düzülüş.\nElementləri sol və sağ ayırıcılar arasında saxlayın."
+
+#: screens/sui_menu.lua:733
+msgid "Invalid arrangement.\nKeep the Left, Center and Right separators in order."
+msgstr "Yanlış düzülüş.\nSol, mərkəz və sağ ayırıcıları ardıcıllıqla saxlayın."
+
+#: features/sui_presets.lua:430
+#: features/sui_presets.lua:610
+msgid "Invalid data"
+msgstr "Yanlış məlumat"
+
+#: features/sui_quickactions.lua:2123
+msgid "Invalid input. Please enter 1–6 hexadecimal digits (0–9, A–F)."
+msgstr "Yanlış giriş. 1–6 onaltılıq rəqəm daxil edin (0–9, A–F)."
+
+#: features/sui_presets.lua:426
+#: features/sui_presets.lua:606
+msgid "Invalid preset file"
+msgstr "Yanlış hazır quruluş faylı"
+
+#: screens/sui_menu.lua:2374
+msgid "Invert in Night Mode"
+msgstr "Gecə rejimində rəngləri tərsinə çevir"
+
+#: modules/module_clock.lua:1045
+#: modules/module_clock.lua:1068
+#: modules/module_clock.lua:1077
+#: modules/module_clock.lua:1115
+#: modules/module_coverdeck.lua:1602
+#: modules/module_coverdeck.lua:1642
+#: modules/module_coverdeck.lua:1656
+#: modules/module_currently.lua:1618
+#: modules/module_currently.lua:1623
+#: modules/module_currently.lua:1646
+#: modules/module_reading_stats.lua:694
+#: modules/module_reading_stats.lua:715
+#: modules/module_reading_stats.lua:737
+#: screens/sui_menu.lua:857
+#: screens/sui_menu.lua:862
+#: screens/sui_menu.lua:951
+#: screens/sui_menu.lua:1991
+#: screens/sui_menu.lua:1996
+#: screens/sui_menu.lua:2022
+msgid "Items"
+msgstr "Elementlər"
+
+#: engines/sui_heatmap_widgets.lua:87
+msgid "Jan"
+msgstr "Yan"
+
+#: modules/module_clock.lua:62
+#: screens/sui_stats_windows.lua:2815
+msgid "January"
+msgstr "Yanvar"
+
+#: engines/sui_heatmap_widgets.lua:88
+msgid "Jul"
+msgstr "İyl"
+
+#: modules/module_clock.lua:63
+#: screens/sui_stats_windows.lua:2816
+msgid "July"
+msgstr "İyul"
+
+#: engines/sui_heatmap_widgets.lua:87
+msgid "Jun"
+msgstr "İyn"
+
+#: modules/module_clock.lua:63
+#: screens/sui_stats_windows.lua:2816
+msgid "June"
+msgstr "İyun"
+
+#: modules/module_quick_actions.lua:648
+msgid "Justified"
+msgstr "Hər iki kənara düzləndirilmiş"
+
+#: screens/sui_menu.lua:517
+msgid "KOReader"
+msgstr "KOReader"
+
+#: screens/sui_stats_windows.lua:2727
+msgid "LAST 7 DAYS"
+msgstr "Son 7 gün"
+
+#: modules/module_quick_actions.lua:556
+#: screens/sui_quicksettings_bar.lua:1224
+msgid "Label"
+msgstr "Yazı"
+
+#: screens/sui_menu.lua:2503
+msgid "Label Scale"
+msgstr "Yazı miqyası"
+
+#: screens/sui_menu.lua:1359
+#: screens/sui_menu.lua:1360
+msgid "Label Size"
+msgstr "Yazı ölçüsü"
+
+#: screens/sui_menu.lua:2492
+msgid "Labels"
+msgstr "Yazılar"
+
+#: screens/sui_menu.lua:1830
+msgid "Large"
+msgstr "Böyük"
+
+#: features/sui_backup.lua:1031
+msgid "Last backup: %s%s"
+msgstr "Son ehtiyat nüsxə: %s%s"
+
+#: features/sui_backup.lua:1028
+msgid "Last backup: never"
+msgstr "Son ehtiyat nüsxə: heç vaxt"
+
+#: features/sui_backup.lua:1009
+#: infra/sui_updater.lua:449
+#: screens/sui_menu.lua:444
+#: screens/sui_menu.lua:847
+#: screens/sui_menu.lua:1058
+#: screens/sui_menu.lua:1119
+#: screens/sui_menu.lua:1335
+#: screens/sui_menu.lua:1794
+#: screens/sui_menu.lua:3448
+#: screens/sui_menu.lua:3471
+#: screens/sui_menu.lua:3493
+#: screens/sui_menu.lua:4342
+#: screens/sui_menu.lua:4544
+#: screens/sui_quicksettings_bar.lua:1120
+msgid "Later"
+msgstr "Daha sonra"
+
+#: modules/module_currently.lua:1472
+#: modules/module_reading_goals.lua:1509
+msgid "Layout"
+msgstr "Düzülüş"
+
+#: screens/sui_settings_window.lua:1084
+#: screens/sui_settings_window.lua:1085
+msgid "Layout Editor"
+msgstr "Düzülüş redaktoru"
+
+#: features/sui_backup.lua:110
+msgid "Layout, modules, custom screens, presets"
+msgstr "Düzülüş, modullar, fərdi ekranlar, hazır quruluşlar"
+
+#: screens/sui_settings_window.lua:324
+msgid "Layout, wallpaper, presets and behaviour"
+msgstr "Düzülüş, fon şəkli, hazır quruluşlar və davranış"
+
+#: modules/module_action_list.lua:66
+#: modules/module_action_list.lua:464
+#: modules/module_clock.lua:166
+#: modules/module_clock.lua:1198
+#: modules/module_quick_actions.lua:658
+#: modules/module_quote.lua:125
+#: modules/module_quote.lua:1558
+#: modules/module_reading_goals.lua:119
+#: modules/module_reading_goals.lua:1568
+#: modules/module_reading_stats.lua:91
+#: modules/module_reading_stats.lua:850
+#: screens/sui_menu.lua:704
+#: screens/sui_menu.lua:937
+#: screens/sui_menu.lua:1475
+#: screens/sui_menu.lua:1682
+msgid "Left"
+msgstr "Sol"
+
+#: engines/sui_heatmap_widgets.lua:375
+#: modules/module_heatmap.lua:176
+msgid "Less"
+msgstr "Daha az"
+
+#: features/sui_backup.lua:119
+#: features/sui_quickactions.lua:639
+#: infra/sui_config.lua:116
+#: infra/sui_config.lua:375
+#: screens/sui_menu.lua:4564
+#: screens/sui_settings_window.lua:337
+#: screens/sui_settings_window.lua:1080
+#: screens/sui_titlebar.lua:1089
+msgid "Library"
+msgstr "Kitabxana"
+
+#: screens/sui_menu.lua:1802
+#: screens/sui_menu.lua:1805
+msgid "Library Buttons"
+msgstr "Kitabxana düymələri"
+
+#: features/sui_presets.lua:187
+msgid "Library View"
+msgstr "Kitabxana görünüşü"
+
+#: engines/sui_book_grid.lua:1915
+#: modules/module_collections.lua:1415
+#: modules/module_coverdeck.lua:1737
+#: screens/sui_menu.lua:2999
+#: screens/sui_menu.lua:3011
+#: screens/sui_menu.lua:3053
+#: screens/sui_menu.lua:3065
+#: screens/sui_menu.lua:3107
+#: screens/sui_menu.lua:3119
+#: screens/sui_menu.lua:3174
+#: screens/sui_menu.lua:3186
+#: screens/sui_menu.lua:3241
+#: screens/sui_menu.lua:3253
+#: screens/sui_menu.lua:3395
+#: screens/sui_menu.lua:3400
+msgid "Light"
+msgstr "Açıq"
+
+#: screens/sui_menu.lua:2386
+msgid "Lighten"
+msgstr "Açıqlaşdır"
+
+#: screens/sui_menu.lua:2399
+msgid "Lighten Wallpaper"
+msgstr "Fon şəklini açıqlaşdır"
+
+#: modules/module_reading_stats.lua:834
+msgid "List"
+msgstr "Siyahı"
+
+#: screens/sui_stats_windows.lua:2491
+msgid "Loading statistics…"
+msgstr "Statistika yüklənir…"
+
+#: screens/sui_menu.lua:2451
+msgid "Lock Scale"
+msgstr "Miqyası kilidlə"
+
+#: infra/sui_config.lua:1277
+msgid "Long Press"
+msgstr "Basıb saxlama"
+
+#: screens/sui_onboarding.lua:161
+msgid "Long press to customize"
+msgstr "Fərdiləşdirmək üçün basıb saxlayın"
+
+#: features/sui_backup.lua:521
+#: features/sui_backup.lua:570
+#: features/sui_presets.lua:409
+#: features/sui_presets.lua:421
+#: features/sui_presets.lua:589
+#: features/sui_presets.lua:601
+msgid "LuaSettings module unavailable"
+msgstr "LuaSettings modulu əlçatan deyil"
+
+#: screens/sui_onboarding.lua:127
+msgid "Make it yours"
+msgstr "Özünüzə uyğunlaşdırın"
+
+#: screens/sui_menu.lua:2718
+msgid "Makes the device's physical Home key open the SimpleUI Home Screen — while reading and while browsing files — instead of KOReader's native Home behaviour. The file browser title-bar home icon still goes to the home folder."
+msgstr "Cihazın fiziki əsas ekran düyməsi həm oxuyarkən, həm də faylları gözdən keçirərkən KOReader-in əsas ekrana keçid üçün standart davranışı əvəzinə Simple UI əsas ekranını açır. Fayl brauzerinin başlıq panelindəki ev işarəsi isə yenə əsas qovluğa aparır."
+
+#: features/sui_presets.lua:897
+#: features/sui_presets.lua:973
+#: features/sui_presets.lua:978
+#: screens/sui_menu.lua:4049
+#: screens/sui_menu.lua:4123
+#: screens/sui_menu.lua:4128
+msgid "Manage presets"
+msgstr "Hazır quruluşları idarə et"
+
+#: modules/module_collections.lua:525
+msgid "Manual order"
+msgstr "Əl ilə sıralama"
+
+#: modules/module_reading_goals.lua:1499
+msgid "Manually Tracked Books"
+msgstr "Əl ilə izlənən kitablar"
+
+#: modules/module_reading_goals.lua:1487
+msgid "Manually Tracked Books  (%s)"
+msgstr "Əl ilə izlənən kitablar  (%s)"
+
+#: engines/sui_heatmap_widgets.lua:87
+msgid "Mar"
+msgstr "Mar"
+
+#: modules/module_clock.lua:62
+#: screens/sui_stats_windows.lua:2815
+msgid "March"
+msgstr "Mart"
+
+#: screens/sui_quicksettings_bar.lua:367
+#: screens/sui_quicksettings_bar.lua:473
+msgid "Max"
+msgstr "Maksimum"
+
+#: engines/sui_heatmap_widgets.lua:87
+#: modules/module_clock.lua:63
+#: screens/sui_stats_windows.lua:2816
+msgid "May"
+msgstr "May"
+
+#: screens/sui_titlebar.lua:102
+#: screens/sui_titlebar.lua:107
+msgid "Menu"
+msgstr "Menyu"
+
+#: features/sui_style.lua:81
+msgid "Menu Button"
+msgstr "Menyu düyməsi"
+
+#: modules/module_clock.lua:386
+msgid "Midnight"
+msgstr "Gecə yarısı"
+
+#: features/sui_presets.lua:149
+msgid "Mindful Reading"
+msgstr "Diqqətli oxu"
+
+#: screens/sui_menu.lua:372
+msgid "Minimum 1 tab required in navpager mode."
+msgstr "Naviqasiya ilə səhifələmə rejimində ən azı 1 vərəq tələb olunur."
+
+#: screens/sui_menu.lua:373
+msgid "Minimum 2 tabs required. Select another tab first."
+msgstr "Ən azı 2 vərəq tələb olunur. Əvvəlcə başqa vərəq seçin."
+
+#: modules/module_reading_goals.lua:778
+msgid "Minutes per day:"
+msgstr "Gündə dəqiqə:"
+
+#: screens/sui_menu.lua:456
+msgid "Mode"
+msgstr "Rejim"
+
+#: screens/sui_menu.lua:2469
+msgid "Module Scale"
+msgstr "Modul miqyası"
+
+#: infra/sui_config.lua:1274
+#: screens/sui_menu.lua:2198
+msgid "Module Settings"
+msgstr "Modul parametrləri"
+
+#: screens/sui_menu.lua:3709
+msgid "Module unavailable"
+msgstr "Modul əlçatan deyil"
+
+#: screens/sui_menu.lua:2462
+#: screens/sui_menu.lua:2737
+msgid "Modules"
+msgstr "Modullar"
+
+#: screens/sui_menu.lua:2186
+msgid "Modules  (%d)"
+msgstr "Modullar  (%d)"
+
+#: engines/sui_screen_engine.lua:2781
+msgid "Modules exceed the visible area.\nMove some to another page or adjust the scale."
+msgstr "Modullar görünən sahədən kənara çıxır.\nBəzilərini başqa səhifəyə köçürün və ya miqyası tənzimləyin."
+
+#: features/sui_presets.lua:169
+msgid "Momentum"
+msgstr "Təkan"
+
+#: engines/sui_heatmap_widgets.lua:95
+#: screens/sui_stats_windows.lua:2805
+msgid "Mon"
+msgstr "B.e."
+
+#: modules/module_clock.lua:58
+msgid "Monday"
+msgstr "Bazar ertəsi"
+
+#: modules/module_reading_goals.lua:1312
+#: modules/module_reading_goals.lua:1359
+#: modules/module_reading_goals.lua:1396
+#: modules/module_reading_goals.lua:1427
+msgid "Monthly Goal"
+msgstr "Aylıq məqsəd"
+
+#: modules/module_reading_goals.lua:765
+msgid "Monthly Reading Goal"
+msgstr "Aylıq oxu məqsədi"
+
+#: engines/sui_heatmap_widgets.lua:382
+msgid "More"
+msgstr "Daha çox"
+
+#: main.lua:1083
+msgid "More by %s (%d)"
+msgstr "%s müəllifinin digər kitabları (%d)"
+
+#: engines/sui_window.lua:2853
+msgid "Move down"
+msgstr "Aşağı köçür"
+
+#: engines/sui_window.lua:2847
+#: screens/sui_settings_window.lua:704
+#: screens/sui_settings_window.lua:739
+msgid "Move to page"
+msgstr "Səhifəyə köçür"
+
+#: engines/sui_window.lua:2850
+msgid "Move up"
+msgstr "Yuxarı köçür"
+
+#: modules/module_quote.lua:1407
+msgid "My Highlights"
+msgstr "Vurğulamalarım"
+
+#: features/sui_presets.lua:795
+#: features/sui_presets.lua:800
+msgid "My Presets"
+msgstr "Hazır quruluşlarım"
+
+#: features/sui_quickactions.lua:2475
+msgid "Name"
+msgstr "Ad"
+
+#: modules/module_collections.lua:526
+msgid "Name (A–Z)"
+msgstr "Ad (A–Z)"
+
+#: modules/module_collections.lua:527
+msgid "Name (Z–A)"
+msgstr "Ad (Z–A)"
+
+#: screens/sui_menu.lua:3135
+#: screens/sui_menu.lua:3144
+#: screens/sui_menu.lua:3156
+#: features/library/sui_foldercovers.lua:314
+msgid "Native"
+msgstr "Daxili"
+
+#: screens/sui_bottombar.lua:821
+#: screens/sui_menu.lua:2773
+msgid "Navigation Bar"
+msgstr "Naviqasiya paneli"
+
+#: screens/sui_menu.lua:1310
+msgid "Navigation Bar Size"
+msgstr "Naviqasiya panelinin ölçüsü"
+
+#: screens/sui_menu.lua:1118
+msgid "Navigation Bar will be %s after restart.\n\nRestart now?"
+msgstr "Yenidən başladıqdan sonra naviqasiya paneli: %s.\n\nİndi yenidən başladılsın?"
+
+#: features/sui_backup.lua:115
+msgid "Navigation, status, title and quick settings bars"
+msgstr "Naviqasiya, vəziyyət, başlıq və sürətli parametrlər panelləri"
+
+#: features/sui_style.lua:1295
+#: screens/sui_menu.lua:469
+msgid "Navpager"
+msgstr "Naviqasiya ilə səhifələmə"
+
+#: screens/sui_menu.lua:476
+msgid "Navpager enabled.\n\nRestart now?"
+msgstr "Naviqasiya ilə səhifələmə qoşulub.\n\nİndi yenidən başladılsın?"
+
+#: features/sui_style.lua:161
+msgid "Navpager: Next"
+msgstr "Naviqasiya ilə səhifələmə: növbəti"
+
+#: features/sui_style.lua:155
+msgid "Navpager: Previous"
+msgstr "Naviqasiya ilə səhifələmə: əvvəlki"
+
+#: features/sui_quickactions.lua:2089
+msgid "Nerd Font Icon"
+msgstr "Nerd Font işarəsi"
+
+#: features/sui_quickactions.lua:2154
+msgid "Nerd Font symbol…"
+msgstr "Nerd Font simvolu…"
+
+#: features/sui_quickactions.lua:253
+msgid "Network manager unavailable."
+msgstr "Şəbəkə meneceri əlçatan deyil."
+
+#: screens/sui_menu.lua:2586
+msgid "Never"
+msgstr "Heç vaxt"
+
+#: engines/sui_book_grid.lua:535
+#: modules/module_new_books.lua:137
+#: features/library/sui_cover_widgets.lua:467
+#: features/library/sui_foldercovers.lua:1263
+#: features/library/sui_foldercovers.lua:1911
+msgid "New"
+msgstr "Yeni"
+
+#: engines/sui_book_grid.lua:2070
+msgid "New Badge Color"
+msgstr "Yeni nişanının rəngi"
+
+#: screens/sui_menu.lua:3198
+msgid "New Book"
+msgstr "Yeni kitab"
+
+#: engines/sui_book_grid.lua:2062
+#: engines/sui_book_grid.lua:2075
+msgid "New Book Badge"
+msgstr "Yeni kitab nişanı"
+
+#: modules/module_new_books.lua:82
+#: modules/module_new_books.lua:83
+msgid "New Books"
+msgstr "Yeni kitablar"
+
+#: features/sui_quickactions.lua:2348
+msgid "New Quick Action"
+msgstr "Yeni sürətli əməl"
+
+#: features/library/sui_group_actions.lua:97
+msgid "New collection name"
+msgstr "Yeni kolleksiya adı"
+
+#: screens/sui_bottombar.lua:501
+msgid "Next"
+msgstr "Növbəti"
+
+#: features/sui_quickactions.lua:880
+#: infra/sui_config.lua:127
+msgid "Night Mode"
+msgstr "Gecə rejimi"
+
+#: modules/module_clock.lua:317
+msgid "Nine"
+msgstr "Doqquz"
+
+#: modules/module_clock.lua:321
+msgid "Nineteen"
+msgstr "On doqquz"
+
+#: screens/sui_stats_windows.lua:1217
+msgid "No"
+msgstr "Xeyr"
+
+#: modules/module_quote.lua:1464
+#: modules/module_quote.lua:1513
+msgid "No .lua files found in sui_quotes/"
+msgstr "sui_quotes/ qovluğunda .lua faylı tapılmadı"
+
+#: screens/sui_menu.lua:3828
+msgid "No .zip files found.\nPlace .zip files in:\n%1"
+msgstr ".zip faylı tapılmadı.\n.zip fayllarını buraya yerləşdirin:\n%1"
+
+#: screens/sui_quicksettings_bar.lua:1138
+#: screens/sui_quicksettings_bar.lua:1158
+msgid "No actions active yet."
+msgstr "Hələ aktiv əməl yoxdur."
+
+#: features/sui_quickactions.lua:1624
+#: modules/module_action_list.lua:95
+#: modules/module_action_list.lua:114
+#: modules/module_quick_actions.lua:150
+#: screens/sui_settings_window.lua:657
+msgid "No actions configured"
+msgstr "Əməl tənzimlənməyib"
+
+#: modules/module_action_list.lua:94
+#: modules/module_action_list.lua:113
+#: modules/module_quick_actions.lua:149
+msgid "No actions configured  —  long press to configure"
+msgstr "Əməl tənzimlənməyib  —  tənzimləmək üçün basıb saxlayın"
+
+#: screens/sui_quicksettings_bar.lua:279
+msgid "No actions configured.\nGo to Bars → Quick Settings Bar."
+msgstr "Əməl tənzimlənməyib.\nPanellər → Sürətli parametrlər paneli bölməsinə keçin."
+
+#: features/sui_backup.lua:1170
+msgid "No backup loaded yet."
+msgstr "Hələ ehtiyat nüsxə yüklənməyib."
+
+#: features/sui_quickactions.lua:760
+msgid "No book in history."
+msgstr "Tarixçədə kitab yoxdur."
+
+#: screens/sui_stats_windows.lua:785
+msgid "No books finished in %s"
+msgstr "%s ərzində kitab bitirilməyib"
+
+#: features/library/sui_foldercovers.lua:651
+msgid "No books found in this folder."
+msgstr "Bu qovluqda kitab tapılmadı."
+
+#: features/library/sui_series_grouping.lua:91
+#: features/library/sui_series_grouping.lua:104
+msgid "No books found in this series."
+msgstr "Bu silsilədə kitab tapılmadı."
+
+#: features/library/sui_group_actions.lua:36
+#: features/library/sui_group_actions.lua:90
+#: features/library/sui_library_browse.lua:370
+#: features/library/sui_library_browse.lua:392
+msgid "No books found."
+msgstr "Kitab tapılmadı."
+
+#: modules/module_tbr.lua:402
+#: modules/module_tbr.lua:427
+#: modules/module_tbr.lua:502
+msgid "No books in To Be Read list."
+msgstr "Oxunacaqlar siyahısında kitab yoxdur."
+
+#: modules/module_feat_coll.lua:257
+#: modules/module_feat_coll.lua:281
+#: modules/module_feat_coll.lua:350
+msgid "No books in this collection."
+msgstr "Bu kolleksiyada kitab yoxdur."
+
+#: engines/sui_screen_engine.lua:441
+msgid "No books opened yet"
+msgstr "Hələ kitab açılmayıb"
+
+#: modules/module_coverdeck.lua:693
+#: modules/module_currently.lua:455
+msgid "No books to show yet — open a book to see it here."
+msgstr "Hələ göstəriləcək kitab yoxdur — burada görmək üçün kitab açın."
+
+#: modules/module_feat_coll.lua:407
+#: screens/sui_settings_window.lua:669
+msgid "No collection selected"
+msgstr "Kolleksiya seçilməyib"
+
+#: modules/module_feat_coll.lua:406
+msgid "No collection selected  —  long press to configure"
+msgstr "Kolleksiya seçilməyib  —  tənzimləmək üçün basıb saxlayın"
+
+#: modules/module_coverdeck.lua:1404
+msgid "No collections found"
+msgstr "Kolleksiya tapılmadı"
+
+#: modules/module_collections.lua:1271
+#: modules/module_collections.lua:1439
+#: modules/module_feat_coll.lua:134
+msgid "No collections found."
+msgstr "Kolleksiya tapılmadı."
+
+#: modules/module_collections.lua:1524
+msgid "No collections selected"
+msgstr "Kolleksiya seçilməyib"
+
+#: modules/module_collections.lua:1523
+msgid "No collections selected  —  long press to configure"
+msgstr "Kolleksiya seçilməyib  —  tənzimləmək üçün basıb saxlayın"
+
+#: modules/module_quote.lua:928
+msgid "No custom quotes found. Add a .lua file to the plugin's sui_quotes/ folder and select it in Settings."
+msgstr "Fərdi sitatlar tapılmadı. Qoşmanın sui_quotes/ qovluğuna .lua faylı əlavə edin və onu parametrlərdə seçin."
+
+#: screens/sui_settings_window.lua:441
+msgid "No custom screens yet."
+msgstr "Hələ fərdi ekran yoxdur."
+
+#: infra/sui_updater.lua:498
+msgid "No download file found.\n\nOpen the releases page?"
+msgstr "Endiriləcək fayl tapılmadı.\n\nBuraxılışlar səhifəsi açılsın?"
+
+#: features/sui_presets.lua:401
+#: features/sui_presets.lua:581
+msgid "No export directory"
+msgstr "İxrac qovluğu yoxdur"
+
+#: screens/sui_stats_windows.lua:159
+msgid "No filepath."
+msgstr "Fayl yolu yoxdur."
+
+#: features/sui_quickactions.lua:3153
+msgid "No folder, collection or plugin configured.\nGo to Simple UI → Settings → Quick Actions to set one."
+msgstr "Qovluq, kolleksiya və ya qoşma tənzimlənməyib.\nTəyin etmək üçün Simple UI → Parametrlər → Sürətli əməllər bölməsinə keçin."
+
+#: features/sui_style.lua:1804
+msgid "No fonts found."
+msgstr "Şrift tapılmadı."
+
+#: modules/module_quote.lua:1000
+msgid "No highlights found. Open a book and highlight some passages."
+msgstr "Vurğulama tapılmadı. Kitab açın və bəzi hissələri vurğulayın."
+
+#: features/sui_quickactions.lua:2189
+msgid "No icons found in:"
+msgstr "Burada işarə tapılmadı:"
+
+#: engines/sui_window.lua:2521
+#: engines/sui_window.lua:3170
+msgid "No items available."
+msgstr "Əlçatan element yoxdur."
+
+#: engines/sui_window.lua:3080
+#: modules/module_action_list.lua:352
+#: modules/module_action_list.lua:377
+#: modules/module_clock.lua:1080
+#: modules/module_collections.lua:1219
+#: modules/module_coverdeck.lua:1650
+#: modules/module_coverdeck.lua:1658
+#: modules/module_currently.lua:1640
+#: modules/module_currently.lua:1724
+#: modules/module_currently.lua:1856
+#: modules/module_currently.lua:1899
+#: modules/module_quick_actions.lua:404
+#: modules/module_quick_actions.lua:429
+#: modules/module_reading_goals.lua:1362
+#: modules/module_reading_goals.lua:1369
+#: modules/module_reading_stats.lua:718
+#: modules/module_reading_stats.lua:739
+#: screens/sui_menu.lua:875
+#: screens/sui_menu.lua:953
+#: screens/sui_menu.lua:1145
+#: screens/sui_menu.lua:1196
+#: screens/sui_menu.lua:1591
+#: screens/sui_menu.lua:1698
+#: screens/sui_menu.lua:1999
+#: screens/sui_menu.lua:2024
+msgid "No items selected."
+msgstr "Element seçilməyib."
+
+#: modules/module_clock.lua:1117
+msgid "No items."
+msgstr "Element yoxdur."
+
+#: screens/sui_settings_window.lua:575
+#: screens/sui_settings_window.lua:750
+msgid "No modules"
+msgstr "Modul yoxdur"
+
+#: screens/sui_settings_window.lua:736
+msgid "No other pages available."
+msgstr "Başqa səhifə yoxdur."
+
+#: screens/sui_menu.lua:3849
+msgid "No packs found."
+msgstr "Dəst tapılmadı."
+
+#: features/sui_quickactions.lua:2570
+msgid "No plugins found."
+msgstr "Qoşma tapılmadı."
+
+#: features/sui_presets.lua:1079
+#: screens/sui_menu.lua:4229
+msgid "No preset files found.\nPlace .lua files in:\n%1"
+msgstr "Hazır quruluş faylı tapılmadı.\n.lua fayllarını buraya yerləşdirin:\n%1"
+
+#: features/sui_presets.lua:1056
+#: screens/sui_menu.lua:4205
+msgid "No presets found."
+msgstr "Hazır quruluş tapılmadı."
+
+#: modules/module_quote.lua:962
+msgid "No quotes found."
+msgstr "Sitat tapılmadı."
+
+#: features/sui_quickactions.lua:3466
+msgid "No recent books."
+msgstr "Son kitab yoxdur."
+
+#: screens/sui_stats_windows.lua:168
+#: screens/sui_stats_windows.lua:202
+#: screens/sui_stats_windows.lua:3565
+msgid "No statistics found for this book."
+msgstr "Bu kitab üçün statistika tapılmadı."
+
+#: modules/module_coverdeck.lua:1525
+msgid "No statistics selected."
+msgstr "Statistika seçilməyib."
+
+#: modules/module_reading_stats.lua:465
+msgid "No stats selected"
+msgstr "Statistika seçilməyib"
+
+#: modules/module_reading_stats.lua:464
+msgid "No stats selected  —  long press to configure"
+msgstr "Statistika seçilməyib  —  tənzimləmək üçün basıb saxlayın"
+
+#: features/sui_quickactions.lua:2596
+msgid "No system actions found."
+msgstr "Sistem əməli tapılmadı."
+
+#: screens/sui_menu.lua:2287
+msgid "No wallpapers found."
+msgstr "Fon şəkli tapılmadı."
+
+#: engines/sui_book_grid.lua:1938
+#: engines/sui_book_grid.lua:2056
+#: features/sui_quickactions.lua:2468
+#: screens/sui_menu.lua:3136
+#: screens/sui_menu.lua:3145
+#: screens/sui_menu.lua:3163
+#: screens/sui_menu.lua:3203
+#: screens/sui_menu.lua:3212
+#: screens/sui_menu.lua:3230
+#: features/library/sui_foldercovers.lua:319
+msgid "None"
+msgstr "Yoxdur"
+
+#: modules/module_clock.lua:389
+msgid "Noon"
+msgstr "Günorta"
+
+#: features/sui_backup.lua:575
+#: features/sui_backup.lua:579
+#: features/sui_backup.lua:589
+#: features/sui_backup.lua:774
+#: features/sui_backup.lua:931
+msgid "Not a valid backup file."
+msgstr "Etibarlı ehtiyat nüsxə faylı deyil."
+
+#: modules/module_reading_goals.lua:1410
+#: modules/module_reading_goals.lua:1425
+#: modules/module_reading_goals.lua:1440
+msgid "Not set"
+msgstr "Təyin edilməyib"
+
+#: screens/sui_stats_windows.lua:1211
+#: screens/sui_stats_windows.lua:3885
+msgid "Notes"
+msgstr "Qeydlər"
+
+#: features/sui_backup.lua:986
+msgid "Nothing selected to import."
+msgstr "İdxal üçün heç nə seçilməyib."
+
+#: engines/sui_heatmap_widgets.lua:88
+msgid "Nov"
+msgstr "Noy"
+
+#: modules/module_clock.lua:64
+#: screens/sui_stats_windows.lua:2817
+msgid "November"
+msgstr "Noyabr"
+
+#: engines/sui_book_grid.lua:1805
+#: engines/sui_book_grid.lua:1806
+msgid "Number of Books"
+msgstr "Kitab sayı"
+
+#: screens/sui_menu.lua:2949
+msgid "Number of Books in Folder"
+msgstr "Qovluqdakı kitab sayı"
+
+#: screens/sui_menu.lua:3023
+msgid "Number of Pages"
+msgstr "Səhifə sayı"
+
+#: modules/module_clock.lua:407
+msgid "O'Clock"
+msgstr "Tamam"
+
+#: features/sui_quickactions.lua:2102
+msgid "OK"
+msgstr "Oldu"
+
+#: engines/sui_heatmap_widgets.lua:88
+msgid "Oct"
+msgstr "Okt"
+
+#: modules/module_clock.lua:64
+#: screens/sui_stats_windows.lua:2817
+msgid "October"
+msgstr "Oktyabr"
+
+#: engines/sui_book_grid.lua:2023
+#: engines/sui_book_grid.lua:2049
+#: modules/module_coverdeck.lua:1747
+#: screens/sui_menu.lua:1439
+#: screens/sui_menu.lua:1649
+#: screens/sui_menu.lua:3269
+#: screens/sui_menu.lua:3434
+#: screens/sui_menu.lua:4526
+msgid "Off"
+msgstr "Sönülü"
+
+#: modules/module_clock.lua:352
+msgid "Oh"
+msgstr "Sıfır"
+
+#: engines/sui_book_grid.lua:2023
+#: engines/sui_book_grid.lua:2049
+#: modules/module_coverdeck.lua:1747
+#: screens/sui_menu.lua:1439
+#: screens/sui_menu.lua:1649
+#: screens/sui_menu.lua:4526
+msgid "On"
+msgstr "Qoşulu"
+
+#: modules/module_coverdeck.lua:1721
+msgid "On side covers too"
+msgstr "Yan üzlüklərdə də"
+
+#: modules/module_clock.lua:315
+msgid "One"
+msgstr "Bir"
+
+#: engines/sui_screen_engine.lua:791
+#: features/sui_quickactions.lua:3421
+#: modules/module_quote.lua:1299
+#: screens/sui_stats_windows.lua:771
+msgid "Open"
+msgstr "Aç"
+
+#: modules/module_collections.lua:1105
+msgid "Open Module Settings"
+msgstr "Modul parametrlərini aç"
+
+#: engines/sui_screen_engine.lua:450
+msgid "Open a book to get started"
+msgstr "Başlamaq üçün kitab açın"
+
+#: infra/sui_updater.lua:499
+msgid "Open in browser"
+msgstr "Brauzerdə aç"
+
+#: features/library/sui_book_hold_dialog.lua:517
+msgid "Open module settings"
+msgstr "Modul parametrlərini aç"
+
+#: engines/sui_screen_engine.lua:790
+#: features/sui_quickactions.lua:3420
+#: modules/module_quote.lua:1298
+#: screens/sui_stats_windows.lua:769
+msgid "Open this file?"
+msgstr "Bu fayl açılsın?"
+
+#: features/library/sui_book_hold_dialog.lua:387
+msgid "Open with…"
+msgstr "Bununla aç…"
+
+#: screens/sui_menu.lua:2668
+msgid "Overflow Warning"
+msgstr "Sahənin aşılması xəbərdarlığı"
+
+#: screens/sui_menu.lua:2913
+msgid "Overlays"
+msgstr "Üst qatlar"
+
+#: features/sui_presets.lua:878
+#: features/sui_presets.lua:908
+#: features/sui_presets.lua:1040
+#: screens/sui_menu.lua:4031
+#: screens/sui_menu.lua:4060
+#: screens/sui_menu.lua:4189
+msgid "Overwrite"
+msgstr "Üzərinə yaz"
+
+#: features/sui_presets.lua:907
+#: features/sui_presets.lua:1039
+msgid "Overwrite preset \"%s\" with the current homescreen settings?"
+msgstr "\"%s\" hazır quruluşunun üzərinə cari əsas ekran parametrləri yazılsın?"
+
+#: screens/sui_menu.lua:4059
+#: screens/sui_menu.lua:4188
+msgid "Overwrite preset \"%s\" with the current icon settings?"
+msgstr "\"%s\" hazır quruluşunun üzərinə cari işarə parametrləri yazılsın?"
+
+#: screens/sui_menu.lua:3864
+msgid "Pack \"%s\" applied.\n%d icons replaced."
+msgstr "\"%s\" dəsti tətbiq edildi.\n%d işarə əvəzləndi."
+
+#: screens/sui_menu.lua:3782
+msgid "Pack \"%s\" installed.\nYou can now apply it from the list."
+msgstr "\"%s\" dəsti quraşdırıldı.\nİndi onu siyahıdan tətbiq edə bilərsiniz."
+
+#: features/sui_style.lua:2045
+msgid "Pack folder not accessible: "
+msgstr "Dəstin qovluğuna giriş yoxdur: "
+
+#: engines/sui_screen_engine.lua:2036
+#: engines/sui_window.lua:1416
+#: infra/sui_patches.lua:2273
+#: infra/sui_patches.lua:2862
+msgid "Page %1 of %2"
+msgstr "Səhifə %1 / %2"
+
+#: screens/sui_settings_window.lua:549
+#: screens/sui_settings_window.lua:713
+#: screens/sui_settings_window.lua:1099
+msgid "Page %d"
+msgstr "Səhifə %d"
+
+#: screens/sui_settings_window.lua:548
+#: screens/sui_settings_window.lua:712
+#: screens/sui_settings_window.lua:1098
+msgid "Page 1 (Home)"
+msgstr "Səhifə 1 (əsas)"
+
+#: screens/sui_stats_windows.lua:947
+#: screens/sui_stats_windows.lua:3650
+msgid "Pages"
+msgstr "Səhifələr"
+
+#: engines/sui_book_grid.lua:2005
+#: engines/sui_book_grid.lua:2021
+msgid "Pages Badge"
+msgstr "Səhifə nişanı"
+
+#: engines/sui_book_grid.lua:2016
+msgid "Pages Badge Color"
+msgstr "Səhifə nişanının rəngi"
+
+#: screens/sui_stats_windows.lua:2412
+msgid "Pages per day"
+msgstr "Gündə səhifə"
+
+#: screens/sui_stats_windows.lua:2429
+#: screens/sui_stats_windows.lua:2445
+msgid "Pages read"
+msgstr "Oxunan səhifələr"
+
+#: features/sui_style.lua:1294
+#: screens/sui_menu.lua:2775
+msgid "Pagination Bar"
+msgstr "Səhifələmə paneli"
+
+#: screens/sui_menu.lua:486
+msgid "Pagination bar hidden.\n\nRestart now?"
+msgstr "Səhifələmə paneli gizlədilib.\n\nİndi yenidən başladılsın?"
+
+#: screens/sui_menu.lua:465
+msgid "Pagination bar set to Default.\n\nRestart now?"
+msgstr "Səhifələmə paneli standart olaraq təyin edilib.\n\nİndi yenidən başladılsın?"
+
+#: screens/sui_menu.lua:572
+#: screens/sui_menu.lua:584
+#: screens/sui_menu.lua:596
+msgid "Pagination bar size will change after restart.\n\nRestart now?"
+msgstr "Səhifələmə panelinin ölçüsü yenidən başladıqdan sonra dəyişəcək.\n\nİndi yenidən başladılsın?"
+
+#: features/sui_style.lua:142
+msgid "Pagination: First Page"
+msgstr "Səhifələmə: ilk səhifə"
+
+#: features/sui_style.lua:148
+msgid "Pagination: Last Page"
+msgstr "Səhifələmə: son səhifə"
+
+#: features/sui_style.lua:136
+msgid "Pagination: Next Page"
+msgstr "Səhifələmə: növbəti səhifə"
+
+#: features/sui_style.lua:130
+msgid "Pagination: Previous Page"
+msgstr "Səhifələmə: əvvəlki səhifə"
+
+#: features/sui_quickactions.lua:2524
+msgid "Path chooser not available."
+msgstr "Yol seçicisi əlçatan deyil."
+
+#: features/sui_style.lua:2034
+msgid "Path does not exist: "
+msgstr "Yol mövcud deyil: "
+
+#: modules/module_coverdeck.lua:143
+#: modules/module_currently.lua:284
+#: modules/module_currently.lua:1599
+msgid "Percentage read"
+msgstr "Oxunan faiz"
+
+#: modules/module_reading_goals.lua:754
+msgid "Physical Books — %s"
+msgstr "Çap kitabları — %s"
+
+#: modules/module_reading_goals.lua:755
+msgid "Physical books read this year:"
+msgstr "Bu il oxunan çap kitabları:"
+
+#: modules/module_quote.lua:1489
+#: modules/module_quote.lua:1538
+msgid "Place .lua files in the plugin's sui_quotes/ folder"
+msgstr ".lua fayllarını qoşmanın sui_quotes/ qovluğuna yerləşdirin"
+
+#: screens/sui_menu.lua:3850
+msgid "Place a folder or .zip in:"
+msgstr "Qovluğu və ya .zip faylını buraya yerləşdirin:"
+
+#: screens/sui_menu.lua:2289
+msgid "Place images in:"
+msgstr "Şəkilləri buraya yerləşdirin:"
+
+#: screens/sui_onboarding.lua:174
+msgid "Place your files in koreader/settings/simpleui/sui_wallpapers or sui_icons."
+msgstr "Fayllarınızı koreader/settings/simpleui/sui_wallpapers və ya sui_icons qovluğuna yerləşdirin."
+
+#: screens/sui_menu.lua:3532
+msgid "Placeholder Cover for Bookless Folders"
+msgstr "Kitabsız qovluqlar üçün əvəzedici üzlük"
+
+#: screens/sui_stats_windows.lua:667
+msgid "Please enter a date in YYYY-MM-DD format."
+msgstr "Tarixi YYYY-MM-DD formatında daxil edin."
+
+#: features/sui_presets.lua:860
+#: screens/sui_menu.lua:4015
+msgid "Please enter a name for the preset."
+msgstr "Hazır quruluş üçün ad daxil edin."
+
+#: features/sui_quickactions.lua:2495
+msgid "Please select an action."
+msgstr "Əməl seçin."
+
+#: features/sui_quickactions.lua:2589
+#: features/sui_quickactions.lua:2708
+msgid "Plugin"
+msgstr "Qoşma"
+
+#: features/sui_quickactions.lua:3099
+msgid "Plugin error: %s"
+msgstr "Qoşma xətası: %s"
+
+#: features/sui_quickactions.lua:3101
+msgid "Plugin not available: %s"
+msgstr "Qoşma əlçatan deyil: %s"
+
+#: screens/sui_menu.lua:2956
+#: screens/sui_menu.lua:3360
+msgid "Position"
+msgstr "Mövqe"
+
+#: features/sui_quickactions.lua:913
+#: infra/sui_config.lua:129
+msgid "Power"
+msgstr "Enerji"
+
+#: screens/sui_menu.lua:2642
+msgid "Preserve Cover Proportions"
+msgstr "Üzlüyün nisbətlərini qoru"
+
+#: screens/sui_menu.lua:2693
+msgid "Preserve Deleted Books in Statistics"
+msgstr "Silinmiş kitabları statistikada saxla"
+
+#: features/sui_presets.lua:1092
+#: screens/sui_menu.lua:4240
+msgid "Preset \"%s\" imported."
+msgstr "\"%s\" hazır quruluşu idxal edildi."
+
+#: features/sui_presets.lua:743
+#: features/sui_presets.lua:821
+#: screens/sui_menu.lua:3978
+msgid "Preset \"%s\" not found."
+msgstr "\"%s\" hazır quruluşu tapılmadı."
+
+#: features/sui_presets.lua:871
+#: screens/sui_menu.lua:4022
+msgid "Preset \"%s\" saved."
+msgstr "\"%s\" hazır quruluşu yadda saxlanıldı."
+
+#: features/sui_presets.lua:914
+#: features/sui_presets.lua:1046
+#: screens/sui_menu.lua:4066
+#: screens/sui_menu.lua:4195
+msgid "Preset \"%s\" updated."
+msgstr "\"%s\" hazır quruluşu yeniləndi."
+
+#: features/sui_presets.lua:1119
+#: screens/sui_menu.lua:4270
+msgid "Preset exported to:\n%s"
+msgstr "Hazır quruluş buraya ixrac edildi:\n%s"
+
+#: features/sui_presets.lua:846
+#: screens/sui_menu.lua:4001
+msgid "Preset name"
+msgstr "Hazır quruluşun adı"
+
+#: features/sui_presets.lua:403
+#: features/sui_presets.lua:583
+msgid "Preset not found"
+msgstr "Hazır quruluş tapılmadı"
+
+#: screens/sui_menu.lua:2747
+#: screens/sui_settings_window.lua:408
+msgid "Presets"
+msgstr "Hazır quruluşlar"
+
+#: screens/sui_settings_window.lua:909
+msgid "Presets module unavailable."
+msgstr "Hazır quruluşlar modulu əlçatan deyil."
+
+#: screens/sui_onboarding.lua:162
+msgid "Press and hold any element on the screen (like modules or bars) to quickly customize its settings."
+msgstr "Parametrlərini tez fərdiləşdirmək üçün ekrandakı istənilən elementi (məsələn, modulu və ya paneli) basıb saxlayın."
+
+#: screens/sui_bottombar.lua:501
+msgid "Prev"
+msgstr "Əvvəlki"
+
+#: screens/sui_menu.lua:3131
+msgid "Progress"
+msgstr "İrəliləyiş"
+
+#: modules/module_coverdeck.lua:1712
+#: modules/module_coverdeck.lua:1745
+msgid "Progress Badge"
+msgstr "İrəliləyiş nişanı"
+
+#: engines/sui_book_grid.lua:1964
+#: modules/module_coverdeck.lua:1732
+msgid "Progress Badge Color"
+msgstr "İrəliləyiş nişanının rəngi"
+
+#: screens/sui_menu.lua:4353
+msgid "Progress Bar Type"
+msgstr "İrəliləyiş zolağının növü"
+
+#: engines/sui_book_grid.lua:1969
+msgid "Progress Indicator"
+msgstr "İrəliləyiş göstəricisi"
+
+#: engines/sui_book_grid.lua:1956
+msgid "Progress Style"
+msgstr "İrəliləyiş üslubu"
+
+#: engines/sui_book_grid.lua:2089
+msgid "Progress and Badges"
+msgstr "İrəliləyiş və nişanlar"
+
+#: modules/module_currently.lua:1951
+msgid "Progress and Stats"
+msgstr "İrəliləyiş və statistika"
+
+#: modules/module_coverdeck.lua:157
+#: modules/module_currently.lua:283
+msgid "Progress bar"
+msgstr "İrəliləyiş zolağı"
+
+#: modules/module_currently.lua:1954
+msgid "Progress bar style"
+msgstr "İrəliləyiş zolağının üslubu"
+
+#: features/sui_backup.lua:124
+#: features/sui_quickactions.lua:1529
+#: features/sui_quickactions.lua:3364
+#: modules/module_action_list.lua:344
+#: modules/module_action_list.lua:349
+#: modules/module_action_list.lua:375
+#: modules/module_quick_actions.lua:396
+#: modules/module_quick_actions.lua:401
+#: modules/module_quick_actions.lua:427
+#: modules/module_quick_actions.lua:538
+#: screens/sui_menu.lua:2175
+#: screens/sui_menu.lua:4581
+#: screens/sui_quicksettings_bar.lua:1130
+#: screens/sui_quicksettings_bar.lua:1135
+#: screens/sui_quicksettings_bar.lua:1156
+#: screens/sui_settings_window.lua:351
+msgid "Quick Actions"
+msgstr "Sürətli əməllər"
+
+#: screens/sui_menu.lua:4585
+msgid "Quick Actions  (%d/%d — %d left)"
+msgstr "Sürətli əməllər  (%d/%d — %d qalıb)"
+
+#: screens/sui_menu.lua:4583
+msgid "Quick Actions  (%d/%d — at limit)"
+msgstr "Sürətli əməllər  (%d/%d — həddə çatıb)"
+
+#: features/sui_quickactions.lua:1511
+#: features/sui_quickactions.lua:1913
+#: screens/sui_menu.lua:3688
+msgid "Quick Actions Icons"
+msgstr "Sürətli əməl işarələri"
+
+#: modules/module_quick_actions.lua:252
+#: modules/module_quick_actions.lua:308
+#: modules/module_quick_actions.lua:692
+#: screens/sui_menu.lua:1925
+msgid "Quick Actions Row"
+msgstr "Sürətli əməllər sətri"
+
+#: screens/sui_menu.lua:2777
+#: screens/sui_quicksettings_bar.lua:979
+msgid "Quick Settings Bar"
+msgstr "Sürətli parametrlər paneli"
+
+#: screens/sui_onboarding.lua:236
+#: screens/sui_onboarding.lua:237
+msgid "Quick Tips"
+msgstr "Qısa məsləhətlər"
+
+#: features/sui_quickactions.lua:584
+msgid "Quit"
+msgstr "Çıx"
+
+#: features/sui_quickactions.lua:587
+msgid "Quitting…"
+msgstr "Çıxılır…"
+
+#: features/sui_presets.lua:150
+#: features/sui_presets.lua:215
+#: modules/module_quote.lua:1117
+msgid "Quote of the Day"
+msgstr "Günün sitatı"
+
+#: features/sui_backup.lua:141
+msgid "Quote pool files from sui_quotes/"
+msgstr "sui_quotes/ qovluğundakı sitat toplusu faylları"
+
+#: modules/module_quote.lua:1429
+msgid "Quotes + My Highlights"
+msgstr "Sitatlar + vurğulamalarım"
+
+#: infra/sui_config.lua:171
+msgid "RAM Usage"
+msgstr "Operativ yaddaş istifadəsi"
+
+#: features/sui_quickactions.lua:766
+#: infra/sui_config.lua:122
+#: modules/module_library.lua:218
+msgid "Random"
+msgstr "Təsadüfi"
+
+#: features/sui_presets.lua:170
+#: features/sui_presets.lua:216
+#: modules/module_reading_goals.lua:872
+#: modules/module_reading_goals.lua:873
+#: modules/module_reading_goals.lua:899
+#: modules/module_reading_goals.lua:1585
+msgid "Reading Goals"
+msgstr "Oxu məqsədləri"
+
+#: modules/module_heatmap.lua:206
+#: modules/module_heatmap.lua:207
+#: modules/module_heatmap.lua:226
+#: modules/module_heatmap.lua:354
+#: screens/sui_heatmap_popup.lua:193
+msgid "Reading Heatmap"
+msgstr "Oxu istilik xəritəsi"
+
+#: screens/sui_stats_windows.lua:2741
+msgid "Reading Insights"
+msgstr "Oxu təhlili"
+
+#: features/sui_presets.lua:170
+#: features/sui_presets.lua:216
+#: modules/module_reading_stats.lua:360
+msgid "Reading Stats"
+msgstr "Oxu statistikası"
+
+#: features/sui_backup.lua:130
+msgid "Reading goals, streak mode and freeze bank"
+msgstr "Oxu məqsədləri, ardıcıllıq rejimi və dondurma ehtiyatı"
+
+#: modules/module_reading_stats.lua:904
+#: modules/module_reading_stats.lua:918
+msgid "Real streak only"
+msgstr "Yalnız həqiqi ardıcıllıq"
+
+#: features/sui_quickactions.lua:570
+msgid "Reboot"
+msgstr "Cihazı yenidən başlat"
+
+#: features/sui_quickactions.lua:739
+#: features/sui_quickactions.lua:3527
+#: infra/sui_config.lua:120
+msgid "Recent"
+msgstr "Son"
+
+#: features/sui_presets.lua:138
+#: features/sui_presets.lua:188
+#: modules/module_coverdeck.lua:1430
+#: modules/module_recent.lua:15
+#: modules/module_recent.lua:16
+msgid "Recent Books"
+msgstr "Son kitablar"
+
+#: modules/module_tbr.lua:589
+msgid "Remove from To Be Read"
+msgstr "Oxunacaqlardan çıxar"
+
+#: modules/module_tbr.lua:526
+msgid "Remove from list when finished"
+msgstr "Bitirildikdə siyahıdan çıxar"
+
+#: engines/sui_window.lua:1938
+#: engines/sui_window.lua:2859
+#: features/sui_presets.lua:920
+#: features/sui_presets.lua:927
+#: features/sui_presets.lua:1013
+#: screens/sui_menu.lua:4072
+#: screens/sui_menu.lua:4079
+#: screens/sui_menu.lua:4164
+msgid "Rename"
+msgstr "Adını dəyiş"
+
+#: features/sui_presets.lua:923
+#: features/sui_presets.lua:1009
+#: screens/sui_menu.lua:4075
+#: screens/sui_menu.lua:4160
+msgid "Rename \"%s\""
+msgstr "\"%s\" adını dəyiş"
+
+#: screens/sui_settings_window.lua:478
+msgid "Rename screen"
+msgstr "Ekranın adını dəyiş"
+
+#: screens/sui_menu.lua:2619
+msgid "Replaces the \"Closing book…\" notice above with the cover for that close, when a cover is available."
+msgstr "Üzlük varsa, kitab bağlanarkən yuxarıdakı \"Kitab bağlanır…\" bildirişi əvəzinə üzlüyü göstərir."
+
+#: screens/sui_menu.lua:472
+msgid "Replaces the pagination bar with Prev/Next arrows at the edges of the navigation bar.\nThe arrows dim when there is no previous or next page.\nWith navpager active, as few as 1 tab and at most 4 tabs can be configured."
+msgstr "Səhifələmə panelini naviqasiya panelinin kənarlarındakı əvvəlki/növbəti oxları ilə əvəz edir.\nƏvvəlki və ya növbəti səhifə olmadıqda oxlar solğunlaşır.\nNaviqasiya ilə səhifələmə aktiv olduqda ən azı 1, ən çoxu 4 vərəq təyin edilə bilər."
+
+#: features/sui_quickactions.lua:1921
+#: features/sui_style.lua:1310
+#: screens/sui_menu.lua:2530
+#: screens/sui_stats_windows.lua:653
+msgid "Reset"
+msgstr "Sıfırla"
+
+#: features/sui_quickactions.lua:1915
+#: features/sui_style.lua:1304
+msgid "Reset All"
+msgstr "Hamısını sıfırla"
+
+#: features/sui_quickactions.lua:2773
+msgid "Reset All Quick Action Icons"
+msgstr "Bütün sürətli əməl işarələrini sıfırla"
+
+#: features/sui_style.lua:1076
+msgid "Reset All System Icons"
+msgstr "Bütün sistem işarələrini sıfırla"
+
+#: features/sui_quickactions.lua:1920
+msgid "Reset all Quick Actions icons to default?"
+msgstr "Bütün sürətli əməl işarələri standart vəziyyətə qaytarılsın?"
+
+#: screens/sui_menu.lua:2529
+msgid "Reset all scales to default (100%)? This cannot be undone."
+msgstr "Bütün miqyaslar standart dəyərə (100%) qaytarılsın? Bu əməl geri alına bilməz."
+
+#: features/sui_style.lua:1309
+msgid "Reset all system icons to default?"
+msgstr "Bütün sistem işarələri standart vəziyyətə qaytarılsın?"
+
+#: screens/sui_menu.lua:2524
+msgid "Reset to Default Scale"
+msgstr "Standart miqyasa qaytar"
+
+#: features/sui_quickactions.lua:564
+#: infra/sui_updater.lua:448
+#: screens/sui_menu.lua:444
+#: screens/sui_menu.lua:847
+#: screens/sui_menu.lua:1057
+#: screens/sui_menu.lua:1119
+#: screens/sui_menu.lua:1334
+#: screens/sui_menu.lua:1793
+#: screens/sui_menu.lua:3448
+#: screens/sui_menu.lua:3471
+#: screens/sui_menu.lua:3493
+#: screens/sui_menu.lua:4341
+#: screens/sui_menu.lua:4544
+#: screens/sui_quicksettings_bar.lua:1120
+msgid "Restart"
+msgstr "Yenidən başlat"
+
+#: features/sui_backup.lua:1008
+msgid "Restart now"
+msgstr "İndi yenidən başlat"
+
+#: features/sui_style.lua:1796
+#: features/sui_style.lua:1840
+msgid "Restart to fully apply the UI font change."
+msgstr "İnterfeys şrifti dəyişikliyini tam tətbiq etmək üçün yenidən başladın."
+
+#: features/sui_quickactions.lua:566
+msgid "Restarting…"
+msgstr "Yenidən başladılır…"
+
+#: features/sui_backup.lua:994
+msgid "Restore"
+msgstr "Bərpa et"
+
+#: features/sui_backup.lua:1162
+msgid "Restore Selected…"
+msgstr "Seçilənləri bərpa et…"
+
+#: features/sui_backup.lua:999
+msgid "Restore failed."
+msgstr "Bərpa uğursuz oldu."
+
+#: features/sui_backup.lua:857
+msgid "Restore failed. Your previous configuration was kept unchanged."
+msgstr "Bərpa uğursuz oldu. Əvvəlki konfiqurasiyanız dəyişdirilmədən saxlanıldı."
+
+#: features/sui_backup.lua:993
+msgid "Restore this backup? Existing settings for these categories will be replaced. Saved presets are merged — yours are kept."
+msgstr "Bu ehtiyat nüsxə bərpa edilsin? Bu kateqoriyalardakı mövcud parametrlər əvəz ediləcək. Yadda saxlanılmış hazır quruluşlar birləşdiriləcək — sizinkilər saxlanılacaq."
+
+#: screens/sui_menu.lua:2544
+msgid "Return to Book Folder"
+msgstr "Kitabın qovluğuna qayıt"
+
+#: screens/sui_menu.lua:2435
+msgid "Return to Home Screen on Wakeup"
+msgstr "Oyanarkən əsas ekrana qayıt"
+
+#: engines/sui_book_grid.lua:2058
+#: screens/sui_menu.lua:3202
+#: screens/sui_menu.lua:3211
+#: screens/sui_menu.lua:3223
+msgid "Ribbon"
+msgstr "Lent"
+
+#: modules/module_action_list.lua:67
+#: modules/module_action_list.lua:476
+#: modules/module_clock.lua:167
+#: modules/module_clock.lua:1212
+#: modules/module_quick_actions.lua:668
+#: modules/module_quote.lua:126
+#: modules/module_quote.lua:1570
+#: modules/module_reading_goals.lua:120
+#: modules/module_reading_goals.lua:1578
+#: modules/module_reading_stats.lua:92
+#: modules/module_reading_stats.lua:870
+#: screens/sui_menu.lua:716
+#: screens/sui_menu.lua:945
+#: screens/sui_menu.lua:1490
+#: screens/sui_menu.lua:1688
+msgid "Right"
+msgstr "Sağ"
+
+#: modules/module_reading_goals.lua:1564
+msgid "Ring Alignment"
+msgstr "Halqaların düzləndirilməsi"
+
+#: modules/module_reading_goals.lua:1538
+msgid "Ring Style"
+msgstr "Halqa üslubu"
+
+#: modules/module_reading_goals.lua:1527
+msgid "Rings"
+msgstr "Halqalar"
+
+#: modules/module_quick_actions.lua:577
+#: screens/sui_quicksettings_bar.lua:1250
+msgid "Round"
+msgstr "Dairəvi"
+
+#: engines/sui_book_grid.lua:1942
+msgid "Round Overlay"
+msgstr "Dairəvi üst qat"
+
+#: modules/module_quick_actions.lua:587
+#: screens/sui_quicksettings_bar.lua:1260
+msgid "Rounded Square"
+msgstr "Yuvarlaq künclü kvadrat"
+
+#: engines/sui_book_grid.lua:1842
+msgid "Rows"
+msgstr "Sətirlər"
+
+#: screens/sui_stats_windows.lua:2805
+msgid "Sat"
+msgstr "Şən"
+
+#: modules/module_clock.lua:59
+msgid "Saturday"
+msgstr "Şənbə"
+
+#: features/sui_presets.lua:854
+#: features/sui_quickactions.lua:2492
+#: modules/module_reading_goals.lua:731
+#: screens/sui_menu.lua:4009
+#: screens/sui_settings_window.lua:488
+#: screens/sui_stats_windows.lua:662
+msgid "Save"
+msgstr "Yadda saxla"
+
+#: features/sui_presets.lua:839
+#: screens/sui_menu.lua:3994
+msgid "Save as new preset"
+msgstr "Yeni hazır quruluş kimi yadda saxla"
+
+#: features/sui_backup.lua:1089
+msgid "Save backup as"
+msgstr "Ehtiyat nüsxəni fərqli adla yadda saxla"
+
+#: screens/sui_menu.lua:3999
+msgid "Save icon preset"
+msgstr "İşarə quruluşunu yadda saxla"
+
+#: features/sui_presets.lua:844
+msgid "Save preset"
+msgstr "Hazır quruluşu yadda saxla"
+
+#: engines/sui_book_grid.lua:1770
+#: engines/sui_book_grid.lua:1772
+#: modules/module_action_list.lua:431
+#: modules/module_action_list.lua:433
+#: modules/module_clock.lua:1004
+#: modules/module_clock.lua:1006
+#: modules/module_coverdeck.lua:1339
+#: modules/module_coverdeck.lua:1341
+#: modules/module_currently.lua:1410
+#: modules/module_currently.lua:1412
+#: modules/module_heatmap.lua:309
+#: modules/module_heatmap.lua:311
+#: modules/module_quick_actions.lua:544
+#: modules/module_quick_actions.lua:546
+#: modules/module_quote.lua:1349
+#: modules/module_quote.lua:1353
+#: modules/module_reading_goals.lua:1250
+#: modules/module_reading_goals.lua:1252
+#: modules/module_reading_stats.lua:655
+#: modules/module_reading_stats.lua:657
+#: screens/sui_menu.lua:2447
+msgid "Scale"
+msgstr "Miqyas"
+
+#: modules/module_currently.lua:1439
+msgid "Scale for all text elements (title, author, progress, time).\n100% is the default size."
+msgstr "Bütün mətn elementlərinin (başlıq, müəllif, irəliləyiş, vaxt) miqyası.\nStandart ölçü: 100%."
+
+#: modules/module_clock.lua:1034
+msgid "Scale for the battery text only.\n100% is the default size."
+msgstr "Yalnız batareya mətninin miqyası.\nStandart ölçü: 100%."
+
+#: modules/module_quick_actions.lua:561
+msgid "Scale for the button label text.\n100% is the default size."
+msgstr "Düymə yazısının miqyası.\nStandart ölçü: 100%."
+
+#: modules/module_clock.lua:1016
+msgid "Scale for the clock face only.\n100% is the default size."
+msgstr "Yalnız saat siferblatının miqyası.\nStandart ölçü: 100%."
+
+#: modules/module_collections.lua:1426
+msgid "Scale for the collection count badge."
+msgstr "Kolleksiya sayı nişanının miqyası."
+
+#: modules/module_currently.lua:1426
+msgid "Scale for the cover thumbnail only.\n100% is the default size.\nWhen Dynamic Cover Size is on, this scales the cover relative to its current dynamic size instead, and the cover never shrinks below its 100% size."
+msgstr "Yalnız üzlük miniatürünün miqyası.\nStandart ölçü: 100%.\nDinamik üzlük ölçüsü qoşulduqda bu, üzlüyü cari dinamik ölçüsünə nisbətən miqyaslandırır və üzlük heç vaxt 100% ölçüsündən kiçik olmur."
+
+#: modules/module_coverdeck.lua:1350
+msgid "Scale for the cover thumbnails only.\n100% is the default size."
+msgstr "Yalnız üzlük miniatürlərinin miqyası.\nStandart ölçü: 100%."
+
+#: engines/sui_book_grid.lua:1790
+msgid "Scale for the cover thumbnails only.\nText and progress bar follow the module scale.\n100% is the default size."
+msgstr "Yalnız üzlük miniatürlərinin miqyası.\nMətn və irəliləyiş zolağı modulun miqyasına uyğunlaşır.\nStandart ölçü: 100%."
+
+#: modules/module_clock.lua:1025
+msgid "Scale for the date text only.\n100% is the default size."
+msgstr "Yalnız tarix mətninin miqyası.\nStandart ölçü: 100%."
+
+#: screens/sui_menu.lua:3421
+msgid "Scale for the folder name overlay text.\n100% is the default size."
+msgstr "Qovluq adının üst qatdakı mətninin miqyası.\nStandart ölçü: 100%."
+
+#: modules/module_action_list.lua:442
+#: screens/sui_quicksettings_bar.lua:1229
+msgid "Scale for the label text.\n100% is the default size."
+msgstr "Yazı mətninin miqyası.\nStandart ölçü: 100%."
+
+#: screens/sui_menu.lua:2930
+msgid "Scale for the library badges (progress, pages, etc.).\n100% is the default size."
+msgstr "Kitabxana nişanlarının (irəliləyiş, səhifələr və s.) miqyası.\nStandart ölçü: 100%."
+
+#: engines/sui_book_grid.lua:1781
+msgid "Scale for the percentage read text.\n100% is the default size."
+msgstr "Oxunan faiz mətninin miqyası.\nStandart ölçü: 100%."
+
+#: modules/module_reading_goals.lua:1268
+msgid "Scale for the text inside the rings.\n100% is the default size."
+msgstr "Halqaların içindəki mətnin miqyası.\nStandart ölçü: 100%."
+
+#: engines/sui_book_grid.lua:1993
+msgid "Scale for this module's corner badges (progress, pages, series, new book)."
+msgstr "Bu modulun künc nişanlarının (irəliləyiş, səhifələr, silsilə, yeni kitab) miqyası."
+
+#: modules/module_coverdeck.lua:1342
+msgid "Scale for this module."
+msgstr "Bu modulun miqyası."
+
+#: engines/sui_book_grid.lua:1773
+#: modules/module_action_list.lua:434
+#: modules/module_clock.lua:1007
+#: modules/module_currently.lua:1413
+#: modules/module_quick_actions.lua:547
+#: modules/module_quote.lua:1355
+#: modules/module_reading_goals.lua:1253
+#: modules/module_reading_stats.lua:658
+msgid "Scale for this module.\n100% is the default size."
+msgstr "Bu modulun miqyası.\nStandart ölçü: 100%."
+
+#: modules/module_heatmap.lua:312
+msgid "Scale for this module.\n100% is the default size. Capped at 100% here: the grid always has as many columns as \"Weeks shown\" (or, in Time of day view, 24), so there's no room to grow the cells past their autofit size without the grid overflowing the card."
+msgstr "Bu modulun miqyası.\nStandart ölçü: 100%. Burada hədd 100% təşkil edir: tordakı sütunların sayı həmişə \"Göstərilən həftələr\" qədərdir (günün vaxtı görünüşündə isə 24-dür), buna görə xanaları avtomatik uyğunlaşdırılmış ölçüdən artıq böyütmək torun kartdan kənara çıxmasına səbəb olur."
+
+#: modules/module_coverdeck.lua:1358
+msgid "Scale for title and statistics text.\n100% is the default size."
+msgstr "Başlıq və statistika mətninin miqyası.\nStandart ölçü: 100%."
+
+#: screens/sui_menu.lua:2471
+msgid "Scales all modules and labels together.\n100% is the default size."
+msgstr "Bütün modulları və yazıları birlikdə miqyaslandırır.\nStandart ölçü: 100%."
+
+#: screens/sui_menu.lua:2504
+msgid "Scales the section label text above each module.\n100% is the default size."
+msgstr "Hər modulun üstündəki bölmə yazısını miqyaslandırır.\nStandart ölçü: 100%."
+
+#: screens/sui_menu.lua:3545
+msgid "Scan Subfolders for Covers"
+msgstr "Üzlüklər üçün alt qovluqları yoxla"
+
+#: screens/sui_settings_window.lua:480
+#: screens/sui_settings_window.lua:1167
+msgid "Screen name"
+msgstr "Ekran adı"
+
+#: screens/sui_titlebar.lua:104
+msgid "Search"
+msgstr "Axtarış"
+
+#: features/sui_style.lua:87
+msgid "Search Button"
+msgstr "Axtarış düyməsi"
+
+#: engines/sui_window.lua:1927
+#: engines/sui_window.lua:2844
+msgid "Select"
+msgstr "Seç"
+
+#: features/sui_presets.lua:750
+#: features/sui_presets.lua:758
+#: features/sui_presets.lua:763
+#: screens/sui_menu.lua:3985
+msgid "Select Preset"
+msgstr "Hazır quruluş seç"
+
+#: screens/sui_menu.lua:2250
+msgid "Select Wallpaper"
+msgstr "Fon şəkli seç"
+
+#: modules/module_collections.lua:1192
+msgid "Select at least 2 collections to arrange."
+msgstr "Sıralamaq üçün ən azı 2 kolleksiya seçin."
+
+#: engines/sui_heatmap_widgets.lua:88
+msgid "Sep"
+msgstr "Sen"
+
+#: modules/module_clock.lua:64
+#: screens/sui_stats_windows.lua:2817
+msgid "September"
+msgstr "Sentyabr"
+
+#: features/sui_quickactions.lua:965
+#: infra/sui_config.lua:133
+#: modules/module_currently.lua:281
+#: features/library/sui_library_browse.lua:59
+msgid "Series"
+msgstr "Silsilə"
+
+#: engines/sui_book_grid.lua:2031
+#: engines/sui_book_grid.lua:2047
+msgid "Series Badge"
+msgstr "Silsilə nişanı"
+
+#: engines/sui_book_grid.lua:2042
+msgid "Series Badge Color"
+msgstr "Silsilə nişanının rəngi"
+
+#: screens/sui_menu.lua:3077
+msgid "Series Index"
+msgstr "Silsilədəki nömrə"
+
+#: screens/sui_menu.lua:655
+#: screens/sui_menu.lua:912
+msgid "Set"
+msgstr "Təyin et"
+
+#: modules/module_reading_goals.lua:1416
+#: modules/module_reading_goals.lua:1431
+#: modules/module_reading_goals.lua:1446
+msgid "Set Goal"
+msgstr "Məqsəd təyin et"
+
+#: modules/module_collections.lua:1097
+msgid "Set collection cover"
+msgstr "Kolleksiya üzlüyünü təyin et"
+
+#: features/library/sui_foldercovers.lua:684
+#: features/library/sui_library_browse.lua:811
+#: features/library/sui_series_grouping.lua:357
+msgid "Set folder cover"
+msgstr "Qovluq üzlüyünü təyin et"
+
+#: screens/sui_onboarding.lua:169
+msgid "Set your reading goal"
+msgstr "Oxu məqsədinizi təyin edin"
+
+#: features/sui_quickactions.lua:923
+#: infra/sui_config.lua:130
+msgid "Settings"
+msgstr "Parametrlər"
+
+#: screens/sui_settings_window.lua:299
+#: screens/sui_settings_window.lua:304
+msgid "Settings not found."
+msgstr "Parametrlər tapılmadı."
+
+#: screens/sui_menu.lua:1088
+#: screens/sui_menu.lua:1390
+#: screens/sui_menu.lua:2680
+#: screens/sui_quicksettings_bar.lua:1320
+msgid "Settings on Long Tap"
+msgstr "Basıb saxladıqda parametrlər"
+
+#: modules/module_clock.lua:317
+msgid "Seven"
+msgstr "Yeddi"
+
+#: modules/module_clock.lua:320
+msgid "Seventeen"
+msgstr "On yeddi"
+
+#: infra/sui_config.lua:1153
+msgid "Share of the row this module occupies.\n100% = full width. Modules under 100% share a row when their widths fit (bento grid)."
+msgstr "Bu modulun sətirdə tutduğu pay.\n100% = tam en. Eni 100% həddindən az olan modullar enləri uyğun gəldikdə eyni sətirdə yerləşir (bölməli tor)."
+
+#: modules/module_clock.lua:1149
+msgid "Show Battery"
+msgstr "Batareyanı göstər"
+
+#: modules/module_clock.lua:1137
+msgid "Show Clock"
+msgstr "Saatı göstər"
+
+#: modules/module_clock.lua:1143
+msgid "Show Date"
+msgstr "Tarixi göstər"
+
+#: modules/module_action_list.lua:451
+msgid "Show Icon"
+msgstr "İşarəni göstər"
+
+#: screens/sui_menu.lua:603
+msgid "Show Page Count in Title Bar"
+msgstr "Başlıq panelində səhifə sayını göstər"
+
+#: screens/sui_menu.lua:2557
+msgid "Show a brief \"Closing book…\" notice when closing a book, preventing accidental double-taps while e-ink refreshes."
+msgstr "Elektron mürəkkəb ekranı yenilənərkən təsadüfi ikiqat toxunmaların qarşısını almaq üçün kitab bağlanarkən qısa \"Kitab bağlanır…\" bildirişi göstərir."
+
+#: screens/sui_menu.lua:2657
+msgid "Show a brief \"Loading statistics…\" notice when opening a statistics window, preventing accidental double-taps while e-ink refreshes."
+msgstr "Elektron mürəkkəb ekranı yenilənərkən təsadüfi ikiqat toxunmaların qarşısını almaq üçün statistika pəncərəsi açılarkən qısa \"Statistika yüklənir…\" bildirişi göstərir."
+
+#: modules/module_coverdeck.lua:1753
+#: modules/module_library.lua:345
+#: modules/module_recent.lua:54
+msgid "Show finished books"
+msgstr "Bitirilmiş kitabları göstər"
+
+#: modules/module_heatmap.lua:356
+msgid "Show legend"
+msgstr "İşarələrin izahını göstər"
+
+#: screens/sui_menu.lua:2618
+msgid "Show on Close"
+msgstr "Bağlayarkən göstər"
+
+#: screens/sui_menu.lua:2607
+msgid "Show on Open"
+msgstr "Açarkən göstər"
+
+#: infra/sui_config.lua:1366
+msgid "Show section label"
+msgstr "Bölmə yazısını göstər"
+
+#: screens/sui_menu.lua:2334
+msgid "Show wallpaper on all screens"
+msgstr "Fon şəklini bütün ekranlarda göstər"
+
+#: screens/sui_menu.lua:608
+msgid "Shows \"Page X of Y\" in the title bar subtitle when browsing the library, history or collections.\nNavpager enables this automatically.\nNot available when Navpager is active."
+msgstr "Kitabxananı, tarixçəni və ya kolleksiyaları gözdən keçirərkən başlıq panelinin alt başlığında \"Səhifə X / Y\" göstərir.\nNaviqasiya ilə səhifələmə bunu avtomatik qoşur.\nNaviqasiya ilə səhifələmə aktiv olduqda əlçatan deyil."
+
+#: screens/sui_menu.lua:504
+msgid "Shows a row of dots at the bottom of the homescreen.\nThe active page dot is filled; the others are dimmed.\nAlways active when Navpager is selected."
+msgstr "Əsas ekranın aşağı hissəsində bir sıra nöqtə göstərir.\nAktiv səhifənin nöqtəsi dolu, digərləri isə solğun olur.\nNaviqasiya ilə səhifələmə seçildikdə həmişə aktivdir."
+
+#: modules/module_feat_coll.lua:171
+#: modules/module_tbr.lua:309
+msgid "Shuffle"
+msgstr "Qarışdır"
+
+#: modules/module_library.lua:273
+msgid "Shuffle now"
+msgstr "İndi qarışdır"
+
+#: modules/module_currently.lua:1956
+msgid "Simple"
+msgstr "Sadə"
+
+#: main.lua:2515
+#: main.lua:2528
+#: _meta.lua:5
+#: screens/sui_menu.lua:4526
+#: screens/sui_menu.lua:4615
+msgid "Simple UI"
+msgstr "Simple UI"
+
+#: infra/sui_updater.lua:445
+msgid "Simple UI %s installed.\n\nRestart KOReader to apply the update?"
+msgstr "Simple UI %s quraşdırıldı.\n\nYeniləməni tətbiq etmək üçün KOReader yenidən başladılsın?"
+
+#: infra/sui_updater.lua:492
+msgid "Simple UI %s is available!\nYou have %s."
+msgstr "Simple UI %s mövcuddur!\nSizdə %s var."
+
+#: screens/sui_settings_window.lua:1076
+msgid "Simple UI Settings"
+msgstr "Simple UI parametrləri"
+
+#: screens/sui_onboarding.lua:134
+msgid "Simple UI is designed to be simple and flexible. Here are a few tips to get the most out of it."
+msgstr "Simple UI sadə və çevik olmaq üçün hazırlanıb. Ondan daha çox faydalanmaq üçün bir neçə məsləhət."
+
+#: infra/sui_updater.lua:486
+msgid "Simple UI is up to date (%s)."
+msgstr "Simple UI ən son versiyadadır (%s)."
+
+#: main.lua:181
+msgid "Simple UI was updated (%s → %s).\n\nA restart is recommended to apply all changes cleanly."
+msgstr "Simple UI yeniləndi (%s → %s).\n\nBütün dəyişikliklərin düzgün tətbiq edilməsi üçün yenidən başlatmaq tövsiyə olunur."
+
+#: screens/sui_menu.lua:4543
+msgid "Simple UI will be %s after restart.\n\nRestart now?"
+msgstr "Yenidən başladıqdan sonra Simple UI: %s.\n\nİndi yenidən başladılsın?"
+
+#: main.lua:887
+msgid "Simple UI: Go to Homescreen"
+msgstr "Simple UI: əsas ekrana keç"
+
+#: main.lua:893
+msgid "Simple UI: Go to Library"
+msgstr "Simple UI: kitabxanaya keç"
+
+#: main.lua:917
+msgid "Simple UI: Navigation Bar"
+msgstr "Simple UI: naviqasiya paneli"
+
+#: main.lua:911
+msgid "Simple UI: Recent"
+msgstr "Simple UI: son"
+
+#: main.lua:905
+msgid "Simple UI: Settings"
+msgstr "Simple UI: parametrlər"
+
+#: main.lua:899
+msgid "Simple UI: Toggle Homescreen / Library"
+msgstr "Simple UI: əsas ekran / kitabxana arasında keçid"
+
+#: modules/module_collections.lua:1337
+#: screens/sui_menu.lua:2877
+msgid "Single Cover"
+msgstr "Tək üzlük"
+
+#: modules/module_clock.lua:316
+msgid "Six"
+msgstr "Altı"
+
+#: modules/module_clock.lua:320
+msgid "Sixteen"
+msgstr "On altı"
+
+#: engines/sui_book_grid.lua:1854
+#: modules/module_action_list.lua:428
+#: modules/module_clock.lua:1157
+#: modules/module_coverdeck.lua:1695
+#: modules/module_currently.lua:1915
+#: modules/module_quick_actions.lua:559
+#: modules/module_quick_actions.lua:560
+#: modules/module_reading_goals.lua:1281
+#: screens/sui_menu.lua:1026
+#: screens/sui_menu.lua:2921
+#: screens/sui_quicksettings_bar.lua:1227
+#: screens/sui_quicksettings_bar.lua:1228
+msgid "Size"
+msgstr "Ölçü"
+
+#: screens/sui_menu.lua:1348
+msgid "Size of the tab icons.\n100% is the default size."
+msgstr "Vərəq işarələrinin ölçüsü.\nStandart ölçü: 100%."
+
+#: screens/sui_menu.lua:1361
+msgid "Size of the tab label text.\n100% is the default size."
+msgstr "Vərəq yazısının ölçüsü.\nStandart ölçü: 100%."
+
+#: modules/module_reading_stats.lua:791
+msgid "Size of the text inside the stat cards.\nDoes not affect card size or padding.\n100% is the default size."
+msgstr "Statistika kartlarının içindəki mətnin ölçüsü.\nKartın ölçüsünə və daxili boşluğuna təsir etmir.\nStandart ölçü: 100%."
+
+#: features/sui_quickactions.lua:577
+msgid "Sleep"
+msgstr "Yuxu"
+
+#: screens/sui_menu.lua:576
+msgid "Small"
+msgstr "Kiçik"
+
+#: modules/module_quick_actions.lua:623
+#: screens/sui_menu.lua:3318
+#: screens/sui_menu.lua:3322
+#: screens/sui_quicksettings_bar.lua:1297
+msgid "Solid"
+msgstr "Bütöv"
+
+#: engines/sui_book_grid.lua:1878
+#: modules/module_currently.lua:1939
+#: modules/module_heatmap.lua:374
+#: modules/module_reading_goals.lua:1596
+msgid "Solid Background"
+msgstr "Bütöv fon"
+
+#: modules/module_collections.lua:1311
+#: modules/module_feat_coll.lua:175
+#: modules/module_library.lua:239
+#: modules/module_tbr.lua:319
+msgid "Sort"
+msgstr "Çeşidlə"
+
+#: modules/module_coverdeck.lua:1440
+#: modules/module_quote.lua:1381
+msgid "Source"
+msgstr "Mənbə"
+
+#: screens/sui_menu.lua:1374
+msgid "Space below the bottom navigation bar.\n100% is the default spacing."
+msgstr "Aşağı naviqasiya panelinin altındakı boşluq.\nStandart aralıq: 100%."
+
+#: modules/module_spacer.lua:58
+#: modules/module_spacer.lua:112
+msgid "Spacer"
+msgstr "Boşluq elementi"
+
+#: modules/module_spacer.lua:89
+#: modules/module_spacer.lua:90
+msgid "Spacer Size"
+msgstr "Boşluq elementinin ölçüsü"
+
+#: modules/module_clock.lua:1223
+#: modules/module_clock.lua:1230
+msgid "Spacing"
+msgstr "Aralıq"
+
+#: screens/sui_onboarding.lua:272
+msgid "Start using Simple UI"
+msgstr "Simple UI istifadəsinə başla"
+
+#: infra/sui_patches.lua:1161
+#: infra/sui_patches.lua:1163
+msgid "Start with"
+msgstr "Başlanğıc seçimi"
+
+#: screens/sui_menu.lua:2424
+msgid "Start with Home Screen"
+msgstr "Əsas ekranla başla"
+
+#: screens/sui_onboarding.lua:62
+msgid "Start with a ready-made layout. You can change everything later."
+msgstr "Hazır düzülüşlə başlayın. Hər şeyi sonra dəyişə bilərsiniz."
+
+#: modules/module_coverdeck.lua:158
+#: modules/module_coverdeck.lua:1523
+#: modules/module_coverdeck.lua:1556
+#: modules/module_coverdeck.lua:1623
+msgid "Statistics"
+msgstr "Statistika"
+
+#: screens/sui_menu.lua:2656
+msgid "Statistics Loading Notice"
+msgstr "Statistikanın yüklənməsi bildirişi"
+
+#: screens/sui_stats_windows.lua:163
+msgid "Statistics database library not available."
+msgstr "Statistika verilənlər bazası kitabxanası əlçatan deyil."
+
+#: features/sui_quickactions.lua:907
+msgid "Statistics plugin not available."
+msgstr "Statistika qoşması əlçatan deyil."
+
+#: features/sui_quickactions.lua:892
+#: infra/sui_config.lua:128
+#: modules/module_currently.lua:1634
+#: modules/module_currently.lua:1716
+#: modules/module_currently.lua:1777
+msgid "Stats"
+msgstr "Statistika"
+
+#: modules/module_currently.lua:1963
+msgid "Stats layout"
+msgstr "Statistikanın düzülüşü"
+
+#: modules/module_coverdeck.lua:1780
+#: modules/module_currently.lua:2000
+#: modules/module_reading_goals.lua:1625
+#: modules/module_reading_stats.lua:949
+msgid "Stats updated successfully."
+msgstr "Statistika uğurla yeniləndi."
+
+#: screens/sui_menu.lua:2772
+msgid "Status Bar"
+msgstr "Vəziyyət paneli"
+
+#: screens/sui_menu.lua:1033
+msgid "Status Bar Size"
+msgstr "Vəziyyət panelinin ölçüsü"
+
+#: screens/sui_menu.lua:846
+msgid "Status Bar will be %s after restart.\n\nRestart now?"
+msgstr "Yenidən başladıqdan sonra vəziyyət paneli: %s.\n\nİndi yenidən başladılsın?"
+
+#: modules/module_reading_stats.lua:130
+msgid "Status — Abandoned"
+msgstr "Vəziyyət — yarımçıq buraxılıb"
+
+#: modules/module_reading_stats.lua:129
+msgid "Status — Reading"
+msgstr "Vəziyyət — oxunur"
+
+#: modules/module_reading_stats.lua:128
+msgid "Status — Unread"
+msgstr "Vəziyyət — oxunmayıb"
+
+#: screens/sui_settings_window.lua:331
+msgid "Status, title, navigation and pagination"
+msgstr "Vəziyyət, başlıq, naviqasiya və səhifələmə"
+
+#: modules/module_reading_stats.lua:119
+#: screens/sui_stats_windows.lua:3494
+msgid "Streak"
+msgstr "Ardıcıllıq"
+
+#: modules/module_reading_stats.lua:900
+msgid "Streak Mode"
+msgstr "Ardıcıllıq rejimi"
+
+#: screens/sui_menu.lua:2352
+msgid "Stretch to fill screen"
+msgstr "Ekranı doldurmaq üçün dart"
+
+#: modules/module_reading_stats.lua:801
+#: screens/sui_menu.lua:4572
+#: screens/sui_settings_window.lua:344
+#: screens/sui_settings_window.lua:1081
+msgid "Style"
+msgstr "Üslub"
+
+#: screens/sui_menu.lua:1808
+#: screens/sui_menu.lua:1811
+msgid "Sub-page Buttons"
+msgstr "Alt səhifə düymələri"
+
+#: screens/sui_stats_windows.lua:2805
+msgid "Sun"
+msgstr "Baz"
+
+#: modules/module_clock.lua:58
+msgid "Sunday"
+msgstr "Bazar"
+
+#: screens/sui_menu.lua:1069
+msgid "Swipe Indicator"
+msgstr "Sürüşdürmə göstəricisi"
+
+#: features/sui_quickactions.lua:1881
+#: features/sui_quickactions.lua:1884
+#: features/sui_quickactions.lua:2614
+#: features/sui_quickactions.lua:2710
+msgid "System Actions"
+msgstr "Sistem əməlləri"
+
+#: features/sui_style.lua:1302
+#: screens/sui_menu.lua:3657
+#: screens/sui_menu.lua:3665
+msgid "System Icons"
+msgstr "Sistem işarələri"
+
+#: features/sui_quickactions.lua:3072
+msgid "System action error: %s"
+msgstr "Sistem əməli xətası: %s"
+
+#: screens/sui_stats_windows.lua:2729
+msgid "THIS MONTH"
+msgstr "Bu ay"
+
+#: screens/sui_stats_windows.lua:2728
+msgid "THIS WEEK"
+msgstr "Bu həftə"
+
+#: screens/sui_heatmap_popup.lua:164
+msgid "TIME OF DAY"
+msgstr "Günün vaxtı"
+
+#: screens/sui_stats_windows.lua:2724
+msgid "TODAY'S SUMMARY"
+msgstr "Bu günün xülasəsi"
+
+#: features/sui_style.lua:1297
+msgid "Tab Bar"
+msgstr "Vərəq paneli"
+
+#: screens/sui_menu.lua:1257
+msgid "Tab Style"
+msgstr "Vərəq üslubu"
+
+#: features/sui_style.lua:1253
+msgid "Tab bar icons must be PNG or SVG."
+msgstr "Vərəq panelinin işarələri PNG və ya SVG formatında olmalıdır."
+
+#: features/sui_style.lua:263
+msgid "Tab: Back to File Browser"
+msgstr "Vərəq: fayl brauzerinə qayıt"
+
+#: features/sui_style.lua:242
+msgid "Tab: File Browser Settings"
+msgstr "Vərəq: fayl brauzerinin parametrləri"
+
+#: features/sui_style.lua:214
+msgid "Tab: Menu"
+msgstr "Vərəq: menyu"
+
+#: features/sui_style.lua:249
+msgid "Tab: Reader Navigation"
+msgstr "Vərəq: oxu naviqasiyası"
+
+#: features/sui_style.lua:256
+msgid "Tab: Reader Typeset"
+msgstr "Vərəq: oxu mətninin tərtibatı"
+
+#: features/sui_style.lua:235
+msgid "Tab: Search"
+msgstr "Vərəq: axtarış"
+
+#: features/sui_style.lua:221
+msgid "Tab: Settings"
+msgstr "Vərəq: parametrlər"
+
+#: features/sui_style.lua:270
+msgid "Tab: SimpleUI Quick Settings"
+msgstr "Vərəq: Simple UI sürətli parametrləri"
+
+#: features/sui_style.lua:228
+msgid "Tab: Tools"
+msgstr "Vərəq: alətlər"
+
+#: screens/sui_menu.lua:1142
+#: screens/sui_menu.lua:1194
+msgid "Tabs"
+msgstr "Vərəqlər"
+
+#: screens/sui_menu.lua:1136
+msgid "Tabs  (%d/%d — %d left)"
+msgstr "Vərəqlər  (%d/%d — %d qalıb)"
+
+#: screens/sui_menu.lua:1134
+msgid "Tabs  (%d/%d — at limit)"
+msgstr "Vərəqlər  (%d/%d — həddə çatıb)"
+
+#: features/sui_quickactions.lua:983
+#: infra/sui_config.lua:135
+#: features/library/sui_library_browse.lua:60
+msgid "Tags"
+msgstr "Etiketlər"
+
+#: screens/sui_settings_window.lua:442
+msgid "Tap \"Create Screen\" below to add one."
+msgstr "Əlavə etmək üçün aşağıdakı \"Ekran yarat\" düyməsinə toxunun."
+
+#: modules/module_clock.lua:318
+msgid "Ten"
+msgstr "On"
+
+#: engines/sui_book_grid.lua:1940
+#: screens/sui_menu.lua:208
+msgid "Text"
+msgstr "Mətn"
+
+#: engines/sui_book_grid.lua:1779
+#: engines/sui_book_grid.lua:1780
+#: modules/module_action_list.lua:440
+#: modules/module_action_list.lua:441
+#: modules/module_coverdeck.lua:1356
+#: modules/module_coverdeck.lua:1357
+#: modules/module_currently.lua:1437
+#: modules/module_currently.lua:1438
+#: modules/module_reading_goals.lua:1265
+#: modules/module_reading_goals.lua:1267
+#: modules/module_reading_stats.lua:789
+#: modules/module_reading_stats.lua:790
+#: screens/sui_menu.lua:3418
+msgid "Text Size"
+msgstr "Mətn ölçüsü"
+
+#: screens/sui_menu.lua:210
+msgid "Text only"
+msgstr "Yalnız mətn"
+
+#: screens/sui_quicksettings_bar.lua:1117
+msgid "The Quick Settings Bar will be %s after restart.\n\nRestart now?"
+msgstr "Yenidən başladıqdan sonra sürətli parametrlər paneli: %s.\n\nİndi yenidən başladılsın?"
+
+#: screens/sui_menu.lua:2631
+msgid "The cover shown right as a book opens normally comes from the library's cached thumbnail, which can look soft on higher-resolution screens. When on, SimpleUI instead reads the cover straight from the book file for that moment (also covers books never opened before, which otherwise show no cover at all) — at the cost of a brief extra pause while opening, since the file has to be read twice. Cover on close is unaffected either way: it already reads the full-quality cover from the open book."
+msgstr "Kitab açılan anda göstərilən üzlük adətən kitabxananın keşdəki miniatüründən alınır və yüksək ayırdetməli ekranlarda bulanıq görünə bilər. Bu seçim qoşulduqda Simple UI həmin an üçün üzlüyü birbaşa kitab faylından oxuyur (əks halda üzlüyü heç göstərilməyən, əvvəllər açılmamış kitablar da daxil olmaqla). Fayl iki dəfə oxunduğundan açılma zamanı qısa əlavə fasilə yaranır. Bağlanarkən göstərilən üzlüyə bu seçim təsir etmir: o, onsuz da açıq kitabdan tam keyfiyyətlə oxunur."
+
+#: main.lua:1335
+#: screens/sui_bottombar.lua:1823
+msgid "The navigation bar is already available on this screen."
+msgstr "Naviqasiya paneli bu ekranda artıq mövcuddur."
+
+#: infra/sui_patches.lua:1307
+msgid "The «To Be Read» collection cannot be renamed."
+msgstr "«Oxunacaqlar» kolleksiyasının adı dəyişdirilə bilməz."
+
+#: modules/module_clock.lua:319
+msgid "Thirteen"
+msgstr "On üç"
+
+#: modules/module_clock.lua:324
+msgid "Thirty"
+msgstr "Otuz"
+
+#: features/sui_backup.lua:941
+msgid "This backup contains no settings or files."
+msgstr "Bu ehtiyat nüsxədə parametr və ya fayl yoxdur."
+
+#: modules/module_tbr.lua:600
+msgid "This book is marked as Finished, so it can't be added to To Be Read.\nChange its status to Reading or On Hold first."
+msgstr "Bu kitab bitirilmiş kimi işarələnib, ona görə oxunacaqlara əlavə edilə bilməz.\nƏvvəlcə vəziyyətini oxunur və ya gözləmədə olaraq dəyişin."
+
+#: features/sui_quickactions.lua:3270
+#: features/sui_quickactions.lua:3348
+msgid "This group is empty.\nAdd actions to it from Settings → Quick Actions."
+msgstr "Bu qrup boşdur.\nParametrlər → Sürətli əməllər bölməsindən ona əməllər əlavə edin."
+
+#: modules/module_reading_stats.lua:116
+msgid "This month — Pages"
+msgstr "Bu ay — səhifələr"
+
+#: modules/module_reading_stats.lua:115
+msgid "This month — Time"
+msgstr "Bu ay — vaxt"
+
+#: features/sui_presets.lua:864
+#: features/sui_presets.lua:932
+#: features/sui_presets.lua:1018
+msgid "This name is reserved by a built-in preset."
+msgstr "Bu ad daxili hazır quruluş üçün ayrılıb."
+
+#: modules/module_reading_stats.lua:112
+msgid "This week — Pages"
+msgstr "Bu həftə — səhifələr"
+
+#: modules/module_reading_stats.lua:111
+msgid "This week — Time"
+msgstr "Bu həftə — vaxt"
+
+#: screens/sui_menu.lua:4438
+msgid "This will delete all Simple UI settings and restart KOReader.\nAre you sure?"
+msgstr "Bu, bütün Simple UI parametrlərini siləcək və KOReader-i yenidən başladacaq.\nƏminsiniz?"
+
+#: modules/module_clock.lua:315
+msgid "Three"
+msgstr "Üç"
+
+#: screens/sui_stats_windows.lua:2805
+msgid "Thu"
+msgstr "C.a."
+
+#: modules/module_clock.lua:59
+msgid "Thursday"
+msgstr "Cümə axşamı"
+
+#: modules/module_heatmap.lua:221
+#: modules/module_heatmap.lua:343
+msgid "Time of day"
+msgstr "Günün vaxtı"
+
+#: modules/module_coverdeck.lua:145
+#: modules/module_currently.lua:286
+msgid "Time read"
+msgstr "Oxu vaxtı"
+
+#: modules/module_coverdeck.lua:146
+#: modules/module_currently.lua:287
+msgid "Time remaining"
+msgstr "Qalan vaxt"
+
+#: modules/module_coverdeck.lua:155
+#: modules/module_currently.lua:279
+#: screens/sui_titlebar.lua:106
+msgid "Title"
+msgstr "Başlıq"
+
+#: modules/module_feat_coll.lua:166
+#: modules/module_library.lua:211
+#: modules/module_tbr.lua:304
+msgid "Title (A–Z)"
+msgstr "Başlıq (A–Z)"
+
+#: modules/module_feat_coll.lua:167
+#: modules/module_library.lua:212
+#: modules/module_tbr.lua:305
+msgid "Title (Z–A)"
+msgstr "Başlıq (Z–A)"
+
+#: features/sui_style.lua:1292
+#: screens/sui_menu.lua:2774
+msgid "Title Bar"
+msgstr "Başlıq paneli"
+
+#: screens/sui_menu.lua:1790
+msgid "Title Bar will be %s after restart.\n\nRestart now?"
+msgstr "Yenidən başladıqdan sonra başlıq paneli: %s.\n\nİndi yenidən başladılsın?"
+
+#: screens/sui_menu.lua:3480
+msgid "Title and Author"
+msgstr "Başlıq və müəllif"
+
+#: screens/sui_menu.lua:3431
+msgid "Title and Author Below Covers"
+msgstr "Üzlüklərin altında başlıq və müəllif"
+
+#: screens/sui_menu.lua:3492
+msgid "Title and author strip enabled.\n\nRestart now?"
+msgstr "Başlıq və müəllif zolağı qoşulub.\n\nİndi yenidən başladılsın?"
+
+#: screens/sui_menu.lua:3458
+msgid "Title only"
+msgstr "Yalnız başlıq"
+
+#: screens/sui_menu.lua:3447
+msgid "Title strip disabled.\n\nRestart now?"
+msgstr "Başlıq zolağı söndürülüb.\n\nİndi yenidən başladılsın?"
+
+#: screens/sui_menu.lua:3470
+msgid "Title strip enabled.\n\nRestart now?"
+msgstr "Başlıq zolağı qoşulub.\n\nİndi yenidən başladılsın?"
+
+#: modules/module_coverdeck.lua:1432
+#: modules/module_tbr.lua:560
+#: modules/module_tbr.lua:620
+#: modules/module_tbr.lua:621
+msgid "To Be Read"
+msgstr "Oxunacaqlar"
+
+#: modules/module_tbr.lua:398
+msgid "To Be Read Books"
+msgstr "Oxunacaq kitablar"
+
+#: modules/module_reading_goals.lua:970
+#: modules/module_reading_goals.lua:1066
+#: modules/module_reading_goals.lua:1068
+#: modules/module_reading_goals.lua:1122
+#: modules/module_reading_goals.lua:1125
+msgid "Today"
+msgstr "Bu gün"
+
+#: modules/module_reading_stats.lua:110
+msgid "Today — Pages"
+msgstr "Bu gün — səhifələr"
+
+#: modules/module_reading_stats.lua:109
+msgid "Today — Time"
+msgstr "Bu gün — vaxt"
+
+#: engines/sui_window.lua:2862
+msgid "Toggle"
+msgstr "Vəziyyəti dəyiş"
+
+#: modules/module_collections.lua:1391
+#: screens/sui_menu.lua:2952
+#: screens/sui_menu.lua:2959
+#: screens/sui_menu.lua:2963
+#: screens/sui_menu.lua:3363
+#: screens/sui_menu.lua:3370
+msgid "Top"
+msgstr "Yuxarı"
+
+#: screens/sui_topbar.lua:508
+msgid "Top Bar"
+msgstr "Yuxarı panel"
+
+#: infra/sui_config.lua:1195
+msgid "Top Margin"
+msgstr "Yuxarı kənar boşluğu"
+
+#: screens/sui_stats_windows.lua:943
+#: screens/sui_stats_windows.lua:3646
+msgid "Total"
+msgstr "Cəmi"
+
+#: screens/sui_stats_windows.lua:2427
+#: screens/sui_stats_windows.lua:2443
+msgid "Total time"
+msgstr "Ümumi vaxt"
+
+#: features/sui_backup.lua:673
+msgid "Total: %d settings, %d files (%s)"
+msgstr "Cəmi: %d parametr, %d fayl (%s)"
+
+#: modules/module_quick_actions.lua:613
+#: screens/sui_menu.lua:3318
+#: screens/sui_menu.lua:3335
+#: screens/sui_quicksettings_bar.lua:1287
+msgid "Transparent"
+msgstr "Şəffaf"
+
+#: screens/sui_menu.lua:2314
+msgid "Transparent navigation bar"
+msgstr "Şəffaf naviqasiya paneli"
+
+#: screens/sui_menu.lua:2296
+msgid "Transparent status bar"
+msgstr "Şəffaf vəziyyət paneli"
+
+#: screens/sui_stats_windows.lua:2805
+msgid "Tue"
+msgstr "Ç.a."
+
+#: modules/module_clock.lua:58
+msgid "Tuesday"
+msgstr "Çərşənbə axşamı"
+
+#: modules/module_clock.lua:318
+msgid "Twelve"
+msgstr "On iki"
+
+#: modules/module_clock.lua:324
+msgid "Twenty"
+msgstr "İyirmi"
+
+#: modules/module_clock.lua:315
+msgid "Two"
+msgstr "İki"
+
+#: modules/module_heatmap.lua:340
+#: screens/sui_menu.lua:3140
+#: screens/sui_menu.lua:3207
+msgid "Type"
+msgstr "Növ"
+
+#: screens/sui_menu.lua:4290
+#: screens/sui_menu.lua:4293
+msgid "UI Font"
+msgstr "İnterfeys şrifti"
+
+#: screens/sui_menu.lua:4297
+msgid "UI Font  (default)"
+msgstr "İnterfeys şrifti  (standart)"
+
+#: screens/sui_menu.lua:4299
+msgid "UI Font  [%s]"
+msgstr "İnterfeys şrifti  [%s]"
+
+#: screens/sui_menu.lua:3507
+msgid "Uniformize Covers (2:3)"
+msgstr "Üzlükləri eyni nisbətə gətir (2:3)"
+
+#: screens/sui_stats_windows.lua:859
+msgid "Unknown error."
+msgstr "Naməlum xəta."
+
+#: features/sui_style.lua:2043
+msgid "Unsupported format (use a folder or a .zip file)"
+msgstr "Dəstəklənməyən format (qovluq və ya .zip faylı istifadə edin)"
+
+#: features/sui_quickactions.lua:107
+#: features/sui_quickactions.lua:1825
+#: features/sui_style.lua:1059
+#: features/sui_style.lua:1246
+msgid "Unsupported icon format.\nPlease use a PNG or SVG file."
+msgstr "Dəstəklənməyən işarə formatı.\nPNG və ya SVG faylı istifadə edin."
+
+#: engines/sui_window.lua:1935
+#: engines/sui_window.lua:2856
+msgid "Update"
+msgstr "Yenilə"
+
+#: modules/module_coverdeck.lua:1762
+#: modules/module_currently.lua:1982
+#: modules/module_reading_goals.lua:1607
+#: modules/module_reading_stats.lua:931
+msgid "Update Stats Now"
+msgstr "Statistikanı indi yenilə"
+
+#: infra/sui_updater.lua:465
+msgid "Update cancelled."
+msgstr "Yeniləmə ləğv edildi."
+
+#: infra/sui_updater.lua:666
+msgid "Update check cancelled."
+msgstr "Yeniləmə yoxlaması ləğv edildi."
+
+#: features/sui_presets.lua:905
+#: screens/sui_menu.lua:4057
+msgid "Update with current settings"
+msgstr "Cari parametrlərlə yenilə"
+
+#: screens/sui_menu.lua:4416
+msgid "Updater module not found."
+msgstr "Yeniləmə modulu tapılmadı."
+
+#: screens/sui_stats_windows.lua:3103
+msgid "Use freeze"
+msgstr "Dondurmadan istifadə et"
+
+#: features/sui_quickactions.lua:2072
+msgid "Use this Nerd Font icon?"
+msgstr "Bu Nerd Font işarəsi istifadə edilsin?"
+
+#: screens/sui_menu.lua:526
+msgid "Uses the standard KOReader pagination bar on the homescreen.\nNot available when Navpager is active."
+msgstr "Əsas ekranda standart KOReader səhifələmə panelindən istifadə edir.\nNaviqasiya ilə səhifələmə aktiv olduqda əlçatan deyil."
+
+#: screens/sui_settings_window.lua:366
+msgid "Version, author and updates"
+msgstr "Versiya, müəllif və yeniləmələr"
+
+#: screens/sui_menu.lua:4391
+msgid "Version: %s"
+msgstr "Versiya: %s"
+
+#: infra/sui_config.lua:1197
+msgid "Vertical space above this module.\n100% is the default spacing."
+msgstr "Bu modulun üstündəki şaquli boşluq.\nStandart aralıq: 100%."
+
+#: modules/module_clock.lua:1231
+msgid "Vertical space between items.\n100% is the default spacing."
+msgstr "Elementlər arasındakı şaquli boşluq.\nStandart aralıq: 100%."
+
+#: screens/sui_menu.lua:3029
+#: screens/sui_menu.lua:3083
+#: screens/sui_menu.lua:3315
+msgid "Visibility"
+msgstr "Görünmə"
+
+#: screens/sui_menu.lua:3025
+#: screens/sui_menu.lua:3031
+#: screens/sui_menu.lua:3035
+#: screens/sui_menu.lua:3079
+#: screens/sui_menu.lua:3085
+#: screens/sui_menu.lua:3089
+msgid "Visible"
+msgstr "Görünən"
+
+#: screens/sui_stats_windows.lua:2726
+#: screens/sui_stats_windows.lua:3364
+msgid "WEEK STREAK"
+msgstr "Ardıcıl həftələr"
+
+#: modules/module_clock.lua:332
+msgid "WORD_CLOCK_TENS_SEP"
+msgstr " "
+
+#: features/sui_backup.lua:134
+#: screens/sui_menu.lua:2743
+#: screens/sui_settings_window.lua:396
+#: screens/sui_settings_window.lua:402
+msgid "Wallpaper"
+msgstr "Fon şəkli"
+
+#: features/sui_backup.lua:135
+msgid "Wallpaper settings and image files"
+msgstr "Fon şəkli parametrləri və şəkil faylları"
+
+#: screens/sui_quicksettings_bar.lua:424
+#: screens/sui_quicksettings_bar.lua:445
+#: screens/sui_quicksettings_bar.lua:456
+msgid "Warmth"
+msgstr "Rəng istiliyi"
+
+#: screens/sui_quicksettings_bar.lua:1213
+msgid "Warmth Slider"
+msgstr "Rəng istiliyi sürüşdürmə çubuğu"
+
+#: screens/sui_menu.lua:2669
+msgid "Warn when modules on a page exceed the available screen height."
+msgstr "Səhifədəki modullar ekranın əlçatan hündürlüyünü aşdıqda xəbərdarlıq et."
+
+#: engines/sui_heatmap_widgets.lua:95
+#: screens/sui_stats_windows.lua:2805
+msgid "Wed"
+msgstr "Çər"
+
+#: modules/module_clock.lua:58
+msgid "Wednesday"
+msgstr "Çərşənbə"
+
+#: modules/module_heatmap.lua:291
+#: modules/module_heatmap.lua:295
+msgid "Weeks shown"
+msgstr "Göstərilən həftələr"
+
+#: screens/sui_onboarding.lua:234
+#: screens/sui_onboarding.lua:235
+msgid "Welcome to Simple UI"
+msgstr "Simple UI-yə xoş gəlmisiniz"
+
+#: infra/sui_updater.lua:493
+msgid "What's new:"
+msgstr "Yeniliklər:"
+
+#: screens/sui_menu.lua:2694
+msgid "When a finished book is deleted from the device (file or folder), keep it counted in the Books Read statistics on the Home Screen.\n\nBooks changed back to Reading or Abandoned are automatically removed from this list."
+msgstr "Bitirilmiş kitab cihazdan silindikdə (fayl və ya qovluq) onu əsas ekrandakı oxunmuş kitablar statistikasında saxlamağa davam edir.\n\nVəziyyəti yenidən oxunur və ya yarımçıq buraxılıb olaraq dəyişdirilən kitablar bu siyahıdan avtomatik çıxarılır."
+
+#: screens/sui_menu.lua:2545
+msgid "When closing a book from the Home Screen, go back to the folder where the book is located instead of the Library home folder."
+msgstr "Əsas ekrandan kitabı bağlayarkən kitabxananın əsas qovluğu əvəzinə kitabın yerləşdiyi qovluğa qayıdır."
+
+#: screens/sui_menu.lua:2681
+msgid "When enabled, long-pressing a module on the home screen opens its settings menu.\nDisable this to prevent settings from appearing on long tap."
+msgstr "Qoşulduqda əsas ekrandakı modulu basıb saxlamaq onun parametrlər menyusunu açır.\nBasıb saxladıqda parametrlərin görünməməsi üçün bunu söndürün."
+
+#: screens/sui_quicksettings_bar.lua:1321
+msgid "When enabled, long-pressing the Quick Settings Bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
+msgstr "Qoşulduqda sürətli parametrlər panelini basıb saxlamaq onun parametrlər menyusunu açır.\nBasıb saxladıqda parametrlər menyusunun görünməməsi üçün bunu söndürün."
+
+#: screens/sui_menu.lua:1391
+msgid "When enabled, long-pressing the navigation bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
+msgstr "Qoşulduqda naviqasiya panelini basıb saxlamaq onun parametrlər menyusunu açır.\nBasıb saxladıqda parametrlər menyusunun görünməməsi üçün bunu söndürün."
+
+#: screens/sui_menu.lua:1089
+msgid "When enabled, long-pressing the top bar opens its settings menu.\nDisable this to prevent the settings menu from appearing on long tap."
+msgstr "Qoşulduqda yuxarı paneli basıb saxlamaq onun parametrlər menyusunu açır.\nBasıb saxladıqda parametrlər menyusunun görünməməsi üçün bunu söndürün."
+
+#: screens/sui_menu.lua:2436
+msgid "When waking the device from sleep/suspend, always return to the Home Screen — even if a book was open when it went to sleep."
+msgstr "Cihaz yuxu/gözləmə rejimindən oyanarkən həmişə əsas ekrana qayıdır — yuxuya keçəndə kitab açıq olsa belə."
+
+#: features/sui_quickactions.lua:855
+#: infra/sui_config.lua:125
+msgid "Wi-Fi"
+msgstr "Wi-Fi"
+
+#: features/sui_quickactions.lua:261
+msgid "Wi-Fi off"
+msgstr "Wi-Fi sönülüdür"
+
+#: infra/sui_config.lua:167
+msgid "WiFi"
+msgstr "WiFi"
+
+#: features/sui_quickactions.lua:248
+msgid "WiFi not available on this device."
+msgstr "Bu cihazda WiFi əlçatan deyil."
+
+#: features/sui_quickactions.lua:2231
+msgid "Wikipedia Lookup"
+msgstr "Vikipediyada axtarış"
+
+#: modules/module_currently.lua:1958
+msgid "With percentage"
+msgstr "Faizlə"
+
+#: modules/module_clock.lua:1164
+#: modules/module_clock.lua:1177
+msgid "Word"
+msgstr "Sözlə"
+
+#: screens/sui_stats_windows.lua:1217
+msgid "Yes"
+msgstr "Bəli"
+
+#: screens/sui_stats_windows.lua:3092
+msgid "Yesterday is already covered by a freeze."
+msgstr "Dünən artıq dondurma ilə əvəz edilib."
+
+#: screens/sui_stats_windows.lua:3090
+msgid "You already read yesterday — there's nothing to freeze."
+msgstr "Dünən artıq oxumusunuz — dondurulacaq gün yoxdur."
+
+#: screens/sui_stats_windows.lua:3084
+msgid "You don't have any freezes available yet."
+msgstr "Hələ istifadə edə biləcəyiniz dondurma yoxdur."
+
+#: screens/sui_stats_windows.lua:3101
+msgid "You have %d freeze(s) available.\nUse one to cover %s?"
+msgstr "%d dondurmanız var.\n%s gününü əvəz etmək üçün biri istifadə edilsin?"
+
+#: modules/module_quote.lua:1002
+msgid "Your highlights"
+msgstr "Vurğulamalarınız"
+
+#: modules/module_reading_stats.lua:130
+msgid "abandoned"
+msgstr "Yarımçıq buraxılıb"
+
+#: screens/sui_stats_windows.lua:416
+#: screens/sui_stats_windows.lua:1424
+msgid "apr"
+msgstr "apr"
+
+#: screens/sui_stats_windows.lua:1428
+msgid "april"
+msgstr "aprel"
+
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1425
+msgid "aug"
+msgstr "avq"
+
+#: screens/sui_stats_windows.lua:1429
+msgid "august"
+msgstr "avqust"
+
+#: modules/module_reading_stats.lua:118
+#: screens/sui_stats_windows.lua:2301
+msgid "books finished"
+msgstr "bitirilmiş kitablar"
+
+#: modules/module_reading_stats.lua:113
+msgid "daily avg (7 days)"
+msgstr "gündəlik orta (7 gün)"
+
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1425
+msgid "dec"
+msgstr "dek"
+
+#: screens/sui_stats_windows.lua:1429
+msgid "december"
+msgstr "dekabr"
+
+#: features/sui_quickactions.lua:1817
+#: features/sui_quickactions.lua:2885
+msgid "default"
+msgstr "standart"
+
+#: screens/sui_menu.lua:846
+#: screens/sui_menu.lua:1118
+#: screens/sui_menu.lua:1791
+#: screens/sui_menu.lua:4543
+#: screens/sui_quicksettings_bar.lua:1118
+msgid "disabled"
+msgstr "söndürülüb"
+
+#: features/sui_backup.lua:667
+msgid "empty"
+msgstr "boş"
+
+#: screens/sui_menu.lua:846
+#: screens/sui_menu.lua:1118
+#: screens/sui_menu.lua:1791
+#: screens/sui_menu.lua:4543
+#: screens/sui_quicksettings_bar.lua:1118
+msgid "enabled"
+msgstr "qoşulub"
+
+#: screens/sui_stats_windows.lua:416
+#: screens/sui_stats_windows.lua:1424
+msgid "feb"
+msgstr "fev"
+
+#: screens/sui_stats_windows.lua:1428
+msgid "february"
+msgstr "fevral"
+
+#: features/sui_style.lua:1989
+msgid "ffi/archiver not available in this KOReader version"
+msgstr "Bu KOReader versiyasında ffi/archiver əlçatan deyil"
+
+#: features/sui_quickactions.lua:2091
+msgid "hex code, e.g. E001"
+msgstr "onaltılıq kod, məs. E001"
+
+#: screens/sui_stats_windows.lua:1960
+#: screens/sui_stats_windows.lua:2299
+msgid "hours read"
+msgstr "oxunan saatlar"
+
+#: modules/module_reading_stats.lua:129
+msgid "in progress"
+msgstr "oxunur"
+
+#: screens/sui_stats_windows.lua:416
+#: screens/sui_stats_windows.lua:1424
+msgid "jan"
+msgstr "yan"
+
+#: screens/sui_stats_windows.lua:1428
+msgid "january"
+msgstr "yanvar"
+
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1425
+msgid "jul"
+msgstr "iyl"
+
+#: screens/sui_stats_windows.lua:1429
+msgid "july"
+msgstr "iyul"
+
+#: screens/sui_stats_windows.lua:416
+#: screens/sui_stats_windows.lua:1424
+msgid "jun"
+msgstr "iyn"
+
+#: screens/sui_stats_windows.lua:1428
+msgid "june"
+msgstr "iyun"
+
+#: infra/sui_updater.lua:680
+msgid "latest"
+msgstr "ən son"
+
+#: screens/sui_stats_windows.lua:416
+#: screens/sui_stats_windows.lua:1424
+msgid "mar"
+msgstr "mar"
+
+#: screens/sui_stats_windows.lua:1428
+msgid "march"
+msgstr "mart"
+
+#: screens/sui_stats_windows.lua:416
+#: screens/sui_stats_windows.lua:1424
+#: screens/sui_stats_windows.lua:1428
+msgid "may"
+msgstr "may"
+
+#: modules/module_reading_stats.lua:121
+msgid "no streak"
+msgstr "ardıcıllıq yoxdur"
+
+#: features/sui_quickactions.lua:1567
+#: features/sui_quickactions.lua:2981
+#: features/sui_quickactions.lua:3000
+msgid "not configured"
+msgstr "tənzimlənməyib"
+
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1425
+msgid "nov"
+msgstr "noy"
+
+#: screens/sui_stats_windows.lua:1429
+msgid "november"
+msgstr "noyabr"
+
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1425
+msgid "oct"
+msgstr "okt"
+
+#: screens/sui_stats_windows.lua:1429
+msgid "october"
+msgstr "oktyabr"
+
+#: modules/module_reading_stats.lua:115
+msgid "of reading this month"
+msgstr "bu ay oxu"
+
+#: modules/module_reading_stats.lua:111
+msgid "of reading this week"
+msgstr "bu həftə oxu"
+
+#: modules/module_reading_stats.lua:109
+msgid "of reading today"
+msgstr "bu gün oxu"
+
+#: modules/module_reading_stats.lua:117
+msgid "of reading, all time"
+msgstr "bütün dövr ərzində oxu"
+
+#: features/sui_style.lua:2032
+msgid "pack_path not provided"
+msgstr "pack_path verilməyib"
+
+#: screens/sui_stats_windows.lua:2300
+#: screens/sui_stats_windows.lua:2615
+msgid "pages read"
+msgstr "oxunan səhifələr"
+
+#: modules/module_reading_stats.lua:116
+msgid "pages read this month"
+msgstr "bu ay oxunan səhifələr"
+
+#: modules/module_reading_stats.lua:112
+msgid "pages read this week"
+msgstr "bu həftə oxunan səhifələr"
+
+#: modules/module_reading_stats.lua:110
+msgid "pages read today"
+msgstr "bu gün oxunan səhifələr"
+
+#: modules/module_reading_stats.lua:114
+msgid "pages/day (7 days)"
+msgstr "səhifə/gün (7 gün)"
+
+#: screens/sui_stats_windows.lua:2613
+msgid "reading time"
+msgstr "oxu vaxtı"
+
+#: screens/sui_stats_windows.lua:417
+#: screens/sui_stats_windows.lua:1425
+msgid "sep"
+msgstr "sen"
+
+#: screens/sui_stats_windows.lua:1429
+msgid "september"
+msgstr "sentyabr"
+
+#: modules/module_reading_stats.lua:128
+msgid "unread"
+msgstr "oxunmayıb"
+
+#: infra/sui_updater.lua:682
+msgid "⬆ Update available: %s"
+msgstr "⬆ Yeniləmə mövcuddur: %s"
+
+#: modules/module_action_list.lua:333
+#: modules/module_quick_actions.lua:376
+#: modules/module_reading_stats.lua:889
+#: screens/sui_menu.lua:350
+#: screens/sui_menu.lua:1971
+msgid "  (%d left)"
+msgid_plural "  (%d left)"
+msgstr[0] "  (%d qalıb)"
+msgstr[1] "  (%d qalıb)"
+
+#: modules/module_reading_goals.lua:1304
+msgid "  Set Goal  (%d book in %s)"
+msgid_plural "  Set Goal  (%d books in %s)"
+msgstr[0] "  Məqsəd təyin et  (%d kitab, %s ərzində)"
+msgstr[1] "  Məqsəd təyin et  (%d kitab, %s ərzində)"
+
+#: modules/module_reading_goals.lua:819
+msgid "%d book"
+msgid_plural "%d books"
+msgstr[0] "%d kitab"
+msgstr[1] "%d kitab"
+
+#: modules/module_reading_goals.lua:1409
+msgid "%d book in %s"
+msgid_plural "%d books in %s"
+msgstr[0] "%d kitab, %s ərzində"
+msgstr[1] "%d kitab, %s ərzində"
+
+#: screens/sui_stats_windows.lua:1286
+msgid "%d book read in %s"
+msgid_plural "%d books read in %s"
+msgstr[0] "%d kitab oxunub, %s ərzində"
+msgstr[1] "%d kitab oxunub, %s ərzində"
+
+#: screens/sui_stats_windows.lua:2165
+#: screens/sui_stats_windows.lua:2167
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] "%d gün"
+msgstr[1] "%d gün"
+
+#: modules/module_coverdeck.lua:1078
+#: modules/module_currently.lua:859
+#: modules/module_currently.lua:860
+#: modules/module_currently.lua:940
+msgid "%d day of reading"
+msgid_plural "%d days of reading"
+msgstr[0] "%d gün oxu"
+msgstr[1] "%d gün oxu"
+
+#: screens/sui_stats_windows.lua:3410
+msgid "%d freeze available"
+msgid_plural "%d freezes available"
+msgstr[0] "%d dondurma mövcuddur"
+msgstr[1] "%d dondurma mövcuddur"
+
+#: modules/module_reading_goals.lua:1495
+msgid "%d in %s"
+msgid_plural "%d in %s"
+msgstr[0] "%d, %s ərzində"
+msgstr[1] "%d, %s ərzində"
+
+#: features/sui_quickactions.lua:1559
+#: features/sui_quickactions.lua:2973
+#: features/sui_quickactions.lua:2994
+msgid "%d item"
+msgid_plural "%d items"
+msgstr[0] "%d element"
+msgstr[1] "%d element"
+
+#: screens/sui_stats_windows.lua:2185
+#: screens/sui_stats_windows.lua:2187
+msgid "%d week"
+msgid_plural "%d weeks"
+msgstr[0] "%d həftə"
+msgstr[1] "%d həftə"
+
+#: modules/module_reading_goals.lua:817
+msgid "%d/%d book"
+msgid_plural "%d/%d books"
+msgstr[0] "%d/%d kitab"
+msgstr[1] "%d/%d kitab"
+
+#: modules/module_collections.lua:1575
+msgid "(%d collection)"
+msgid_plural "(%d collections)"
+msgstr[0] "(%d kolleksiya)"
+msgstr[1] "(%d kolleksiya)"
+
+#: modules/module_quick_actions.lua:486
+#: modules/module_reading_stats.lua:387
+msgid "(%d/%d — %d left)"
+msgid_plural "(%d/%d — %d left)"
+msgstr[0] "(%d/%d — %d qalıb)"
+msgstr[1] "(%d/%d — %d qalıb)"
+
+#: features/sui_quickactions.lua:2465
+msgid "Group (%d item)"
+msgid_plural "Group (%d items)"
+msgstr[0] "Qrup (%d element)"
+msgstr[1] "Qrup (%d element)"
+
+#: modules/module_reading_goals.lua:1486
+msgid "Manually Tracked Books  (%d in %s)"
+msgid_plural "Manually Tracked Books  (%d in %s)"
+msgstr[0] "Əl ilə izlənən kitablar  (%d, %s ərzində)"
+msgstr[1] "Əl ilə izlənən kitablar  (%d, %s ərzində)"
+
+#: screens/sui_quicksettings_bar.lua:1094
+#: screens/sui_quicksettings_bar.lua:1180
+msgid "Maximum of %d slot reached. Remove one first."
+msgid_plural "Maximum of %d slots reached. Remove one first."
+msgstr[0] "Maksimum %d yer həddinə çatılıb. Əvvəlcə birini çıxarın."
+msgstr[1] "Maksimum %d yer həddinə çatılıb. Əvvəlcə birini çıxarın."
+
+#: screens/sui_menu.lua:644
+#: screens/sui_menu.lua:906
+msgid "Text shown in the top bar.\nMaximum %d character."
+msgid_plural "Text shown in the top bar.\nMaximum %d characters."
+msgstr[0] "Yuxarı paneldə göstərilən mətn.\nƏn çox %d simvol."
+msgstr[1] "Yuxarı paneldə göstərilən mətn.\nƏn çox %d simvol."
+
+#: modules/module_action_list.lua:276
+#: modules/module_action_list.lua:403
+#: modules/module_quick_actions.lua:323
+#: modules/module_quick_actions.lua:455
+#: screens/sui_menu.lua:1936
+#: screens/sui_menu.lua:2050
+msgid "The maximum of %d action per module has been reached. Remove one first."
+msgid_plural "The maximum of %d actions per module has been reached. Remove one first."
+msgstr[0] "Hər modul üçün maksimum %d əməl həddinə çatılıb. Əvvəlcə birini çıxarın."
+msgstr[1] "Hər modul üçün maksimum %d əməl həddinə çatılıb. Əvvəlcə birini çıxarın."
+
+#: features/sui_quickactions.lua:1629
+#: features/sui_quickactions.lua:2938
+msgid "The maximum of %d quick action has been reached. Delete one first."
+msgid_plural "The maximum of %d quick actions has been reached. Delete one first."
+msgstr[0] "Maksimum %d sürətli əməl həddinə çatılıb. Əvvəlcə birini silin."
+msgstr[1] "Maksimum %d sürətli əməl həddinə çatılıb. Əvvəlcə birini silin."
+
+#: modules/module_reading_stats.lua:683
+#: modules/module_reading_stats.lua:763
+msgid "The maximum of %d stat per row has been reached. Remove one first."
+msgid_plural "The maximum of %d stats per row has been reached. Remove one first."
+msgstr[0] "Hər sətir üçün maksimum %d statistik göstərici həddinə çatılıb. Əvvəlcə birini çıxarın."
+msgstr[1] "Hər sətir üçün maksimum %d statistik göstərici həddinə çatılıb. Əvvəlcə birini çıxarın."
+
+#: screens/sui_menu.lua:379
+#: screens/sui_menu.lua:1229
+msgid "The maximum of %d tab has been reached. Remove one first."
+msgid_plural "The maximum of %d tabs has been reached. Remove one first."
+msgstr[0] "Maksimum %d vərəq həddinə çatılıb. Əvvəlcə birini çıxarın."
+msgstr[1] "Maksimum %d vərəq həddinə çatılıb. Əvvəlcə birini çıxarın."
+
+#: screens/sui_stats_windows.lua:1963
+msgid "day read"
+msgid_plural "days read"
+msgstr[0] "oxunan gün"
+msgstr[1] "oxunan gün"
+
+#: modules/module_reading_stats.lua:122
+msgid "day streak"
+msgid_plural "days streak"
+msgstr[0] "gün ardıcıl oxu"
+msgstr[1] "gün ardıcıl oxu"
+
+#: screens/sui_stats_windows.lua:1978
+msgid "page read"
+msgid_plural "pages read"
+msgstr[0] "oxunan səhifə"
+msgstr[1] "oxunan səhifə"


### PR DESCRIPTION
Adds Azerbaijani (az) language support.

New file: locale/az.po, copied from locale/simpleui.pot and fully translated.

1050 of 1050 msgid entries have a msgstr. Placeholder count and order match the source for every entry. Key order matches locale/simpleui.pot.

Header fields: Language: az, Plural-Forms: nplurals=2; plural=(n != 1);

One entry, WORD_CLOCK_TENS_SEP, uses a single space as its value, the same convention used by locale/cs.po for languages that need a space but no connecting word between tens and units in the word clock feature.

No other files changed.
